### PR TITLE
[GEOS-11349] MapML Use WMS Resource Consumption Limit to specify max image size

### DIFF
--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLStyleVisitorTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLStyleVisitorTest.java
@@ -54,29 +54,25 @@ public class MapMLStyleVisitorTest extends MapMLTestSupport {
         cat.save(li);
 
         Mapml mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.LAKES.getLocalPart(),
-                        null,
-                        null,
-                        "0,-0.002,0.00451,0",
-                        "EPSG:4326",
-                        "lakeScale",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.LAKES.getLocalPart())
+                        .bbox("0,-0.002,0.00451,0")
+                        .srs("EPSG:4326")
+                        .styles("lakeScale")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "No features are returned because the scale denominator is not within the range of the style",
                 0,
                 mapmlFeatures.getBody().getFeatures().size());
         mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.LAKES.getLocalPart(),
-                        null,
-                        null,
-                        "-50,-50,50,50",
-                        "EPSG:4326",
-                        "lakeScale",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.LAKES.getLocalPart())
+                        .bbox("-50,-50,50,50")
+                        .srs("EPSG:4326")
+                        .styles("lakeScale")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "Feature is returned because scale is between minscaledenominator and maxscaledenominator",
                 1,
@@ -97,15 +93,13 @@ public class MapMLStyleVisitorTest extends MapMLTestSupport {
         cat.save(li);
 
         Mapml mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.BUILDINGS.getLocalPart(),
-                        null,
-                        null,
-                        "0,0,0.01,0.01",
-                        "EPSG:4326",
-                        "polygonSymbolizer",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.BUILDINGS.getLocalPart())
+                        .bbox("0,0,0.01,0.01")
+                        .srs("EPSG:4326")
+                        .styles("polygonSymbolizer")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "Style classes string",
                 ".bbox {display:none} .polygonSymbolizer-r1-s1{stroke-opacity:1.0; stroke-dashoffset:0; stroke-width:2.0; fill:#000080; fill-opacity:0.5; stroke:#FFFFFF; stroke-linecap:butt} .polygonSymbolizer-r2-s1{stroke-opacity:1.0; stroke-dashoffset:0; stroke-width:4.0; fill:#033080; fill-opacity:0.74; stroke:#FF66FF; stroke-linecap:butt}",
@@ -130,15 +124,13 @@ public class MapMLStyleVisitorTest extends MapMLTestSupport {
         cat.save(li);
 
         Mapml mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.BUILDINGS.getLocalPart(),
-                        null,
-                        null,
-                        "0,0,0.01,0.01",
-                        "EPSG:4326",
-                        "polygonFilterSymbolizer",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.BUILDINGS.getLocalPart())
+                        .bbox("0,0,0.01,0.01")
+                        .srs("EPSG:4326")
+                        .styles("polygonFilterSymbolizer")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "Style classes string",
                 ".bbox {display:none} .polygonFilterSymbolizer-r1-s1{stroke-opacity:1.0; stroke-dashoffset:0; stroke-width:0.5; fill:#0033cc; fill-opacity:1.0; stroke:#000000; stroke-linecap:butt} .polygonFilterSymbolizer-r2-s1{stroke-opacity:1.0; stroke-dashoffset:0; stroke-width:0.7; fill:#8833cc; fill-opacity:1.0; stroke:#001200; stroke-linecap:butt}",
@@ -165,15 +157,12 @@ public class MapMLStyleVisitorTest extends MapMLTestSupport {
         cat.save(li);
 
         Mapml mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.BUILDINGS.getLocalPart(),
-                        null,
-                        null,
-                        null,
-                        "EPSG:4326",
-                        "simpleLineSymbolizer",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.BUILDINGS.getLocalPart())
+                        .srs("EPSG:4326")
+                        .styles("simpleLineSymbolizer")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "The polygon features are represented as is because line sybolizers can paint a polygon too",
                 "class org.geoserver.mapml.xml.MultiPolygon",
@@ -187,15 +176,12 @@ public class MapMLStyleVisitorTest extends MapMLTestSupport {
                         .toString());
 
         mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.BUILDINGS.getLocalPart(),
