### PR TITLE
[GEOS-11202] Respect proxy base URL when building CAS service URL.

### DIFF
--- a/src/extension/security/cas/src/test/java/org/geoserver/security/cas/GeoServerCasAuthenticationFilterTest.java
+++ b/src/extension/security/cas/src/test/java/org/geoserver/security/cas/GeoServerCasAuthenticationFilterTest.java
@@ -1,0 +1,143 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.cas;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.ows.HTTPHeadersCollector;
+import org.geoserver.ows.ProxifyingURLMangler;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class GeoServerCasAuthenticationFilterTest extends GeoServerSystemTestSupport {
+
+    @Test
+    public void testRetrieveServiceWithNoProxyBaseUrl() {
+        GeoServer geoServer = getGeoServer();
+        String oldValue = System.getProperty("PROXY_BASE_URL");
+        try {
+            setProxyBase(geoServer, null);
+            setSystemProperty("PROXY_BASE_URL", null);
+
+            MockHttpServletRequest request =
+                    buildMockRequest(
+                            "http",
+                            "localhost",
+                            8080,
+                            "/geoserver",
+                            "/geoserver/myworkspace/wms?SERVICE=WMS");
+
+            String serviceUrl = GeoServerCasAuthenticationFilter.retrieveService(request);
+
+            assertEquals("http://localhost:8080/geoserver/myworkspace/wms?SERVICE=WMS", serviceUrl);
+        } finally {
+            // Reset to make sure we don't interfere with other tests at all
+            setSystemProperty("PROXY_BASE_URL", oldValue);
+        }
+    }
+
+    @Test
+    public void testRetrieveServiceWithProxyBaseUrlSystemProperty() {
+
+        String oldValue = System.getProperty("PROXY_BASE_URL");
+        try {
+            setSystemProperty("PROXY_BASE_URL", "https://example.com/geoserver");
+
+            MockHttpServletRequest request =
+                    buildMockRequest(
+                            "http",
+                            "localhost",
+                            8080,
+                            "/geoserver",
+                            "/geoserver/myworkspace/wms?SERVICE=WMS");
+
+            String serviceUrl = GeoServerCasAuthenticationFilter.retrieveService(request);
+
+            assertEquals("https://example.com/geoserver/myworkspace/wms?SERVICE=WMS", serviceUrl);
+        } finally {
+            // Reset to make sure we don't interfere with other tests at all
+            setSystemProperty("PROXY_BASE_URL", oldValue);
+        }
+    }
+
+    @Test
+    public void testRetrieveServiceWithProxyBaseUrlConfig() {
+        GeoServer geoServer = getGeoServer();
+        try {
+            setProxyBase(geoServer, "https://example.com/geoserver");
+
+            MockHttpServletRequest request =
+                    buildMockRequest(
+                            "http",
+                            "localhost",
+                            8080,
+                            "/geoserver",
+                            "/geoserver/myworkspace/wms?SERVICE=WMS");
+
+            String serviceUrl = GeoServerCasAuthenticationFilter.retrieveService(request);
+
+            assertEquals("https://example.com/geoserver/myworkspace/wms?SERVICE=WMS", serviceUrl);
+        } finally {
+            setProxyBase(geoServer, null);
+        }
+    }
+
+    @Test
+    public void testRetrieveServiceWithProxyBaseUrlConfigAndParameterization() {
+        GeoServer geoServer = getGeoServer();
+        try {
+            setProxyBase(geoServer, "https://${X-Forwarded-Host}/geoserver");
+
+            MockHttpServletRequest request =
+                    buildMockRequest(
+                            "http",
+                            "localhost",
+                            8080,
+                            "/geoserver",
+                            "/geoserver/myworkspace/wms?SERVICE=WMS");
+
+            // Add headers
+            request.addHeader(
+                    ProxifyingURLMangler.Headers.FORWARDED_HOST.asString(), "example.com");
+            HTTPHeadersCollector filter = new HTTPHeadersCollector();
+            filter.collectHeaders(request);
+
+            String serviceUrl = GeoServerCasAuthenticationFilter.retrieveService(request);
+
+            assertEquals("https://example.com/geoserver/myworkspace/wms?SERVICE=WMS", serviceUrl);
+        } finally {
+            setProxyBase(geoServer, null);
+        }
+    }
+
+    private MockHttpServletRequest buildMockRequest(
+            String scheme, String serverName, int port, String contextPath, String uri) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme(scheme);
+        request.setServerName(serverName);
+        request.setServerPort(port);
+        request.setContextPath(contextPath);
+        request.setRequestURI(uri);
+        return request;
+    }
+
+    private void setProxyBase(GeoServer gs, String s) {
+        final GeoServerInfo global = gs.getGlobal();
+        global.getSettings().setProxyBaseUrl(s);
+        global.getSettings().setUseHeadersProxyURL(s != null);
+        gs.save(global);
+    }
+
+    private void setSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-11202](https://badgen.net/badge/JIRA/GEOS-11202/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11202) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The service URL built by the CAS extension now respects the proxy base URL (both the system property and the config value). I accomplished this by running the URL through ResponseUtils.buildUrl to ensure it ultimately goes through ProxifyingURLManger.

Furthermore, it also preserves the end-user's path and query parameters. This is to ensure that by the time the user is redirect back to the application from CAS, they will land on the original page they were trying to hit.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->