### PR TITLE
[GEOS-11332] Renaming style with uppercase/downcase empty the sld file

### DIFF
--- a/src/platform/src/main/java/org/geoserver/util/IOUtils.java
+++ b/src/platform/src/main/java/org/geoserver/util/IOUtils.java
@@ -30,6 +30,7 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
+import org.geoserver.platform.resource.Files;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -470,7 +471,7 @@ public class IOUtils {
      */
     public static void rename(File source, File dest) throws IOException {
         // same path? Do nothing
-        if (source.getCanonicalPath().equalsIgnoreCase(dest.getCanonicalPath())) return;
+        if (source.getCanonicalPath().equals(dest.getCanonicalPath())) return;
 
         // windows needs special treatment, we cannot rename onto an existing file
         boolean win = System.getProperty("os.name").startsWith("Windows");
@@ -482,7 +483,9 @@ public class IOUtils {
             }
         }
         // make sure the rename actually succeeds
-        if (!source.renameTo(dest)) {
+        // using Files.move() instead of File.renameTo() to get better cross-platform support
+        // see also the javadoc of File.renameTo for more details
+        if (!Files.move(source, dest)) {
             FileUtils.deleteQuietly(dest);
             if (source.isDirectory()) {
                 FileUtils.moveDirectory(source, dest);

--- a/src/platform/src/test/java/org/geoserver/util/IOUtilsTest.java
+++ b/src/platform/src/test/java/org/geoserver/util/IOUtilsTest.java
@@ -70,4 +70,15 @@ public class IOUtilsTest {
             assertThat(e.getMessage(), startsWith("Entry is outside of the target directory"));
         }
     }
+
+    @Test
+    public void testRenameCaseChange() throws IOException {
+        File f = temp.newFile("foo.txt");
+        IOUtils.rename(f, "FOO.txt");
+        File renamed = new File(f.getParent(), "FOO.txt");
+
+        // file system can be case sensitive or not, so we can't really test
+        // that the old file is gone, but the new file should be there
+        assertTrue(renamed.exists());
+    }
 }


### PR DESCRIPTION
[![GEOS-11332](https://badgen.net/badge/JIRA/GEOS-11332/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11332) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Nasty little bug that causes "data loss" (as in, stylesheet loss)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->