### PR TITLE
[Backport 2.24.x] [GEOS-11362] Upgrade Spring libs from 5.3.32 to 5.3.33

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -92,7 +92,7 @@
     <gt.version>30-SNAPSHOT</gt.version>
     <gwc.version>1.24-SNAPSHOT</gwc.version>
     <jts.version>1.19.0</jts.version>
-    <spring.version>5.3.32</spring.version>
+    <spring.version>5.3.33</spring.version>
     <spring.security.version>5.7.12</spring.security.version>
     <spring-integration.version>5.5.18</spring-integration.version>
     <spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>


### PR DESCRIPTION
[![GEOS-11362](https://badgen.net/badge/JIRA/GEOS-11362/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11362) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7538
 **Authored by:** @mprins