### PR TITLE
[Backport 2.24.x] [GEOS-11347] STAC Landing Page links should include root link

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/Link.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/Link.java
@@ -30,6 +30,8 @@ public class Link {
     public static final String REL_SERVICE_DESC = "service-desc";
     public static final String REL_SERVICE_DOC = "service-doc";
     public static final String REL_CONFORMANCE = "conformance";
+    public static final String REL_ROOT = "root";
+
     /**
      * Refers to a resource that identifies the specifications that the link’s context conforms to.
      *

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/OGCAPIMediaTypes.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/OGCAPIMediaTypes.java
@@ -11,8 +11,15 @@ public class OGCAPIMediaTypes {
 
     /** GeoJSON media type */
     public static final String GEOJSON_VALUE = "application/geo+json";
+
     /** GeoJSON media type */
     public static MediaType GEOJSON = MediaType.parseMediaType(GEOJSON_VALUE);
+
+    /** JSON media type */
+    public static final String JSON_VALUE = "application/json";
+
+    /** JSON media type */
+    public static MediaType JSON = MediaType.parseMediaType(JSON_VALUE);
 
     /** Not meant to be instantiated */
     private OGCAPIMediaTypes() {}

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACLandingPage.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACLandingPage.java
@@ -84,6 +84,14 @@ public class STACLandingPage extends AbstractLandingPageDocumentNoConformance {
                     return mtypes;
                 };
 
+        // only allow JSON, for compatibility with pySTAC
+        Function<List<MediaType>, List<MediaType>> jsonOnlyUpdater =
+                mtypes -> {
+                    mtypes.clear();
+                    mtypes.add(OGCAPIMediaTypes.JSON);
+                    return mtypes;
+                };
+
         // search, GET
         new LinksBuilder(SearchResponse.class, basePath)
                 .segment("search")
@@ -92,6 +100,13 @@ public class STACLandingPage extends AbstractLandingPageDocumentNoConformance {
                 .classification("searchGet")
                 .updater((t1, l2) -> l2.setMethod(HttpMethod.GET))
                 .mediaTypeCustomizer(jsonFirstUpdater)
+                .add(this);
+
+        // root
+        new LinksBuilder(STACLandingPage.class, basePath)
+                .title("Root Catalog as ")
+                .rel(Link.REL_ROOT)
+                .mediaTypeCustomizer(jsonOnlyUpdater)
                 .add(this);
 
         // search, POST

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/LandingPageTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/LandingPageTest.java
@@ -102,8 +102,17 @@ public class LandingPageTest extends STACTestSupport {
         // check landing page links
         assertJSONList(
                 json,
-                "links[?(@.type == 'application/json' && @.href =~ /.*ogc\\/stac\\/v1\\/\\?.*/)].rel",
+                "links[?(@.type == 'application/json' && @.title == 'This document' && @.href =~ /.*ogc\\/stac\\/v1\\/\\?.*/)].rel",
                 "self");
+        assertJSONList(
+                json,
+                "links[?(@.type == 'application/json' && @.title == 'Root Catalog as application/json')].rel",
+                "root");
+        List<String> selfRels =
+                json.read(
+                        "links[?(@.type == 'application/json' && @.title == 'Root Catalog as application/json')].rel");
+        // Limiting Root links to only JSON MIME type
+        assertEquals(1, selfRels.size());
         assertJSONList(
                 json,
                 "links[?(@.type != 'application/json' && @.href =~ /.*ogc\\/stac\\/v1\\/\\?.*/)].rel",


### PR DESCRIPTION
[![GEOS-11347](https://badgen.net/badge/JIRA/GEOS-11347/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11347) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7525
 **Authored by:** @turingtestfail