### PR TITLE
[Backport 2.25.x] [GEOS-11395] Upgrade guava from 32.0.0 to 33.2.0

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1337,7 +1337,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>32.0.0-jre</version>
+        <version>33.2.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
[![GEOS-11395](https://badgen.net/badge/JIRA/GEOS-11395/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11395) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7619
 **Authored by:** @sikeoka