### PR TITLE
[GEOS-11379] Refactor inline JavaScript in the OGC API modules

### DIFF
--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/main/resources/org/geoserver/ogcapi/v1/dggs/collection_include.ftl
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/main/resources/org/geoserver/ogcapi/v1/dggs/collection_include.ftl
@@ -23,8 +23,7 @@
     <#if collection.mapPreviewURL??>
     <li>The layer can also be explored in this <a href="${collection.mapPreviewURL}">map preview</a></li>
     </#if>
-    <#-- TODO when upgrading Freemaker add ?no_esc to avoid html escaping --> 
-    ${htmlExtensions(collection)}
+    ${htmlExtensions(collection)?no_esc}
   </ul>
 </div>
       

--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/main/resources/org/geoserver/ogcapi/v1/dggs/collections.ftl
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/main/resources/org/geoserver/ogcapi/v1/dggs/collections.ftl
@@ -1,4 +1,7 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>Collections</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>Collections</li>
+</#global>
 <#include "common-header.ftl">
 
   <h2>GeoServer DGGS collections</h2>

--- a/src/community/ogcapi/dggs/ogcapi-dggs/src/main/resources/org/geoserver/ogcapi/v1/dggs/landingPage.ftl
+++ b/src/community/ogcapi/dggs/ogcapi-dggs/src/main/resources/org/geoserver/ogcapi/v1/dggs/landingPage.ftl
@@ -1,4 +1,6 @@
-<#global pagecrumbs="<li class='breadcrumb-item active'>Home</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item active'>Home</li>
+</#global>
 <#include "common-header.ftl">
 
   <h1>${service.title!"GeoServer DGGS 1.0 Service"}</h1>

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/FreemarkerTemplateSupport.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/FreemarkerTemplateSupport.java
@@ -6,6 +6,7 @@ package org.geoserver.ogcapi;
 
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.core.Environment;
+import freemarker.core.HTMLOutputFormat;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -112,6 +113,7 @@ public class FreemarkerTemplateSupport {
                     Configuration cfg = TemplateUtils.getSafeConfiguration();
                     cfg.setDefaultEncoding(StandardCharsets.UTF_8.name());
                     cfg.setObjectWrapper(new FeatureWrapper(FC_FACTORY));
+                    cfg.setOutputFormat(HTMLOutputFormat.INSTANCE);
                     return cfg;
                 });
     }

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/api.ftl
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/api.ftl
@@ -35,26 +35,7 @@
 
     <script src="${resourceLink('swagger-ui/swagger-ui-bundle.js')}"> </script>
     <script src="${resourceLink('swagger-ui/swagger-ui-standalone-preset.js')}"> </script>
-    <script>
-    window.onload = function() {
-
-      // Build a system
-      const ui = SwaggerUIBundle({
-        url: "${model.getApiLocation()}",
-        dom_id: '#swagger-ui',
-        deepLinking: true,
-        presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIStandalonePreset
-        ],
-        plugins: [
-          SwaggerUIBundle.plugins.DownloadUrl
-        ],
-        layout: "StandaloneLayout"
-      })
-
-      window.ui = ui
-    }
-  </script>
+    <script src="${resourceLink('webresources/ogcapi/api.js')}"></script>
+    <input type="hidden" id="apiLocation" value="${model.getApiLocation()}"/>
   </body>
 </html>

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/common-header.ftl
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/common-header.ftl
@@ -14,13 +14,14 @@
       <link rel="stylesheet" href="${resourceLink("apicss/bootstrap.min.css")}" type="text/css" media="all" />
       <link rel="stylesheet" href="${resourceLink("apicss/geoserver.css")}" type="text/css" media="all" />
       <link rel="stylesheet" href="${resourceLink("apicss/treeview.css")}" type="text/css" media="all" />
+      <script src="${resourceLink('webresources/ogcapi/common.js')}"></script>
   </head>
 <body>
   <header id="header">
     <a href="${serviceLink("")}"></a>
     <#if model??>
        <div id="fetch"><span style="margin: 0.5em">Fetch this resource as:</span>
