### PR TITLE
Removing unecessary jackson-mapper-asl dependency

### DIFF
--- a/src/community/release/ext-oauth2-openid-connect.xml
+++ b/src/community/release/ext-oauth2-openid-connect.xml
@@ -20,7 +20,6 @@
         <include>spring-security-jwt*</include>
         <include>commons-codec*</include>
         <include>jackson-core-*</include>
-        <include>jackson-mapper-asl-*</include>
         <include>jackson-databind-*</include>
         <include>jackson-annotations-*</include>
         <include>jettison-*</include>

--- a/src/community/security/keycloak/pom.xml
+++ b/src/community/security/keycloak/pom.xml
@@ -49,10 +49,6 @@
       <artifactId>json-lib</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/community/security/oauth2-geonode/pom.xml
+++ b/src/community/security/oauth2-geonode/pom.xml
@@ -55,10 +55,6 @@
       <artifactId>json-lib</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/community/security/oauth2-github/pom.xml
+++ b/src/community/security/oauth2-github/pom.xml
@@ -55,10 +55,6 @@
       <artifactId>json-lib</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
@@ -71,11 +71,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/community/security/oauth2/oauth2-core/pom.xml
+++ b/src/community/security/oauth2/oauth2-core/pom.xml
@@ -42,11 +42,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1215,11 +1215,6 @@
         <!-- fork: https://github.com/geosolutions-it/Json-lib -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>${jackson1.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson2.version}</version>


### PR DESCRIPTION
This dependency contains a very old version of jackson-databind, still located in the "org.codehaus" package. I don't see anything actually using it, the build in the OAuth modules works fine (tests included) when removing it.
@afabiani any idea why it's still there? Am I missing something?

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
