### PR TITLE
[GEOS-11392] ConcurrentModificationException while using proxy-base-ext

### DIFF
--- a/src/community/proxy-base-ext/src/main/java/org/geoserver/proxybase/ext/ProxyBaseExtUrlMangler.java
+++ b/src/community/proxy-base-ext/src/main/java/org/geoserver/proxybase/ext/ProxyBaseExtUrlMangler.java
@@ -45,13 +45,19 @@ public class ProxyBaseExtUrlMangler implements URLMangler {
      */
     public ProxyBaseExtUrlMangler(GeoServerDataDirectory dataDirectory) {
         Resource resource = dataDirectory.get(ProxyBaseExtRuleDAO.PROXY_BASE_EXT_RULES_PATH);
-        proxyBaseExtensionRules = getProxyBaseExtensionRules(resource);
-        resource.addListener(
-                notify -> proxyBaseExtensionRules = getProxyBaseExtensionRules(resource));
+        updateRules(resource);
+        resource.addListener(notify -> updateRules(resource));
+    }
+
+    private void updateRules(Resource resource) {
+        List<ProxyBaseExtensionRule> rules = getProxyBaseExtensionRules(resource);
+        rules.sort(ProxyBaseExtensionRule::compareTo);
+        proxyBaseExtensionRules = rules;
     }
 
     /** Constructor for testing purposes */
     public ProxyBaseExtUrlMangler(List<ProxyBaseExtensionRule> proxyBaseExtensionRules) {
+        proxyBaseExtensionRules.sort(ProxyBaseExtensionRule::compareTo);
         this.proxyBaseExtensionRules = proxyBaseExtensionRules;
     }
 
@@ -196,7 +202,6 @@ public class ProxyBaseExtUrlMangler implements URLMangler {
     }
 
     private Optional<String> getFirstMatchingTransformer(String path) {
-        proxyBaseExtensionRules.sort(ProxyBaseExtensionRule::compareTo);
         return proxyBaseExtensionRules.stream()
                 .filter(rule -> ruleMatches(path, rule))
                 .map(ProxyBaseExtensionRule::getTransformer)


### PR DESCRIPTION
[![GEOS-11392](https://badgen.net/badge/JIRA/GEOS-11392/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11392) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->