-          <select class="form-select form-select-sm" onchange="window.open(this.options[this.selectedIndex].value);this.selectedIndex=0" >
+          <select class="form-select form-select-sm form-select-open-basic">
             <option value="none" selected>-- Please choose a format --</option>
             <#list model.getLinksFor("alternate") as link>
             <option value="${link.href}">${link.type}</option>

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/conformance.ftl
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/conformance.ftl
@@ -1,4 +1,7 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>GeoServer "+model.apiName+" Conformance</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>GeoServer ${model.apiName} Conformance</li>
+</#global>
 <#include "common-header.ftl">
   <h1 id="title">GeoServer ${model.apiName} Conformance</h1>
   <p class="my-4">

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/queryables.ftl
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/queryables.ftl
@@ -1,4 +1,8 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'><a href='"+serviceLink("collections")+"'>Collections</a></li><li class='breadcrumb-item active'>"+model.collectionId+"</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item active'>${model.collectionId}</li>
+</#global>
 <#include "common-header.ftl">
 
   <div class="card my-4">

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/webresources/ogcapi/api.js
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/webresources/ogcapi/api.js
@@ -1,0 +1,17 @@
+
+window.addEventListener('load', function() {
+  // Build a system
+  window.ui = SwaggerUIBundle({
+    url: document.getElementById('apiLocation').value,
+    dom_id: "#swagger-ui",
+    deepLinking: true,
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [
+      SwaggerUIBundle.plugins.DownloadUrl
+    ],
+    layout: "StandaloneLayout"
+  });
+});

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/webresources/ogcapi/common.js
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/webresources/ogcapi/common.js
@@ -1,0 +1,10 @@
+
+window.addEventListener('load', function() {
+  const inputs = document.getElementsByClassName('form-select-open-basic');
+  for (let input of inputs) {
+    input.addEventListener('change', function() {
+      window.open(this.options[this.selectedIndex].value);
+      this.selectedIndex = 0;
+    });
+  }
+});

--- a/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/collection.ftl
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/collection.ftl
@@ -1,6 +1,10 @@
 <#global pagetitle=model.id>
 <#global pagepath="/collections/"+model.id>
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'><a href='"+serviceLink("collections")+"'>Collections</a></li><li class='breadcrumb-item active'>"+model.id+"</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item active'>${model.id}</li>
+</#global>
 <#include "common-header.ftl">
 
   <div class="row">

--- a/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/collection_include.ftl
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/collection_include.ftl
@@ -27,7 +27,7 @@
       or choose another format:
     </div>
     <div class="col-auto py-1">
-      <select class="form-select form-select-sm" onchange="window.open(this.options[this.selectedIndex].value);this.selectedIndex=0" >
+      <select class="form-select form-select-sm form-select-open-basic">
         <option value="none" selected>-- Please choose a format --</option>
         <#list collection.getLinksExcept("coverage", "image/geotiff") as link>
         <option value="${link.href}">${link.type}</option>

--- a/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/collections.ftl
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/collections.ftl
@@ -1,4 +1,7 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>Collections</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>Collections</li>
+</#global>
 <#include "common-header.ftl">
 
   <h1>GeoServer Coverage Collections</h1>

--- a/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/landingPage.ftl
@@ -1,4 +1,6 @@
-<#global pagecrumbs="<li class='breadcrumb-item active'>Home</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item active'>Home</li>
+</#global>
 <#include "common-header.ftl">
 
   <h1>${service.title!"GeoServer Coverages 1.0 Service"}</h1>

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/ApiTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -79,7 +80,13 @@ public class ApiTest extends CoveragesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/coverages/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/api.js\">"));
+        assertThat(
+                html,
+                containsString(
+                        "<input type=\"hidden\" id=\"apiLocation\" value="
+                                + "\"http://localhost:8080/geoserver/ogc/coverages/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\"/>"));
+        assertThat(html, not(containsString("<script>")));
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/CollectionTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/CollectionTest.java
@@ -6,8 +6,10 @@ package org.geoserver.ogcapi.v1.coverages;
 
 import static org.geoserver.catalog.ResourceInfo.TIME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 
 import com.jayway.jsonpath.DocumentContext;
@@ -128,5 +130,16 @@ public class CollectionTest extends CoveragesTestSupport {
         assertEquals(
                 "Temporal extent: 2014-01-01T00:00:00Z/2019-01-01T00:00:00Z",
                 document.select("#" + id + "_temporal").text());
+    }
+
+    @Test
+    public void testCollectionHTMLRemovedInlineJS() throws Exception {
+        String html = getAsString("ogc/coverages/v1/collections/rs:DEM?f=html");
+        assertThat(
+                html,
+                containsString(
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/common.js\"></script>"));
+        assertThat(html, containsString("form-select-open-basic"));
+        assertThat(html, not(containsString("onchange")));
     }
 }

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/collection.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/collection.ftl
@@ -1,6 +1,10 @@
 <#global pagetitle=model.id>
 <#global pagepath="/collections/"+model.id>
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'><a href='"+serviceLink("collections")+"'>Collections</a></li><li class='breadcrumb-item active'>"+model.id+"</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item active'>${model.id}</li>
+</#global>
 <#include "common-header.ftl">
 
   <div class="row">
@@ -35,4 +39,8 @@
       <#--  MAP PLACEHOLDER  -->
     </div>
   </div>
+
+  <script src="${resourceLink('webresources/ogcapi/features.js')}"></script>
+  <input type="hidden" id="maxNumberOfFeaturesForPreview" value="${service.maxNumberOfFeaturesForPreview}"/>
+
 <#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/collection_include.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/collection_include.ftl
