### PR TITLE
[Backport 2.24.x] [GEOS-11385] Demo Requests functionality does not honour ENV variable PROXY_BASE_URL

### DIFF
--- a/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
+++ b/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
@@ -283,6 +283,9 @@ public class TestWfsPost extends HttpServlet {
     }
 
     String getProxyBaseURL() {
+    	if (GeoServerExtensions.getProperty("PROXY_BASE_URL") != null) {
+    		return GeoServerExtensions.getProperty("PROXY_BASE_URL");
+    	}
         GeoServer geoServer = getGeoServer();
         if (geoServer != null) {
             return geoServer.getGlobal().getSettings().getProxyBaseUrl();

--- a/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
+++ b/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
@@ -283,9 +283,9 @@ public class TestWfsPost extends HttpServlet {
     }
 
     String getProxyBaseURL() {
-    	if (GeoServerExtensions.getProperty("PROXY_BASE_URL") != null) {
-    		return GeoServerExtensions.getProperty("PROXY_BASE_URL");
-    	}
+        if (GeoServerExtensions.getProperty("PROXY_BASE_URL") != null) {
+            return GeoServerExtensions.getProperty("PROXY_BASE_URL");
+        }
         GeoServer geoServer = getGeoServer();
         if (geoServer != null) {
             return geoServer.getGlobal().getSettings().getProxyBaseUrl();

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetCapabilitiesTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetCapabilitiesTest.java
@@ -339,7 +339,7 @@ public class GetCapabilitiesTest extends WFSTestSupport {
     }
 
     @Test
-    public void testMetadataLinksTransormToProxyBaseURL() throws Exception {
+    public void testMetadataLinksTransformToProxyBaseURL() throws Exception {
         FeatureTypeInfo mpolys =
                 getCatalog().getFeatureTypeByName(getLayerId(MockTestData.MPOLYGONS));
         // a valid link whose metadata type needs tweaking

--- a/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
+++ b/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
@@ -256,6 +256,31 @@ public class TestWfsPostTest {
         assertEquals("https://foo.com/geoserver", servlet.getProxyBaseURL());
     }
 
+    @Test
+    // https://osgeo-org.atlassian.net/browse/GEOS-11385
+    public void testGetProxyBaseURLfromEnv() {
+        SettingsInfo settings = new SettingsInfoImpl();
+        settings.setProxyBaseUrl("https://foo.com/geoserver1");
+        // Override the Proxy Base Url with the Environment variable
+        System.setProperty("PROXY_BASE_URL", "https://foo.com/geoserver2");
+
+        GeoServerInfo info = new GeoServerInfoImpl();
+        info.setSettings(settings);
+
+        GeoServer gs = new GeoServerImpl();
+        gs.setGlobal(info);
+
+        TestWfsPost servlet =
+                new TestWfsPost() {
+                    @Override
+                    protected GeoServer getGeoServer() {
+                        return gs;
+                    }
+                };
+        assertEquals("https://foo.com/geoserver2", servlet.getProxyBaseURL());
+        System.clearProperty("PROXY_BASE_URL");
+    }
+
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     protected static MockHttpServletRequest buildMockRequest() {
         MockHttpServletRequest request = new MockHttpServletRequest();


### PR DESCRIPTION
[![GEOS-11385](https://badgen.net/badge/JIRA/GEOS-11385/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11385) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7602
 **Authored by:** @petersmythe