-                        null,
-                        null,
-                        null,
-                        "EPSG:4326",
-                        "simplePointSymbolizer",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.BUILDINGS.getLocalPart())
+                        .srs("EPSG:4326")
+                        .styles("simplePointSymbolizer")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "The polygon features are represented as points because the style has a point symbolizer",
                 "class org.geoserver.mapml.xml.Point",
@@ -220,15 +206,12 @@ public class MapMLStyleVisitorTest extends MapMLTestSupport {
         cat.save(li);
 
         Mapml mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.STREAMS.getLocalPart(),
-                        null,
-                        null,
-                        null,
-                        "EPSG:4326",
-                        "simplePolygonSymbolizer",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.STREAMS.getLocalPart())
+                        .srs("EPSG:4326")
+                        .styles("simplePolygonSymbolizer")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "The line features are represented as polygons because the style has a polygon symbolizer",
                 "class org.geoserver.mapml.xml.Polygon",
@@ -242,15 +225,12 @@ public class MapMLStyleVisitorTest extends MapMLTestSupport {
                         .toString());
 
         mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.STREAMS.getLocalPart(),
-                        null,
-                        null,
-                        null,
-                        "EPSG:4326",
-                        "simplePointSymbolizer",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.STREAMS.getLocalPart())
+                        .srs("EPSG:4326")
+                        .styles("simplePointSymbolizer")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "The line features are represented as points because the style has a point symbolizer",
                 "class org.geoserver.mapml.xml.Point",
@@ -275,30 +255,26 @@ public class MapMLStyleVisitorTest extends MapMLTestSupport {
         cat.save(li);
 
         Mapml mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.POINTS.getLocalPart(),
-                        null,
-                        null,
-                        "166021.44,0.0,833978.56,9329005.18",
-                        "EPSG:32615",
-                        "simpleLineSymbolizer",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.POINTS.getLocalPart())
+                        .bbox("166021.44,0.0,833978.56,9329005.18")
+                        .srs("EPSG:32615")
+                        .styles("simpleLineSymbolizer")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "No features are returned because points are not converted to line representations",
                 0,
                 mapmlFeatures.getBody().getFeatures().size());
 
         mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.POINTS.getLocalPart(),