@@ -23,8 +23,7 @@
       <#if collection.mapPreviewURL??>
       <li>The layer can also be explored in this <a href="${collection.mapPreviewURL}">map preview</a></li>
       </#if>
-      <#-- TODO when upgrading Freemaker add ?no_esc to avoid html escaping -->
-      ${htmlExtensions(collection)}
+      ${htmlExtensions(collection)?no_esc}
   </ul>
 </div>
 <div class="card-footer">
@@ -34,7 +33,7 @@
       or choose another format:
     </div>
     <div class="col-auto py-1">
-      <select class="form-select form-select-sm" onchange="window.open(this.options[this.selectedIndex].value + '&limit=${service.maxNumberOfFeaturesForPreview}');this.selectedIndex=0" >
+      <select class="form-select form-select-sm form-select-open-limit">
         <option value="none" selected>-- Please choose a format --</option>
         <#list collection.getLinksExcept("items", "text/html") as link>
         <option value="${link.href}">${link.type}</option>

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/collections.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/collections.ftl
@@ -1,4 +1,7 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>Collections</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>Collections</li>
+</#global>
 <#include "common-header.ftl">
 
   <h1>GeoServer Feature Collections</h1>
@@ -18,5 +21,8 @@
     </div>
     </#list>
   </div>
+
+  <script src="${resourceLink('webresources/ogcapi/features.js')}"></script>
+  <input type="hidden" id="maxNumberOfFeaturesForPreview" value="${service.maxNumberOfFeaturesForPreview}"/>
 
 <#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/functions.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/functions.ftl
@@ -1,4 +1,7 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>Filter capabilities</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>Filter capabilities</li>
+</#global>
 <#include "common-header.ftl">
        <h2>Functions</h2>
        <#list model.functions as f>

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/getfeature-complex-content.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/getfeature-complex-content.ftl
@@ -54,15 +54,4 @@ will be called multiple times if there are various feature collections
    </li>
 </ul>
 </#list>
-<script>
- window.onload=function(){
- var toggler = document.getElementsByClassName("caret");
- var i;
- for (let item of toggler) {
-      item.addEventListener("click", function() {
-      this.parentElement.querySelector(".nested").classList.toggle("active");
-      this.classList.toggle("caret-down");
-    });
-   }
- }
-</script>
+<script src="${resourceLink('webresources/ogcapi/features.js')}"></script>

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/getfeature-header.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/getfeature-header.ftl
@@ -1,2 +1,6 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item'><a href='"+serviceLink("collections")+"'>Collections</a></li><li class='breadcrumb-item active'>Feature</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item active'>Feature</li>
+</#global>
 <#include "common-header.ftl">

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/landingPage.ftl
@@ -1,4 +1,6 @@
-<#global pagecrumbs="<li class='breadcrumb-item active'>Home</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item active'>Home</li>
+</#global>
 <#include "common-header.ftl">
 
   <h1>${service.title!"GeoServer Features 1.0 Service"}</h1>
@@ -27,7 +29,7 @@
       </div>
     </div>
     
-    ${htmlExtensions('landing')}
+    ${htmlExtensions('landing')?no_esc}
 
     <div class="col-6 col-xl-3 mb-3">
       <div class="card h-100">

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/webresources/ogcapi/features.js
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/webresources/ogcapi/features.js
@@ -1,0 +1,18 @@
+
+window.addEventListener('load', function() {
+  const inputs = document.getElementsByClassName('form-select-open-limit');
+  for (let input of inputs) {
+    input.addEventListener('change', function() {
+      window.open(this.options[this.selectedIndex].value + '&limit='
+        + document.getElementById('maxNumberOfFeaturesForPreview').value);
+      this.selectedIndex = 0;
+    });
+  }
+  const toggler = document.getElementsByClassName('caret');
+  for (let item of toggler) {
+    item.addEventListener('click', function() {
+      this.parentElement.querySelector('.nested').classList.toggle('active');
+      this.classList.toggle('caret-down');
+    });
+  }
+});

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ApiTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -112,7 +113,13 @@ public class ApiTest extends FeaturesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/features/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/api.js\">"));
+        assertThat(
+                html,
+                containsString(
+                        "<input type=\"hidden\" id=\"apiLocation\" value="
+                                + "\"http://localhost:8080/geoserver/ogc/features/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\"/>"));
+        assertThat(html, not(containsString("<script>")));
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/CollectionTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/CollectionTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -213,6 +214,30 @@ public class CollectionTest extends FeaturesTestSupport {
                         + getLayerId(ROAD_SEGMENTS)
                         + "?f=application/x-yaml");
         // System.out.println(yaml);
