### PR TITLE
Fixed ogcapi-changeset unit test error on Windows

### DIFF
--- a/src/community/ogcapi/ogcapi-changeset/src/main/java/org/geoserver/ogcapi/v1/changeset/ChangesetIndexProvider.java
+++ b/src/community/ogcapi/ogcapi-changeset/src/main/java/org/geoserver/ogcapi/v1/changeset/ChangesetIndexProvider.java
@@ -48,6 +48,8 @@ import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -66,6 +68,11 @@ public class ChangesetIndexProvider {
     public ChangesetIndexProvider(GeoServerDataDirectory dd, Catalog catalog) throws IOException {
         this.checkpointIndex = getCheckpointDataStore(dd);
         catalog.addListener(new IndexCatalogListener());
+    }
+
+    @EventListener
+    public void handleContextClosedEvent(ContextClosedEvent event) {
+        this.checkpointIndex.dispose();
     }
 
     DataStore getCheckpointDataStore(GeoServerDataDirectory dd) throws IOException {


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR fixes an error running the ogcapi-changeset unit tests on Windows. The class is creating an H2 datastore in a temp directory that never gets disposed so the test class can't delete the temp directory on Windows. There's no ticket since this is just to fix a unit test in a community module.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->