### PR TITLE
[GEOS-11040] Fix serviceInfo missing in FeatureService and TileService classes

### DIFF
--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
@@ -199,6 +199,12 @@ public class FeatureService {
         return geoServer.getService(WFSInfo.class);
     }
 
+    @SuppressWarnings("unused")
+    public WFSInfo getServiceInfo() {
+        // required for DisabledServiceCheck class
+        return getService();
+    }
+
     private Catalog getCatalog() {
         return geoServer.getCatalog();
     }

--- a/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/v1/tiles/TilesService.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/main/java/org/geoserver/ogcapi/v1/tiles/TilesService.java
@@ -134,6 +134,12 @@ public class TilesService {
         return geoServer.getService(TilesServiceInfo.class);
     }
 
+    @SuppressWarnings("unused")
+    public TilesServiceInfo getServiceInfo() {
+        // required for DisabledServiceCheck class
+        return getService();
+    }
+
     @GetMapping(
             path = {"openapi", "openapi.json", "openapi.yaml"},
             name = "getApi",


### PR DESCRIPTION
Resolve frequent log messages generated by DisabledServiceCheck class
Referenced JIRA issue: [GEOS-11040](https://osgeo-org.atlassian.net/browse/GEOS-11040)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).