+    }
+
+    @Test
+    public void testCollectionHTMLRemovedInlineJS() throws Exception {
+        String html =
+                getAsString(
+                        "ogc/features/v1/collections/"
+                                + getLayerId(MockData.ROAD_SEGMENTS)
+                                + "?f=text/html");
+        assertThat(
+                html,
+                containsString(
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/common.js\"></script>"));
+        assertThat(
+                html,
+                containsString(
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/features.js\"></script>"));
+        assertThat(
+                html,
+                containsString(
+                        "<input type=\"hidden\" id=\"maxNumberOfFeaturesForPreview\" value=\"50\"/>"));
+        assertThat(html, containsString("form-select-open-basic"));
+        assertThat(html, containsString("form-select-open-limit"));
+        assertThat(html, not(containsString("onchange")));
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ComplexFeaturesTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ComplexFeaturesTest.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.ogcapi.v1.features;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 
 import org.geoserver.test.AbstractAppSchemaMockData;
@@ -28,5 +31,20 @@ public class ComplexFeaturesTest extends AbstractAppSchemaTestSupport {
         // nested features are present
         assertEquals(4, doc.select("li>span:containsOwn(GeologicUnitType)").size());
         assertEquals(6, doc.select("li>span:containsOwn(CompositionPartType)").size());
+    }
+
+    @Test
+    public void testHTMLMappedFeatureRemovedInlineJS() throws Exception {
+        String html =
+                getAsString("ogc/features/v1/collections/gsml:MappedFeature/items?f=text/html");
+        assertThat(
+                html,
+                containsString(
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/common.js\"></script>"));
+        assertThat(
+                html,
+                containsString(
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/features.js\"></script>"));
+        assertThat(html, not(containsString("<script>")));
     }
 }

--- a/src/community/ogcapi/ogcapi-images/src/main/resources/org/geoserver/ogcapi/v1/images/collection.ftl
+++ b/src/community/ogcapi/ogcapi-images/src/main/resources/org/geoserver/ogcapi/v1/images/collection.ftl
@@ -1,6 +1,10 @@
 <#global pagetitle=model.id>
 <#global pagepath="/collections/"+model.id>
-<#global pagecrumbs="<a href='"+serviceLink("")+"'>Home</a><a href='"+serviceLink("collections")+"/collections'>Collections</a><b>"+model.id+"</b>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item active'>${model.id}</li>
+</#global>
 <#include "common-header.ftl">
 <h2>${model.id}</h2>
 <ul>

--- a/src/community/ogcapi/ogcapi-images/src/main/resources/org/geoserver/ogcapi/v1/images/collections.ftl
+++ b/src/community/ogcapi/ogcapi-images/src/main/resources/org/geoserver/ogcapi/v1/images/collections.ftl
@@ -1,4 +1,7 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>Collections</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>Collections</li>
+</#global>
 <#include "common-header.ftl">
        <h2>GeoServer Image Mosaics Collections</h2>
        <p>This document lists all the image collections available in the Images service.</p>

--- a/src/community/ogcapi/ogcapi-images/src/main/resources/org/geoserver/ogcapi/v1/images/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-images/src/main/resources/org/geoserver/ogcapi/v1/images/landingPage.ftl
@@ -1,5 +1,7 @@
 <#global pagetitle=service.title!"GeoServer Images 1.0 Service">
-<#global pagecrumbs="<li class='breadcrumb-item active'>Home</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item active'>Home</li>
+</#global>
 <#include "common-header.ftl">
    <div id="content">
        <h2>${service.title!"GeoServer Images 1.0 Service"}</h2>

--- a/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/v1/images/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-images/src/test/java/org/geoserver/ogcapi/v1/images/ApiTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -76,7 +77,13 @@ public class ApiTest extends ImagesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/images/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\""));
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/api.js\">"));
+        assertThat(
+                html,
+                containsString(
+                        "<input type=\"hidden\" id=\"apiLocation\" value="
+                                + "\"http://localhost:8080/geoserver/ogc/images/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\"/>"));
+        assertThat(html, not(containsString("<script>")));
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-maps/src/main/resources/org/geoserver/ogcapi/v1/maps/collection_include.ftl
+++ b/src/community/ogcapi/ogcapi-maps/src/main/resources/org/geoserver/ogcapi/v1/maps/collection_include.ftl
@@ -19,7 +19,6 @@
       </#if>
       <li> <a id="html_${collection.htmlId}_link" href="${collection.getLinkUrl('styles', 'text/html')!}">Map styles</a>.
                  
-      <#-- TODO when upgrading Freemaker add ?no_esc to avoid html escaping --> 
-      ${htmlExtensions(collection)}
+      ${htmlExtensions(collection)?no_esc}
       </ul>
       

--- a/src/community/ogcapi/ogcapi-maps/src/main/resources/org/geoserver/ogcapi/v1/maps/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-maps/src/main/resources/org/geoserver/ogcapi/v1/maps/landingPage.ftl
@@ -13,8 +13,7 @@
        <p>The <a id="htmlCollectionsLink" href="${model.getLinkUrl('data', 'text/html')!}"> collection page</a> provides a list of all the collections available in this service. 
        </p>
        
