### PR TITLE
[Backport 2.25.x] [GEOS-11306] Chace GetFeature total using AtomicLong for thread safety

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -711,10 +712,13 @@ public class GetFeature {
             long total = getTotalCount(totalCountExecutors);
             return () -> BigInteger.valueOf(total);
         } else {
+            AtomicLong cache = new AtomicLong(Long.MIN_VALUE);
             return () -> {
                 try {
-                    long totalCount1 = getTotalCount(totalCountExecutors);
-                    return BigInteger.valueOf(totalCount1);
+                    if (cache.get() == Long.MIN_VALUE) {
+                        cache.set(getTotalCount(totalCountExecutors));
+                    }
+                    return BigInteger.valueOf(cache.get());
                 } catch (IOException ioException) {
                     throw new RuntimeException(
                             "Lazy total count unavailable " + ioException.getMessage(),


### PR DESCRIPTION
[![GEOS-11306](https://badgen.net/badge/JIRA/GEOS-11306/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11306) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7553
 **Authored by:** @jodygarnett