### PR TITLE
[Backport 2.25.x] Removing unecessary jackson-mapper-asl dependency

### DIFF
--- a/src/community/release/ext-oauth2-openid-connect.xml
+++ b/src/community/release/ext-oauth2-openid-connect.xml
@@ -20,7 +20,6 @@
         <include>spring-security-jwt*</include>
         <include>commons-codec*</include>
         <include>jackson-core-*</include>
-        <include>jackson-mapper-asl-*</include>
         <include>jackson-databind-*</include>
         <include>jackson-annotations-*</include>
         <include>jettison-*</include>

--- a/src/community/security/keycloak/pom.xml
+++ b/src/community/security/keycloak/pom.xml
@@ -49,10 +49,6 @@
       <artifactId>json-lib</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/community/security/oauth2-geonode/pom.xml
+++ b/src/community/security/oauth2-geonode/pom.xml
@@ -55,10 +55,6 @@
       <artifactId>json-lib</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/community/security/oauth2-github/pom.xml
+++ b/src/community/security/oauth2-github/pom.xml
@@ -55,10 +55,6 @@
       <artifactId>json-lib</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
@@ -71,11 +71,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/community/security/oauth2/oauth2-core/pom.xml
+++ b/src/community/security/oauth2/oauth2-core/pom.xml
@@ -42,11 +42,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1215,11 +1215,6 @@
         <!-- fork: https://github.com/geosolutions-it/Json-lib -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>${jackson1.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${jackson2.version}</version>


### PR DESCRIPTION
Backport #7600
 **Authored by:** @aaime