-       <#-- TODO when upgrading Freemaker add ?no_esc to avoid html escaping --> 
-       ${htmlExtensions('landing')}
+       ${htmlExtensions('landing')?no_esc}
        
        <#include "landingpage-conformance.ftl">
 

--- a/src/community/ogcapi/ogcapi-maps/src/main/resources/webresources/ogcapi/maps.js
+++ b/src/community/ogcapi/ogcapi-maps/src/main/resources/webresources/ogcapi/maps.js
@@ -1,0 +1,225 @@
+
+var map;
+var untiled;
+var tiled;
+
+window.addEventListener('load', function() {
+
+  var format = 'image/png';
+  var bounds = [parseFloat(document.getElementById('minX').value),
+                parseFloat(document.getElementById('minY').value),
+                parseFloat(document.getElementById('maxX').value),
+                parseFloat(document.getElementById('maxY').value)];
+
+  var mousePositionControl = new ol.control.MousePosition({
+    className: 'custom-mouse-position',
+    target: document.getElementById('location'),
+    coordinateFormat: ol.coordinate.createStringXY(5),
+    undefinedHTML: '&nbsp;'
+  });
+  var cleaningFunction = function(params) {
+    return params.split("&")
+      .map(function(kv) {
+        var kva = kv.split("=");
+        return kva[0].toLowerCase() + "=" + kva[1];
+      })
+      .filter(function(kv) {
+        var kva = kv.split("=");
+        var skip = ["service", "version", "request", "format"]
+        return !skip.includes(kva[0]);
+      })
+    .join("&");
+  }
+  var imageLoadFunction = function(image, src) {
+   var url = src.split('?');
+   var newParams = cleaningFunction(url[1]);
+   (image.getImage()).src = url[0] + "?" + newParams;
+  }
+  var untiledParams = {};
+  var tiledParams = {};
+  var paramInputs = document.getElementsByTagName('input');
+  for (var i = 0; i < paramInputs.length; i++) {
+    if (paramInputs[i].getAttribute('class') == 'param') {
+      untiledParams[paramInputs[i].title] = paramInputs[i].value;
+      tiledParams[paramInputs[i].title] = paramInputs[i].value;
+    }
+  }
+  untiledParams.f = format;
+  tiledParams.f = format;
+  tiledParams.tiled = true;
+  tiledParams.tilesOrigin = document.getElementById('minX').value + ',' + document.getElementById('minY').value;
+  untiled = new ol.layer.Image({
+    source: new ol.source.ImageWMS({
+      ratio: 1,
+      url: document.getElementById('url').value,
+      imageLoadFunction: imageLoadFunction,
+      params: untiledParams
+    })
+  });
+  tiled = new ol.layer.Tile({
+    visible: false,
+    source: new ol.source.TileWMS({
+      url: document.getElementById('url').value,
+      tileLoadFunction: imageLoadFunction,
+      params: tiledParams
+    })
+  });
+  var projection = new ol.proj.Projection({
+    code: document.getElementById('SRS').value,
+    units: document.getElementById('units').value,
+    global: false
+  });
+  map = new ol.Map({
+    controls: ol.control.defaults({
+      attribution: false
+    }).extend([mousePositionControl]),
+    target: 'map',
+    layers: [
+      untiled,
+      tiled
+    ],
+    view: new ol.View({
+       projection: projection
+    })
+  });
+  map.getView().on('change:resolution', function(evt) {
+    var resolution = evt.target.get('resolution');
+    var units = map.getView().getProjection().getUnits();
+    var dpi = 25.4 / 0.28;
+    var mpu = ol.proj.METERS_PER_UNIT[units];
+    var scale = resolution * mpu * 39.37 * dpi;
+    if (scale >= 9500 && scale <= 950000) {
+      scale = Math.round(scale / 1000) + "K";
+    } else if (scale >= 950000) {
+      scale = Math.round(scale / 1000000) + "M";
+    } else {
+      scale = Math.round(scale);
+    }
+    document.getElementById('scale').innerHTML = "Scale = 1 : " + scale;
+  });
+  map.getView().fit(bounds, map.getSize());
+  
+  map.on('singleclick', function(evt) {
+    document.getElementById('nodelist').innerHTML = "Loading... please wait...";
+    var view = map.getView();
+    var viewResolution = view.getResolution();
+    var source = untiled.get('visible') ? untiled.getSource() : tiled.getSource();
+    var url = source.getGetFeatureInfoUrl(
+      evt.coordinate, viewResolution, view.getProjection(),
+      {'f': 'text/html', 'FEATURE_COUNT': 50});
+    if (url) {
+      var urlParts = url.split('?');
+      var newParams = cleaningFunction(urlParts[1]);
+      url = urlParts[0] + "/info" + "?" + newParams;
+      document.getElementById('nodelist').innerHTML =
+        '<iframe seamless src="' + url.replace(/"/g, "&quot;") + '"></iframe>';
+    }
+  });
+
+  // Tiling mode, can be 'tiled' or 'untiled'
+  function setTileMode(tilingMode) {
+    if (tilingMode == 'tiled') {
+      untiled.set('visible', false);
+      tiled.set('visible', true);
+    } else {
+      tiled.set('visible', false);
+      untiled.set('visible', true);
+    }
+  }
+
+  function setAntialiasMode(mode) {
+    map.getLayers().forEach(function(lyr) {
+      lyr.getSource().updateParams({'FORMAT_OPTIONS': 'antialias:' + mode});
+    });
+  }
+
+  // changes the current tile format
+  function setImageFormat(mime) {
+    map.getLayers().forEach(function(lyr) {
+      lyr.getSource().updateParams({'f': mime});
+    });
+  }
+
+  function setWidth(size){
+    var mapDiv = document.getElementById('map');
+    var wrapper = document.getElementById('wrapper');
+
+    if (size == "auto") {
+      // reset back to the default value
+      mapDiv.style.width = null;
+      wrapper.style.width = null;
+    }
+    else {
+      mapDiv.style.width = size + "px";
+      wrapper.style.width = size + "px";
+    }
+    // notify OL that we changed the size of the map div
+    map.updateSize();
+  }
+
+  function setHeight(size){
+    var mapDiv = document.getElementById('map');
+    if (size == "auto") {
+      // reset back to the default value
+      mapDiv.style.height = null;
+    }
+    else {
+      mapDiv.style.height = size + "px";
+    }
+    // notify OL that we changed the size of the map div
+    map.updateSize();
+  }
+
+  function updateFilter(){
+    var filterType = document.getElementById('filterType').value;
+    var filter = document.getElementById('filter').value;
+    // by default, reset all filters
+    var filterParams = {
+      'FILTER': null,
+      'CQL_FILTER': null,
+      'FEATUREID': null
+    };
+    if (filter.replace(/^\s\s*/, '').replace(/\s\s*$/, '') != "") {
+      if (filterType == "cql") {
+        filterParams["CQL_FILTER"] = filter;
+      }
+      if (filterType == "ogc") {
+        filterParams["FILTER"] = filter;
+      }
+      if (filterType == "fid")
+        filterParams["FEATUREID"] = filter;
+    }
+    // merge the new filter definitions
+    map.getLayers().forEach(function(lyr) {
+      lyr.getSource().updateParams(filterParams);
+    });
+  }
+
+  function resetFilter() {
+    document.getElementById('filter').value = "";
+    updateFilter();
+  }
+
+  // shows/hide the control panel
+  function toggleControlPanel(){
+    var toolbar = document.getElementById("toolbar");
+    if (toolbar.style.display == "none") {
+      toolbar.style.display = "block";
+    }
+    else {
+      toolbar.style.display = "none";
+    }
+    map.updateSize()
+  }
+
+  // set event handlers
+  document.getElementById('tilingModeSelector').onchange = function(event) { setTileMode(event.target.value); };
+  document.getElementById('antialiasSelector').onchange = function(event) { setAntialiasMode(event.target.value); };
+  document.getElementById('imageFormatSelector').onchange = function(event) { setImageFormat(event.target.value); };
+  document.getElementById('widthSelector').onchange = function(event) { setWidth(event.target.value); };
+  document.getElementById('heightSelector').onchange = function(event) { setHeight(event.target.value); };
+  document.getElementById('updateFilterButton').onclick = updateFilter;
+  document.getElementById('resetFilterButton').onclick = resetFilter;
+  document.getElementById('options').onclick = toggleControlPanel;
+
+});

--- a/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/v1/styles/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/v1/styles/landingPage.ftl
@@ -1,5 +1,7 @@
 <#global pagetitle="GeoServer Styles 1.0 Service">
-<#global pagecrumbs="<li class='breadcrumb-item active'>Home</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item active'>Home</li>
+</#global>
 <#include "common-header.ftl">
 
   <h1>${pagetitle}</h1>

--- a/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/v1/styles/styleMetadata.ftl
+++ b/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/v1/styles/styleMetadata.ftl
@@ -1,6 +1,10 @@
 <#global pagetitle=model.id>
 <#global pagepath="/collections/"+model.id>
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item'><a href='"+serviceLink("styles")+"'>Styles</a></li><li class='breadcrumb-item active'>"+model.id+"</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("styles")}'>Styles</a></li>
+  <li class='breadcrumb-item active'>${model.id}</li>
+</#global>
 <#include "common-header.ftl">
 
   <div class="card my-4">
@@ -48,7 +52,7 @@
               <li>
                 ${layer.id}: ${layer.type}. 
                 <#if layer.sampleData?has_content><br/>Sample data available:
-                      <select onchange="window.open(this.options[this.selectedIndex].value);this.selectedIndex=0" >
+                      <select class="form-select-open-basic">
                         <option value="none" selected>-- Please choose a format --</option>
                         <#list layer.sampleData as link>
                         <option value="${link.href}">${link.type}</option>

--- a/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/v1/styles/styles.ftl
+++ b/src/community/ogcapi/ogcapi-styles/src/main/resources/org/geoserver/ogcapi/v1/styles/styles.ftl
@@ -1,4 +1,7 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>GeoServer Styles</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>GeoServer Styles</li>
+</#global>
 <#include "common-header.ftl">
   <h1>GeoServer Styles</h1>
   <p class="my-4">

--- a/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/v1/styles/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/v1/styles/ApiTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -79,7 +80,13 @@ public class ApiTest extends StylesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/styles/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\""));
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/api.js\">"));
+        assertThat(
+                html,
+                containsString(
+                        "<input type=\"hidden\" id=\"apiLocation\" value="
+                                + "\"http://localhost:8080/geoserver/ogc/styles/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\"/>"));
+        assertThat(html, not(containsString("<script>")));
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/v1/styles/StyleMetadataTest.java
+++ b/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/v1/styles/StyleMetadataTest.java
@@ -8,6 +8,8 @@ import static java.util.Map.entry;
 import static junit.framework.TestCase.assertEquals;
 import static org.geoserver.data.test.MockData.BUILDINGS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNull;
 
 import com.jayway.jsonpath.DocumentContext;
