### PR TITLE
[GEOS-11394] OGC APIs cannot handle time extent when the source data type is java.sql.Date

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/CollectionExtents.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/CollectionExtents.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -51,14 +53,27 @@ public class CollectionExtents {
 
         public List<String[]> getInterval() {
             if (temporal != null) {
+                java.util.Date minValue = temporal.getMinValue();
+                java.util.Date maxValue = temporal.getMaxValue();
+                if (minValue instanceof java.sql.Date) {
+                    return Collections.singletonList(
+                            new String[] {
+                                ISO_INSTANT.format(sqlDateToInstant((java.sql.Date) minValue)),
+                                ISO_INSTANT.format(sqlDateToInstant((java.sql.Date) maxValue))
+                            });
+                }
                 return Collections.singletonList(
                         new String[] {
-                            ISO_INSTANT.format(temporal.getMinValue().toInstant()),
-                            ISO_INSTANT.format(temporal.getMaxValue().toInstant())
+                            ISO_INSTANT.format(minValue.toInstant()),
+                            ISO_INSTANT.format(maxValue.toInstant())
                         });
             } else {
                 return null;
             }
+        }
+
+        private Instant sqlDateToInstant(java.sql.Date minValue) {
+            return minValue.toLocalDate().atStartOfDay(ZoneOffset.UTC).toInstant();
         }
 
         public String getTrs() {

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/TimeExtentCalculator.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/TimeExtentCalculator.java
@@ -6,6 +6,7 @@ package org.geoserver.ogcapi;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Optional;
 import java.util.logging.Logger;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.DimensionInfo;
@@ -62,14 +63,17 @@ public class TimeExtentCalculator {
                 ft.getFeatureSource(null, null);
         FeatureCollection<? extends FeatureType, ? extends Feature> collection = fs.getFeatures();
 
-        final MinVisitor min = new MinVisitor(time.getAttribute());
+        String timeAttribute = time.getAttribute();
+        final MinVisitor min = new MinVisitor(timeAttribute);
         collection.accepts(min, null);
         CalcResult minResult = min.getResult();
         // check calcresult first to avoid potential IllegalStateException if no features are in
         // collection
         if (minResult != CalcResult.NULL_RESULT) {
             Date minDate = (Date) min.getMin();
-            final MaxVisitor max = new MaxVisitor(time.getAttribute());
+            String endTimeAttribute =
+                    Optional.ofNullable(time.getEndAttribute()).orElse(timeAttribute);
+            final MaxVisitor max = new MaxVisitor(endTimeAttribute);
             collection.accepts(max, null);
             Date maxDate = (Date) max.getMax();
 

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/common-header.ftl
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/common-header.ftl
@@ -1,4 +1,7 @@
 <#setting locale="en_US">
+<#setting time_zone="utc">
+<#setting date_format="iso">
+<#setting datetime_format="iso">
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/collection_include.ftl
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/resources/org/geoserver/ogcapi/v1/coverages/collection_include.ftl
@@ -16,7 +16,7 @@
       </li>
       <#if collection.extent.temporal??>
       <#assign temporal = collection.extent.temporal>
-      <li id="${collection.htmlId}_temporal"><b>Temporal extent</b>: ${temporal.minValue?datetime?iso_utc}/${temporal.maxValue?datetime?iso_utc}</li>
+      <li id="${collection.htmlId}_temporal"><b>Temporal extent</b>: ${temporal.minValue}/${temporal.maxValue}</li>
       </#if>
   </ul>
 </div>

--- a/src/community/ogcapi/ogcapi-maps/src/main/resources/org/geoserver/ogcapi/v1/maps/collection_include.ftl
+++ b/src/community/ogcapi/ogcapi-maps/src/main/resources/org/geoserver/ogcapi/v1/maps/collection_include.ftl
@@ -15,7 +15,7 @@
       </li>
       <#if collection.extent.temporal??>
             <#assign temporal = collection.extent.temporal>
-            <li id="${collection.htmlId}_temporal"><b>Temporal extent</b>: ${temporal.minValue?datetime?iso_utc}/${temporal.maxValue?datetime?iso_utc}</li>
+            <li id="${collection.htmlId}_temporal"><b>Temporal extent</b>: ${temporal.minValue}/${temporal.maxValue}</li>
       </#if>
       <li> <a id="html_${collection.htmlId}_link" href="${collection.getLinkUrl('styles', 'text/html')!}">Map styles</a>.
                  

--- a/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/CollectionTest.java
+++ b/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/CollectionTest.java
@@ -99,6 +99,39 @@ public class CollectionTest extends MapsTestSupport {
                 document.select("#" + id + "_temporal").text());
     }
 
+    /**
+     * Checks a temporal dimension defined over java.sql.date works in HTML
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testTemporalSqlDateHTML() throws Exception {
+        setupStartEndTimeDimension(TIME_WITH_START_END_DATE, "time", "startTime", "endTime");
+        org.jsoup.nodes.Document document =
+                getAsJSoup("ogc/maps/v1/collections/sf:TimeWithStartEndDate?f=html");
+
+        String id = getLayerId(TIME_WITH_START_END_DATE).replace(":", "__");
+
+        // check temporal extent
+        assertEquals(
+                "Temporal extent: 2012-02-11/2012-02-14",
+                document.select("#" + id + "_temporal").text());
+    }
+
+    /**
+     * Checks a temporal dimension defined over java.sql.date works in JSON
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testTemporalSqlDateJSON() throws Exception {
+        setupStartEndTimeDimension(TIME_WITH_START_END_DATE, "time", "startTime", "endTime");
+        DocumentContext json =
+                getAsJSONPath("ogc/maps/v1/collections/sf:TimeWithStartEndDate", 200);
+        assertEquals("2012-02-11T00:00:00Z", json.read("$.extent.temporal.interval[0][0]"));
+        assertEquals("2012-02-14T00:00:00Z", json.read("$.extent.temporal.interval[0][1]"));
+    }
+
     @Test
     public void testCollectionJson() throws Exception {
         setupRasterDimension(TIMESERIES, TIME, DimensionPresentation.LIST, null, null, null);

--- a/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/MapsTest.java
+++ b/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/MapsTest.java
@@ -20,8 +20,7 @@ import org.junit.Test;
 public class MapsTest extends MapsTestSupport {
     @Test
     public void testDatetimeJson() throws Exception {
-        setupStartEndTimeDimension(
-                TIME_WITH_START_END.getLocalPart(), "time", "startTime", "endTime");
+        setupStartEndTimeDimension(TIME_WITH_START_END, "time", "startTime", "endTime");
         Integer[] values = {1, 1, 1, 1, 0, 1};
         // work with different time resolutions
         String[] dates = {
@@ -44,8 +43,7 @@ public class MapsTest extends MapsTestSupport {
 
     @Test
     public void testDatetimeHTMLMapsFormat() throws Exception {
-        setupStartEndTimeDimension(
-                TIME_WITH_START_END.getLocalPart(), "time", "startTime", "endTime");
+        setupStartEndTimeDimension(TIME_WITH_START_END, "time", "startTime", "endTime");
         Document document =
                 getAsJSoup(
                         "ogc/maps/v1/collections/sf:TimeWithStartEnd/styles/Default/map?f=html&datetime=2012-02-12T00:00:00Z");
@@ -55,8 +53,7 @@ public class MapsTest extends MapsTestSupport {
 
     @Test
     public void testHTMLNoDatetime() throws Exception {
-        setupStartEndTimeDimension(
-                TIME_WITH_START_END.getLocalPart(), "time", "startTime", "endTime");
+        setupStartEndTimeDimension(TIME_WITH_START_END, "time", "startTime", "endTime");
         // failed here when no datetime provided, FTL processing error, null on js_string
         Document document =
                 getAsJSoup("ogc/maps/v1/collections/sf:TimeWithStartEnd/styles/Default/map?f=html");

--- a/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/MapsTestSupport.java
+++ b/src/community/ogcapi/ogcapi-maps/src/test/java/org/geoserver/ogcapi/v1/maps/MapsTestSupport.java
@@ -5,6 +5,7 @@
 package org.geoserver.ogcapi.v1.maps;
 
 import java.util.Collections;
+import java.util.TimeZone;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.DimensionPresentation;
@@ -13,12 +14,21 @@ import org.geoserver.catalog.impl.DimensionInfoImpl;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.ogcapi.OGCApiTestSupport;
+import org.junit.BeforeClass;
 
 public class MapsTestSupport extends OGCApiTestSupport {
     protected static final QName TIMESERIES =
             new QName(MockData.SF_URI, "timeseries", MockData.SF_PREFIX);
     static final QName TIME_WITH_START_END =
             new QName(MockData.SF_URI, "TimeWithStartEnd", MockData.SF_PREFIX);
+
+    static final QName TIME_WITH_START_END_DATE =
+            new QName(MockData.SF_URI, "TimeWithStartEndDate", MockData.SF_PREFIX);
+
+    @BeforeClass
+    public static void setupTimeZone() throws Exception {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
 
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
@@ -37,11 +47,17 @@ public class MapsTestSupport extends OGCApiTestSupport {
                 "TimeElevationWithStartEnd.properties",
                 getClass(),
                 getCatalog());
+        testData.addVectorLayer(
+                TIME_WITH_START_END_DATE,
+                Collections.emptyMap(),
+                "TimeElevationWithStartEndDate.properties",
+                getClass(),
+                getCatalog());
     }
 
     protected void setupStartEndTimeDimension(
-            String featureTypeName, String dimension, String start, String end) {
-        FeatureTypeInfo info = getCatalog().getFeatureTypeByName(featureTypeName);
+            QName typeName, String dimension, String start, String end) {
+        FeatureTypeInfo info = getCatalog().getFeatureTypeByName(typeName.getLocalPart());
         DimensionInfo di = new DimensionInfoImpl();
         di.setEnabled(true);
         di.setAttribute(start);

--- a/src/community/ogcapi/ogcapi-maps/src/test/resources/org/geoserver/ogcapi/v1/maps/TimeElevationWithStartEndDate.properties
+++ b/src/community/ogcapi/ogcapi-maps/src/test/resources/org/geoserver/ogcapi/v1/maps/TimeElevationWithStartEndDate.properties
@@ -1,0 +1,4 @@
+_=id:java.lang.Integer,startTime:java.sql.Date,endTime:java.sql.Date,startElevation:double,endElevation:double,geom:Polygon:srid=4326
+TimeElevationWithStartEnd.0=0|2012-02-11|2012-02-12|1.0|2.0|POLYGON((-180 90, 0 90, 0 0, -180 0, -180 90))
+TimeElevationWithStartEnd.1=1|2012-02-12|2012-02-13|2.0|3.0|POLYGON((0 90, 180 90, 180 0, 0 0, 0 90))
+TimeElevationWithStartEnd.2=2|2012-02-11|2012-02-14|1.0|3.0|POLYGON((-180 -90, 0 -90, 0 0, -180 0, -180 -90))

--- a/src/main/src/main/java/org/geoserver/template/FeatureWrapper.java
+++ b/src/main/src/main/java/org/geoserver/template/FeatureWrapper.java
@@ -13,6 +13,7 @@ import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.SimpleHash;
 import freemarker.template.TemplateCollectionModel;
+import freemarker.template.TemplateDateModel;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 import freemarker.template.TemplateSequenceModel;
@@ -225,6 +226,12 @@ public class FeatureWrapper extends BeansWrapper {
         }
 
         return super.wrap(object);
+    }
+
+    @Override
+    public int getDefaultDateType() {
+        // allows to just serialize dates without specifying a formatting
+        return TemplateDateModel.DATETIME;
     }
 
     private SimpleHash buildType(ComplexType ft) {


### PR DESCRIPTION
[![GEOS-11394](https://badgen.net/badge/JIRA/GEOS-11394/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11394) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->