### PR TITLE
[GEOS-11381] Fix error in OIDC plugin in combination with RoleService

### DIFF
--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectAuthenticationFilter.java
@@ -158,7 +158,7 @@ public class OpenIdConnectAuthenticationFilter extends GeoServerOAuthAuthenticat
             return null;
         }
         if (!(rs instanceof OpenIdRoleSource)) {
-            super.getRoles(request, principal);
+            return super.getRoles(request, principal);
         }
         OpenIdRoleSource oirs = (OpenIdRoleSource) rs;
 


### PR DESCRIPTION
[![GEOS-11381](https://badgen.net/badge/JIRA/GEOS-11381/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11381) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://osgeo-org.atlassian.net/browse/GEOS-11381

Using the latest version of OIDC plugin in combination with RoleService as Role source causes a casting exception:

java.lang.ClassCastException: class org.geoserver.security.config.PreAuthenticatedUserNameFilterConfig$PreAuthenticatedUserNameRoleSource cannot be cast to class org.geoserver.security.oauth2.OpenIdConnectFilterConfig$OpenIdRoleSource (org.geoserver.security.config.PreAuthenticatedUserNameFilterConfig$PreAuthenticatedUserNameRoleSource and org.geoserver.security.oauth2.OpenIdConnectFilterConfig$OpenIdRoleSource are in unnamed module of loader 'app')
                at org.geoserver.security.oauth2.OpenIdConnectAuthenticationFilter.getRoles(OpenIdConnectAuthenticationFilter.java:163)

In getRoles of OpenIdConnectAuthenticationFilter it is checked whether the role source is an instance of OpenIdRoleSource. If not, the roles are loaded from the parent class. Then, contrary to the check, the role source is cast to OpenIdRoleSource. This should not happen and the roles from the parent class should be returned.