@@ -148,6 +150,17 @@ public class StyleMetadataTest extends StylesTestSupport {
         assertEquals(
                 "Default Polygon: polygon.",
                 doc.select("#layers>ul>li").first().textNodes().get(0).text().trim());
+    }
+
+    @Test
+    public void testGetMetadataHTMLRemovedInlineJS() throws Exception {
+        String html = getAsString("ogc/styles/v1/styles/polygon/metadata?f=html");
+        assertThat(
+                html,
+                containsString(
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/common.js\"></script>"));
+        assertThat(html, containsString("form-select-open-basic"));
+        assertThat(html, not(containsString("onchange")));
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/collection.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/collection.ftl
@@ -3,7 +3,11 @@
 <#else>
 <#global pagetitle=model.id>
 </#if>
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item'><a href='"+serviceLink("collections")+"'>Collections</a></li><li class='breadcrumb-item'>"+pagetitle+"</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item active'>${pagetitle}</li>
+</#global>
 <#include "common-header.ftl">
 
   <div class="row">

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/collections.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/collections.ftl
@@ -1,4 +1,7 @@
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>Collections</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>Collections</li>
+</#global>
 <#include "common-header.ftl">
 
   <h1>GeoServer Tiled Collections</h1>

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/landingPage.ftl
@@ -1,5 +1,8 @@
 <#global pagetitle=service.title!"GeoServer Tiles 1.0 Service">
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>"+pagetitle+"</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>${pagetitle}</li>
+</#global>
 <#include "common-header.ftl">
 
   <h1>${pagetitle}</h1>

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/styles.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/styles.ftl
@@ -1,5 +1,10 @@
 <#global pagetitle=model.tileLayerId>
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item'><a href='"+serviceLink("collections")+"'>Collections</a></li><li class='breadcrumb-item'><a href='" + serviceLink("collections/" + model.tileLayerId) + "'>" + pagetitle+ "</a></li><li class='breadcrumb-item'>styles</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections/" + model.tileLayerId)}'>${pagetitle}</a></li>
+  <li class='breadcrumb-item active'>styles</li>
+</#global>
 <#include "common-header.ftl">
        <h2>Styles for ${model.tileLayerId}</h2>
        <p>This document lists the styles available for the ${model.tileLayerId} collection:</p>

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tileMatrixSet.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tileMatrixSet.ftl
@@ -1,5 +1,9 @@
 <#global pagetitle=model.id>
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item'><a href='"+serviceLink("tileMatrixSets")+"'>Tile Matrix Sets</a></li><li class='breadcrumb-item active'>"+pagetitle+"</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("tileMatrixSets")}'>Tile Matrix Sets</a></li>
+  <li class='breadcrumb-item active'>${pagetitle}</li>
+</#global>
 <#include "common-header.ftl">
 
   <h2>${model.id}</h2>

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tileMatrixSets.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tileMatrixSets.ftl
@@ -1,5 +1,8 @@
 <#global pagetitle="Tile matrix sets">
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item active'>"+pagetitle+"</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>${pagetitle}</li>
+</#global>
 <#include "common-header.ftl">
 
   <h1>${pagetitle}</h1>

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tiles-style.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tiles-style.ftl
@@ -1,5 +1,13 @@
 <#global pagetitle=model.id>
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item'><a href='" + serviceLink("collections")+"'>Collections</a></li><li class='breadcrumb-item'><a href='" + serviceLink("collections/" + model.id) + "'>" + pagetitle+ "</a></li><li class='breadcrumb-item'><a href='" + serviceLink("collections/" + model.id + "/styles") + "'>styles</a></li><li class='breadcrumb-item'>" + model.styleId + "</li><li class='breadcrumb-item'>tiles</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections/" + model.id)}'>${pagetitle}</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections/" + model.id + "/styles")}'>styles</a></li>
+  <li class='breadcrumb-item'>${model.styleId}</li>
+  <li class='breadcrumb-item'>map</li>
+  <li class='breadcrumb-item active'>tiles</li>
+</#global>
 <#include "common-header.ftl">
 <#include "tiles-include.ftl">  
 <#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tiles.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tiles.ftl
@@ -1,5 +1,10 @@
 <#global pagetitle=model.id>
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item'><a href='" + serviceLink("collections")+"'>Collections</a></li><li class='breadcrumb-item'><a href='" + serviceLink("collections/" + model.id) + "'>" + pagetitle+ "</a></li><li class='breadcrumb-item'>tiles</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections/" + model.id)}'>${pagetitle}</a></li>
+  <li class='breadcrumb-item active'>tiles</li>
+</#global>
 <#include "common-header.ftl">
 <#include "tiles-include.ftl">  
 <#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tileset-style.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tileset-style.ftl
@@ -1,18 +1,14 @@
 <#global pagetitle=model.id>
-<#global homeLink=serviceLink("")>
-<#global collectionsLink=serviceLink("collections")>
-<#global collectionLink=serviceLink("collections/" + model.id)>
-<#global stylesLink=serviceLink("collections/" + model.id + "/styles")>
-<#global tilesLink=serviceLink("collections/" + model.id + "/styles/" + model.styleId + "/map/tiles")>
-<#global pagecrumbs=
-    "<li class='breadcrumb-item'><a href='"+ homeLink +"'>Home</a></li>
-    <li class='breadcrumb-item'><a href='" + collectionsLink +"'>Collections</a></li>
-    <li class='breadcrumb-item'><a href='" + collectionLink  + "'>" + pagetitle+ "</a></li>
-    <li class='breadcrumb-item'><a href='" + stylesLink + "'>styles</a></li>
-    <li class='breadcrumb-item'>" + model.styleId + "</li><li class='breadcrumb-item'>map</li>
-    <li class='breadcrumb-item'><a href='" + tilesLink + "'>tiles</a></li>
-    <li class='breadcrumb-item'>" + model.tileMatrixId + "</li>">
-
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections/" + model.id)}'>${pagetitle}</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections/" + model.id + "/styles")}'>styles</a></li>
+  <li class='breadcrumb-item'>${model.styleId}</li>
+  <li class='breadcrumb-item'>map</li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections/" + model.id + "/styles/" + model.styleId + "/map/tiles")}'>tiles</a></li>
+  <li class='breadcrumb-item active'>${model.tileMatrixId}</li>
+</#global>
 <#include "common-header.ftl">
 <#include "tileset-include.ftl">  
 <#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tileset.ftl
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/resources/org/geoserver/ogcapi/v1/tiles/tileset.ftl
@@ -1,5 +1,10 @@
 <#global pagetitle=model.id>
