### PR TITLE
[GEOS-11385] Demo Requests functionality does not honour ENV variable PROXY_BASE_URL

### DIFF
--- a/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
+++ b/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
@@ -283,6 +283,9 @@ public class TestWfsPost extends HttpServlet {
     }
 
     String getProxyBaseURL() {
+    	if (GeoServerExtensions.getProperty("PROXY_BASE_URL") != null) {
+    		return GeoServerExtensions.getProperty("PROXY_BASE_URL");
+    	}
         GeoServer geoServer = getGeoServer();
         if (geoServer != null) {
             return geoServer.getGlobal().getSettings().getProxyBaseUrl();

--- a/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
+++ b/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
@@ -283,9 +283,9 @@ public class TestWfsPost extends HttpServlet {
     }
 
     String getProxyBaseURL() {
-    	if (GeoServerExtensions.getProperty("PROXY_BASE_URL") != null) {
-    		return GeoServerExtensions.getProperty("PROXY_BASE_URL");
-    	}
+        if (GeoServerExtensions.getProperty("PROXY_BASE_URL") != null) {
+            return GeoServerExtensions.getProperty("PROXY_BASE_URL");
+        }
         GeoServer geoServer = getGeoServer();
         if (geoServer != null) {
             return geoServer.getGlobal().getSettings().getProxyBaseUrl();

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetCapabilitiesTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetCapabilitiesTest.java
@@ -337,7 +337,7 @@ public class GetCapabilitiesTest extends WFSTestSupport {
     }
 
     @Test
-    public void testMetadataLinksTransormToProxyBaseURL() throws Exception {
+    public void testMetadataLinksTransformToProxyBaseURL() throws Exception {
         FeatureTypeInfo mpolys =
                 getCatalog().getFeatureTypeByName(getLayerId(MockTestData.MPOLYGONS));
         // a valid link whose metadata type needs tweaking

--- a/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
+++ b/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
@@ -256,6 +256,31 @@ public class TestWfsPostTest {
         assertEquals("https://foo.com/geoserver", servlet.getProxyBaseURL());
     }
 
+    @Test
+    // https://osgeo-org.atlassian.net/browse/GEOS-11385
+    public void testGetProxyBaseURLfromEnv() {
+        SettingsInfo settings = new SettingsInfoImpl();
+        settings.setProxyBaseUrl("https://foo.com/geoserver1");
+        // Override the Proxy Base Url with the Environment variable
+        System.setProperty("PROXY_BASE_URL", "https://foo.com/geoserver2");
+
+        GeoServerInfo info = new GeoServerInfoImpl();
+        info.setSettings(settings);
+
+        GeoServer gs = new GeoServerImpl();
+        gs.setGlobal(info);
+
+        TestWfsPost servlet =
+                new TestWfsPost() {
+                    @Override
+                    protected GeoServer getGeoServer() {
+                        return gs;
+                    }
+                };
+        assertEquals("https://foo.com/geoserver2", servlet.getProxyBaseURL());
+        System.clearProperty("PROXY_BASE_URL");
+    }
+
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     protected static MockHttpServletRequest buildMockRequest() {
         MockHttpServletRequest request = new MockHttpServletRequest();


### PR DESCRIPTION
[![GEOS-11385](https://badgen.net/badge/JIRA/GEOS-11385/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11385) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->