-                        null,
-                        null,
-                        "166021.44,0.0,833978.56,9329005.18",
-                        "EPSG:32615",
-                        "simplePolygonSymbolizer",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.POINTS.getLocalPart())
+                        .bbox("166021.44,0.0,833978.56,9329005.18")
+                        .srs("EPSG:32615")
+                        .styles("simplePolygonSymbolizer")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(
                 "The point features are represented as polygons because the style has a polygon symbolizer",
                 "class org.geoserver.mapml.xml.Polygon",

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLTestSupport.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLTestSupport.java
@@ -19,52 +19,6 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 /** MapML test support class */
 public class MapMLTestSupport extends WMSTestSupport {
-    /**
-     * Get the WMS response as a MapML object
-     *
-     * @param name the name of the layer
-     * @param kvp the key value pairs
-     * @param locale the locale
-     * @param bbox the bounding box
-     * @param srs the SRS
-     * @param styles the styles
-     * @param cqlFilter the CQL filter
-     * @return the MapML object
-     * @throws Exception if an error occurs
-     */
-    protected Mapml getWMSAsMapML(
-            String name,
-            Map kvp,
-            Locale locale,
-            String bbox,
-            String srs,
-            String styles,
-            String cqlFilter,
-            boolean isFeatureRepresentation)
-            throws Exception {
-        MockHttpServletRequest request =
-                getMapMLWMSRequest(
-                        name, kvp, locale, bbox, srs, styles, cqlFilter, isFeatureRepresentation);
-        MockHttpServletResponse response = dispatch(request);
-        return mapml(response);
-    }
-
-    protected String getWMSAsMapMLString(
-            String name,
-            Map kvp,
-            Locale locale,
-            String bbox,
-            String srs,
-            String styles,
-            String cqlFilter,
-            boolean isFeatureRepresentation)
-            throws Exception {
-        MockHttpServletRequest request =
-                getMapMLWMSRequest(
-                        name, kvp, locale, bbox, srs, styles, cqlFilter, isFeatureRepresentation);
-        MockHttpServletResponse response = dispatch(request);
-        return response.getContentAsString();
-    }
 
     /**
      * Get the response as a MapML object
@@ -99,62 +53,182 @@ public class MapMLTestSupport extends WMSTestSupport {
         return mapml;
     }
 
-    /**
-     * Get a MapML request
-     *
-     * @param name the name of the layer
-     * @param kvp the key value pairs
-     * @param locale the locale
-     * @param bbox the bounding box
-     * @param srs the SRS
-     * @param styles the styles
-     * @param cql the CQL filter
-     * @return the request
-     * @throws Exception if an error occurs
-     */
-    protected MockHttpServletRequest getMapMLWMSRequest(
-            String name,
-            Map kvp,
-            Locale locale,
-            String bbox,
-            String srs,
-            String styles,
-            String cql,
-            boolean isFeatureRepresentation)
-            throws Exception {
-        String path = null;
-        cql = cql != null ? cql : "";
-        MockHttpServletRequest request = null;
-        String formatOptions =
-                isFeatureRepresentation
-                        ? MapMLConstants.MAPML_FEATURE_FO + ":true"
-                        : MapMLConstants.MAPML_WMS_MIME_TYPE_OPTION + ":image/png";
-        if (kvp != null) {
-            path = "wms";
-            request = createRequest(path, kvp);
-        } else {
-            path =
-                    "wms?LAYERS="
-                            + name
-                            + "&STYLES="
-                            + (styles != null ? styles : "")
-                            + "&FORMAT="
-                            + MapMLConstants.MAPML_MIME_TYPE
-                            + "&SERVICE=WMS&VERSION=1.3.0"
-                            + "&REQUEST=GetMap"
-                            + "&SRS="
-                            + srs
-                            + "&BBOX="
-                            + (bbox != null ? bbox : "0,0,1,1")
-                            + "&WIDTH=150"
-                            + "&HEIGHT=150"
-                            + "&cql_filter="
-                            + cql
-                            + "&format_options="
-                            + formatOptions;
-            request = createRequest(path);
+    @Override
+    protected MockHttpServletRequest createRequest(String path) {
+        return super.createRequest(path);
+    }
+
+    @Override
+    protected MockHttpServletRequest createRequest(String path, Map kvp) {
+        return super.createRequest(path, kvp);
+    }
+
+    public class MapMLWMSRequest {
+        private String name;
+        private Map kvp;
+        private Locale locale;
+        private String bbox;
+        private String srs;
+        private String styles;
+        private String cql;
+        private String width;
+        private String height;
+        private String format;
+        private boolean feature;
+
+        public String getName() {
+            return name;
         }
 
-        return request;
+        public Map getKvp() {
+            return kvp;
+        }
+
+        public Locale getLocale() {
+            return locale;
+        }
+
+        public String getBbox() {
+            return bbox;
+        }
+
+        public String getSrs() {
+            return srs;
+        }
+
+        public String getStyles() {
+            return styles;
+        }
+
+        public String getCql() {
+            return cql;
+        }
+
+        public String getWidth() {
+            return width;
+        }
+
+        public String getHeight() {
+            return height;
+        }
+
+        public String getFormat() {
+            return format;
+        }
+
+        public boolean isFeature() {
+            return feature;
+        }
+
+        public MapMLWMSRequest cql(String cql) {
+            this.cql = cql;
+            return this;
+        }
+
+        public MapMLWMSRequest name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public MapMLWMSRequest kvp(Map kvp) {
+            this.kvp = kvp;
+            return this;
+        }
+
+        public MapMLWMSRequest locale(Locale locale) {
+            this.locale = locale;
+            return this;
+        }
+
+        public MapMLWMSRequest bbox(String bbox) {
+            this.bbox = bbox;
+            return this;
+        }
+
+        public MapMLWMSRequest srs(String srs) {
+            this.srs = srs;
+            return this;
+        }
+
+        public MapMLWMSRequest styles(String styles) {
+            this.styles = styles;
+            return this;
+        }
+
+        public MapMLWMSRequest width(String width) {
+            this.width = width;
+            return this;
+        }
+
+        public MapMLWMSRequest height(String height) {
+            this.height = height;
+            return this;
+        }
+
+        public MapMLWMSRequest format(String format) {
+            this.format = format;
+            return this;
+        }
+
+        public MapMLWMSRequest feature(boolean feature) {
+            this.feature = feature;
+            return this;
+        }
+
+        /** Get a MapML request */
+        protected MockHttpServletRequest toHttpRequest() throws Exception {
+            String path = null;
+            cql(getCql() != null ? getCql() : "");
+            MockHttpServletRequest httpRequest = null;
+            String formatOptions =
+                    isFeature()
+                            ? MapMLConstants.MAPML_FEATURE_FO + ":true"
+                            : MapMLConstants.MAPML_WMS_MIME_TYPE_OPTION + ":image/png";
+            if (getKvp() != null) {
+                path = "wms";
+                httpRequest = createRequest(path, getKvp());
+            } else {
+                path =
+                        "wms?LAYERS="
+                                + getName()
+                                + "&STYLES="
+                                + (getStyles() != null ? getStyles() : "")
+                                + "&FORMAT="
+                                + (getFormat() != null
+                                        ? getFormat()
+                                        : MapMLConstants.MAPML_MIME_TYPE)
+                                + "&SERVICE=WMS&VERSION=1.3.0"
+                                + "&REQUEST=GetMap"
+                                + "&SRS="
+                                + getSrs()
+                                + "&BBOX="
+                                + (getBbox() != null ? getBbox() : "0,0,1,1")
+                                + "&WIDTH="
+                                + (getWidth() != null ? getWidth() : "150")
+                                + "&HEIGHT="
+                                + (getHeight() != null ? getHeight() : "150")
+                                + "&cql_filter="
+                                + getCql()
+                                + "&format_options="
+                                + formatOptions;
+                httpRequest = createRequest(path);
+            }
+
+            return httpRequest;
+        }
+
+        /** Get the WMS response as a MapML object */
+        protected Mapml getAsMapML() throws Exception {
+            MockHttpServletRequest request = toHttpRequest();
+            MockHttpServletResponse response = dispatch(request);
+            return mapml(response);
+        }
+
+        /** Get the WMS response as a string */
+        protected String getAsString() throws Exception {
+            MockHttpServletRequest request = toHttpRequest();
+            MockHttpServletResponse response = dispatch(request);
+            return response.getContentAsString();
+        }
     }
 }

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSFeatureTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSFeatureTest.java
@@ -98,15 +98,12 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
         cat.save(li);
 
         Mapml mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.BASIC_POLYGONS.getLocalPart(),
-                        null,
-                        null,
-                        "-180,-90,180,90",
-                        "EPSG:4326",
-                        null,
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.BASIC_POLYGONS.getLocalPart())
+                        .bbox("-180,-90,180,90")
+                        .srs("EPSG:4326")
+                        .feature(true)
+                        .getAsMapML();
 
         assertEquals(
                 "Basic Polygons layer has three features, so one should show up in the conversion",
@@ -140,15 +137,13 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
         cat.save(li);
         String bbox = "-0.1,-0.1,0.1,0.1";
         Mapml mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.BUILDINGS.getLocalPart(),
-                        null,
-                        null,
-                        bbox,
-                        "EPSG:4326",
-                        "polygonOneFilter",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.BUILDINGS.getLocalPart())
+                        .bbox(bbox)
+                        .srs("EPSG:4326")
+                        .styles("polygonOneFilter")
+                        .feature(true)
+                        .getAsMapML();
 
         assertEquals(
                 "Buildings layer has two features, only one should show up after the SLD is applied",
@@ -156,15 +151,13 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
                 mapmlFeatures.getBody().getFeatures().size());
 
         Mapml mapmlFeaturesElse =
-                getWMSAsMapML(
-                        MockData.BUILDINGS.getLocalPart(),
-                        null,
-                        null,
-                        bbox,
-                        "EPSG:4326",
-                        "polygonElseFilter",
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.BUILDINGS.getLocalPart())
+                        .bbox(bbox)
+                        .srs("EPSG:4326")
+                        .styles("polygonElseFilter")
+                        .feature(true)
+                        .getAsMapML();
 
         assertEquals(
                 "Buildings layer has two features, both should show up after the SLD with elseFilter is applied",
@@ -182,7 +175,8 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
         kvp.put("width", "256");
         kvp.put("height", "256");
         kvp.put("BBOX", bbox);
-        Mapml mapmlFeaturesCQL = getWMSAsMapML(null, kvp, null, bbox, null, null, null, true);
+        Mapml mapmlFeaturesCQL =
+                new MapMLWMSRequest().kvp(kvp).bbox(bbox).feature(true).getAsMapML();
 
         assertEquals(
                 "SLD filters yield two features, only one should show up after the CQL filter is applied",
@@ -190,7 +184,8 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
                 mapmlFeaturesCQL.getBody().getFeatures().size());
 
         kvp.put("CQL_FILTER", "ADDRESS = '99 Minor Street'");
-        Mapml mapmlNoFeaturesCQL = getWMSAsMapML(null, kvp, null, bbox, null, null, null, true);
+        Mapml mapmlNoFeaturesCQL =
+                new MapMLWMSRequest().kvp(kvp).bbox(bbox).feature(true).getAsMapML();
         assertEquals(
                 "SLD filters yield two features, none should show up after the CQL filter is applied",
                 0,
@@ -207,28 +202,22 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
 
         // test small bbox, the two features are big enough that they should both be returned
         Mapml mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.BUILDINGS.getLocalPart(),
-                        null,
-                        null,
-                        "-0.1,-0.1,0.1,0.1",
-                        "EPSG:4326",
-                        null,
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.BUILDINGS.getLocalPart())
+                        .bbox("-0.1,-0.1,0.1,0.1")
+                        .srs("EPSG:4326")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(2, mapmlFeatures.getBody().getFeatures().size());
 
         // test larger bbox, this time they are smaller than a pixel, only one remains
         mapmlFeatures =
-                getWMSAsMapML(
-                        MockData.BUILDINGS.getLocalPart(),
-                        null,
-                        null,
-                        "-10,-10,10,10",
-                        "EPSG:4326",
-                        null,
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.BUILDINGS.getLocalPart())
+                        .bbox("-10,-10,10,10")
+                        .srs("EPSG:4326")
+                        .feature(true)
+                        .getAsMapML();
         assertEquals(1, mapmlFeatures.getBody().getFeatures().size());
     }
 
@@ -243,15 +232,12 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
 
         // test with a small bbox, that should still lead to a geometric simplification
         Mapml mapml =
-                getWMSAsMapML(
-                        MockData.ROAD_SEGMENTS.getLocalPart(),
-                        null,
-                        null,
-                        "-0.1,-0.1,0.1,0.1",
-                        "EPSG:4326",
-                        null,
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.ROAD_SEGMENTS.getLocalPart())
+                        .bbox("-0.1,-0.1,0.1,0.1")
+                        .srs("EPSG:4326")
+                        .feature(true)
+                        .getAsMapML();
         List<Feature> features = mapml.getBody().getFeatures();
         assertEquals(5, features.size());
         for (Feature feature : features) {
@@ -315,15 +301,11 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
         lgi.getMetadata().put(MAPML_USE_TILES, false);
         cat.save(lgi);
         String response =
-                getWMSAsMapMLString(
-                        "layerGroup" + "," + MockData.BASIC_POLYGONS.getLocalPart(),
-                        null,
-                        null,
-                        null,
-                        "EPSG:4326",
-                        null,
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name("layerGroup" + "," + MockData.BASIC_POLYGONS.getLocalPart())
+                        .srs("EPSG:4326")
+                        .feature(true)
+                        .getAsString();
 
         assertTrue(
                 "MapML response contains an exception due to multiple feature types",
@@ -339,15 +321,11 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
         liRaster.getResource().getMetadata().put(MAPML_USE_TILES, false);
         cat.save(liRaster);
         String response =
-                getWMSAsMapMLString(
-                        MockData.WORLD.getLocalPart(),
-                        null,
-                        null,
-                        null,
-                        "EPSG:3857",
-                        null,
-                        null,
-                        true);
+                new MapMLWMSRequest()
+                        .name(MockData.WORLD.getLocalPart())
+                        .srs("EPSG:3857")
+                        .feature(true)
+                        .getAsString();
 
         assertTrue(
                 "MapML response contains an exception due to non-vector type",


### PR DESCRIPTION
[![GEOS-11349](https://badgen.net/badge/JIRA/GEOS-11349/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11349) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…image size


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->