-<#global pagecrumbs="<li class='breadcrumb-item'><a href='"+serviceLink("")+"'>Home</a></li><li class='breadcrumb-item'><a href='" + serviceLink("collections")+"'>Collections</a></li><li class='breadcrumb-item'><a href='" + serviceLink("collections/" + model.id) + "'>" + pagetitle+ "</a></li><li class='breadcrumb-item'>tiles</li>">
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections")}'>Collections</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("collections/" + model.id)}'>${pagetitle}</a></li>
+  <li class='breadcrumb-item active'>tiles</li>
+</#global>
 <#include "common-header.ftl">
 <#include "tileset-include.ftl">  
 <#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/ApiTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -79,7 +80,13 @@ public class ApiTest extends TilesTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/tiles/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\""));
+                        "<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/api.js\">"));
+        assertThat(
+                html,
+                containsString(
+                        "<input type=\"hidden\" id=\"apiLocation\" value="
+                                + "\"http://localhost:8080/geoserver/ogc/tiles/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\"/>"));
+        assertThat(html, not(containsString("<script>")));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-11379](https://badgen.net/badge/JIRA/GEOS-11379/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11379) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR moves the inline JavaScript in all of the OGC API community modules into external files. This PR is related to Content-Security-Policy work for GeoServer 2.26.0 and should **NOT** be backported.

All Java inputs that were previously written directly into the script tag are now written to hidden input fields that the external JavaScript file will read. Enabling HTML escaping was necessary to not introduce new vulnerabilities with this PR but that also required changing how the pagecrumbs are initialized everywhere.

This PR uses the new webresources path added to gs-main by https://github.com/geoserver/geoserver/pull/7554 which does not affect unit tests but is required if attempting to manually run GeoServer with these changes.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->