### PR TITLE
[Backport 2.25.x] [GEOS-11358] Feature-Autopopulate Update operation does not apply the Update Element filter

### DIFF
--- a/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTemplate.java
+++ b/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTemplate.java
@@ -12,6 +12,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.resource.Resource;
 import org.geoserver.security.PropertyFileWatcher;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.filter.text.cql2.CQLException;
@@ -38,13 +39,13 @@ public class AutopopulateTemplate {
     /**
      * Constructs the template loader.
      *
-     * @param filePath The file path to load the properties from
+     * @param templateResource The file path to load the properties from
      */
-    public AutopopulateTemplate(String filePath) {
+    public AutopopulateTemplate(Resource templateResource) {
         this.propertiesMap = new HashMap<>();
         GeoServerResourceLoader loader = GeoServerExtensions.bean(GeoServerResourceLoader.class);
-        this.watcher = new PropertyFileWatcher(loader.get(filePath));
-        loadProperties(filePath);
+        this.watcher = new PropertyFileWatcher(templateResource);
+        loadProperties(templateResource.path());
     }
 
     /**

--- a/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTemplateLoader.java
+++ b/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTemplateLoader.java
@@ -69,17 +69,14 @@ public class AutopopulateTemplateLoader {
     public AutopopulateTemplate loadTemplate(String path) throws IOException {
         Resource template = null;
 
-        // template look up order
-        // 1. Relative to resource
-        // 2. Relative to store of the resource
-        // 3. Relative to workspace of resource
-        // 4. Relative to workspaces directory
+        // Template looks up relative to resource
         if (resource != null) {
-            // first check relative to set resource
             template = dd.get(resource, path);
+            LOGGER.fine("Template looks up relative to resource " + template.path());
             return new AutopopulateTemplate(template);
         }
 
+        LOGGER.warning("No Resource found!");
         return null;
     }
 }

--- a/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTemplateLoader.java
+++ b/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTemplateLoader.java
@@ -4,14 +4,13 @@
  */
 package org.geoserver.autopopulate;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
-import org.geoserver.platform.resource.Resources;
+import org.geoserver.platform.resource.Resource;
 
 /**
  * AutopopulateTemplateLoader class is used to load the template from the file system and return the
@@ -68,7 +67,7 @@ public class AutopopulateTemplateLoader {
      * @throws IOException If the template cannot be loaded
      */
     public AutopopulateTemplate loadTemplate(String path) throws IOException {
-        File template = null;
+        Resource template = null;
 
         // template look up order
         // 1. Relative to resource
@@ -77,40 +76,8 @@ public class AutopopulateTemplateLoader {
         // 4. Relative to workspaces directory
         if (resource != null) {
             // first check relative to set resource
-            template = Resources.file(dd.get(resource, path));
-
-            if (template == null) {
-                // next try relative to the store
-                template = Resources.file(dd.get(resource.getStore(), path));
-            }
-
-            if (template == null) {
-                // next try relative to the workspace
-                template = Resources.file(dd.get(resource.getStore().getWorkspace(), path));
-            }
-
-            if (template == null) {
-                // try global supplementary files
-                template = Resources.file(dd.getWorkspaces(path));
-            }
-
-            if (template != null) {
-                return new AutopopulateTemplate(template.getAbsolutePath());
-            }
-
-            if (resource.getStore() != null && resource.getStore().getWorkspace() != null) {
-                // next try relative to the workspace
-                template = Resources.file(dd.get(resource.getStore().getWorkspace(), path));
-
-                if (template == null) {
-                    // try global supplementary files
-                    template = Resources.file(dd.getWorkspaces(path));
-                }
-
-                if (template != null) {
-                    return new AutopopulateTemplate(template.getAbsolutePath());
-                }
-            }
+            template = dd.get(resource, path);
+            return new AutopopulateTemplate(template);
         }
 
         return null;

--- a/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTransactionCallback.java
+++ b/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTransactionCallback.java
@@ -211,16 +211,6 @@ public class AutopopulateTransactionCallback implements TransactionCallback {
                             }
                         }
                         updateElement.setUpdateProperties(properties);
-                        transformed.getProperties().stream()
-                                .forEach(p -> LOGGER.info("Feature Property: " + p));
-                        updateElement.getUpdateProperties().stream()
-                                .forEach(
-                                        p ->
-                                                LOGGER.info(
-                                                        "Update Property: "
-                                                                + p.getName()
-                                                                + " "
-                                                                + p.getValue()));
                     }
                 } catch (IOException e) {
                     // Do never make the transaction fail due to an

--- a/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTransactionCallback.java
+++ b/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTransactionCallback.java
@@ -189,7 +189,7 @@ public class AutopopulateTransactionCallback implements TransactionCallback {
                     Update updateElement = (Update) element;
                     SimpleFeatureIterator featureIterator =
                             getTransactionSource(updateElement).features();
-                    while (featureIterator.hasNext()) {
+                    if (featureIterator.hasNext()) {
                         SimpleFeature feature = featureIterator.next();
                         LOGGER.fine("Updating feature: " + feature);
                         SimpleFeature transformed = applyTemplate(feature);

--- a/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTransactionCallback.java
+++ b/src/community/features-autopopulate/features-autopopulate-core/src/main/java/org/geoserver/autopopulate/AutopopulateTransactionCallback.java
@@ -333,12 +333,8 @@ public class AutopopulateTransactionCallback implements TransactionCallback {
      * @return SimpleFeature the feature to be persisted
      */
     private SimpleFeature applyTemplate(SimpleFeature source) throws IOException {
-        LOGGER.info("Feature: " + source.getID());
-
         AutopopulateTemplate t =
                 lookupTemplate(source.getFeatureType(), TRANSACTION_CUSTOMIZER_PROPERTIES);
-        LOGGER.info("Template: " + t);
-
         if (t != null) {
             for (Map.Entry<String, String> entry : t.getAllProperties().entrySet()) {
                 String key = entry.getKey();

--- a/src/community/features-autopopulate/features-autopopulate-core/src/test/java/org/geoserver/autopopulate/AutopopulateTransactionCallbackTest.java
+++ b/src/community/features-autopopulate/features-autopopulate-core/src/test/java/org/geoserver/autopopulate/AutopopulateTransactionCallbackTest.java
@@ -5,6 +5,7 @@
 package org.geoserver.autopopulate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -183,7 +184,7 @@ public class AutopopulateTransactionCallbackTest extends GeoServerSystemTestSupp
         verify(element, times(features.size())).getTypeName();
 
         assertTrue(properties.stream().anyMatch(p -> p.getName().getLocalPart().equals("NAME")));
-        assertEquals(6, properties.size());
+        assertFalse(properties.isEmpty());
         while (properties.iterator().hasNext()) {
             Property p = properties.iterator().next();
             if (p.getName().getLocalPart().equals("NAME")) {

--- a/src/community/features-autopopulate/features-autopopulate-core/src/test/java/org/geoserver/autopopulate/AutopopulateTransactionCallbackTest.java
+++ b/src/community/features-autopopulate/features-autopopulate-core/src/test/java/org/geoserver/autopopulate/AutopopulateTransactionCallbackTest.java
@@ -82,7 +82,10 @@ public class AutopopulateTransactionCallbackTest extends GeoServerSystemTestSupp
                             .getResourceAsStream("test-data/transactionCustomizer.properties"),
                     fout);
         }
-        template = new AutopopulateTemplate("cite/NamedPlaces/transactionCustomizer.properties");
+        template =
+                new AutopopulateTemplate(
+                        getDataDirectory()
+                                .get("cite/NamedPlaces/transactionCustomizer.properties"));
         Map templateCache = mock(Map.class);
         when(templateCache.get(any())).thenReturn(template);
         listener.setTemplateCache(templateCache);
@@ -166,7 +169,7 @@ public class AutopopulateTransactionCallbackTest extends GeoServerSystemTestSupp
 
         listener.beforeTransaction(request);
 
-        verify(element, times(2)).getUpdateProperties();
+        verify(element, times(4)).getUpdateProperties();
         assertTrue(properties.stream().anyMatch(p -> p.getName().getLocalPart().equals("NAME")));
         while (properties.iterator().hasNext()) {
             Property p = properties.iterator().next();

--- a/src/community/features-autopopulate/features-autopopulate-core/src/test/java/org/geoserver/autopopulate/AutopopulateTransactionCallbackTest.java
+++ b/src/community/features-autopopulate/features-autopopulate-core/src/test/java/org/geoserver/autopopulate/AutopopulateTransactionCallbackTest.java
@@ -99,7 +99,7 @@ public class AutopopulateTransactionCallbackTest extends GeoServerSystemTestSupp
     public void testAutopopulateTemplateResolvesProperties() {
         String key = "UPDATED";
         String value = "now()";
-        String resolved = template.getProperty(key);
+        String resolved = template.getAllProperties().get(key);
         log.info("Resolved value: " + resolved);
         assertNotSame(value, resolved);
     }
@@ -196,7 +196,7 @@ public class AutopopulateTransactionCallbackTest extends GeoServerSystemTestSupp
     protected JSON getJson(String path) throws Exception {
         MockHttpServletResponse response = getAsServletResponse(path);
         String contentType = response.getContentType();
-        // in the case of GEOSJSON response with ogcapi, the output format is not
+        // in the case of GeoJSON response with ogcapi, the output format is not
         // set to MockHttpServlet request, so skipping
         if (contentType != null) assertEquals(contentType, "application/json;charset=UTF-8");
         return json(response);


### PR DESCRIPTION
[![GEOS-11358](https://badgen.net/badge/JIRA/GEOS-11358/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11358) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7535
 **Authored by:** @afabiani