### PR TITLE
[Backport 2.24.x] [GEOS-11398] Javadoc clarification and test cases for Entity Resolution

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerInfo.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerInfo.java
@@ -109,14 +109,16 @@ public interface GeoServerInfo extends Info {
     Integer getXmlPostRequestLogBufferSize();
 
     /**
-     * If true it enables evaluation of XML entities contained in XML files received in a service
-     * (WMS, WFS, ...) request. Default is FALSE. Enabling this feature is a security risk.
+     * If true it enables unrestricted evaluation of XML entities contained in XML files received in
+     * a service (WMS, WFS, ...) request. Default is FALSE. Enabling this feature is a security
+     * risk.
      */
     void setXmlExternalEntitiesEnabled(Boolean xmlExternalEntitiesEnabled);
 
     /**
-     * If true it enables evaluation of XML entities contained in XML files received in a service
-     * (WMS, WFS, ...) request. Default is FALSE. Enabling this feature is a security risk.
+     * If true it enables unrestricted evaluation of XML entities contained in XML files received in
+     * a service (WMS, WFS, ...) request. Default is FALSE. Enabling this feature is a security
+     * risk.
      */
     Boolean isXmlExternalEntitiesEnabled();
 

--- a/src/main/src/main/java/org/geoserver/config/impl/GeoServerInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/config/impl/GeoServerInfoImpl.java
@@ -268,8 +268,9 @@ public class GeoServerInfoImpl implements GeoServerInfo {
     }
 
     /**
-     * If true it enables evaluation of XML entities contained in XML files received in a service
-     * (WMS, WFS, ...) request. Default is FALSE. Enabling this feature is a security risk.
+     * If true it enables unrestricted evaluation of XML entities contained in XML files received in
+     * a service (WMS, WFS, ...) request. Default is FALSE. Enabling this feature is a security
+     * risk.
      */
     @Override
     public void setXmlExternalEntitiesEnabled(Boolean xmlExternalEntitiesEnabled) {
@@ -277,8 +278,9 @@ public class GeoServerInfoImpl implements GeoServerInfo {
     }
 
     /**
-     * If true it enables evaluation of XML entities contained in XML files received in a service
-     * (WMS, WFS, ...) request. Default is FALSE. Enabling this feature is a security risk.
+     * If true it enables unrestricted evaluation of XML entities contained in XML files received in
+     * a service (WMS, WFS, ...) request. Default is FALSE. Enabling this feature is a security
+     * risk.
      */
     @Override
     public Boolean isXmlExternalEntitiesEnabled() {

--- a/src/main/src/main/java/org/geoserver/util/EntityResolverProvider.java
+++ b/src/main/src/main/java/org/geoserver/util/EntityResolverProvider.java
@@ -5,6 +5,9 @@
  */
 package org.geoserver.util;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.geoserver.config.GeoServer;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geotools.util.PreventLocalEntityResolver;
@@ -70,7 +73,7 @@ public class EntityResolverProvider {
      * preventing local file access. This implementation allows access to XSD files included in the
      * geoserver application.
      *
-     * @return EntityResolver, or null if
+     * @return EntityResolver, or {@code null} if unrestricted
      */
     public EntityResolver getEntityResolver() {
         if (geoServer != null) {
@@ -79,21 +82,19 @@ public class EntityResolverProvider {
                 // XML parser is unrestricted, and can access any XSD location
                 return null;
             }
-
-            if (ALLOW_LIST != null) {
-                // External entity resolution limited to those approved for use
-                // those built-in to GeoSever, while restricting file access
-                return ALLOWLIST_ENTITY_RESOLVER;
-            }
         }
         if (entityResolver != null) {
             // override provided (usually by a test case)
             return entityResolver;
-        } else {
-            // Allows access to any http(s) location, and those built-in to GeoServer jars, while
-            // restricting file access.
-            return PreventLocalEntityResolver.INSTANCE;
         }
+        if (ALLOW_LIST != null) {
+            // External entity resolution limited to those approved for use
+            // those built-in to GeoSever, while restricting file access
+            return ALLOWLIST_ENTITY_RESOLVER;
+        }
+        // Allows access to any http(s) location, and those built-in to GeoServer jars, while
+        // restricting file access.
+        return PreventLocalEntityResolver.INSTANCE;
     }
 
     /**
@@ -101,7 +102,7 @@ public class EntityResolverProvider {
      * "ENTITY_RESOLUTION_ALLOWLIST".
      *
      * <ul>
-     *   <li><code>"*" or undefined</code>: Allow all http(s) schema locations
+     *   <li><code>"*" or null</code>: Allow all http(s) schema locations
      *   <li><code>"": Restrict to schemas provided by w3c, ogc and inspire</code>
      *   <li><code>
      *       "location1,location2": Restrict to the provided locations, and those list by w4c, ogc and inspire
@@ -118,14 +119,37 @@ public class EntityResolverProvider {
      */
     public static String[] entityResolutionAllowlist() {
         String allowed = GeoServerExtensions.getProperty(ENTITY_RESOLUTION_ALLOWLIST);
-        if (allowed == null || "*".equals(allowed.trim())) {
-            // allow all external http(s) access
+        return entityResolutionAllowlist(allowed);
+    }
+
+    /**
+     * Provides parsing of ENTITY_RESOLUTION_ALLOWLIST property for {@link
+     * #entityResolutionAllowlist()}.
+     *
+     * @param allowed Allowed list of expansion locations seperated by | character.
+     * @return set of allowed http(s) entity expansion external locations.
+     */
+    static String[] entityResolutionAllowlist(String allowed) {
+        final String[] DEFAULT_LIST = {
+            AllowListEntityResolver.W3C,
+            AllowListEntityResolver.OGC1,
+            AllowListEntityResolver.OGC2,
+            AllowListEntityResolver.INSPIRE
+        };
+
+        // 2.24 defaults to UNRESTRICTED
+        if (allowed == null || allowed.equals(AllowListEntityResolver.UNRESTRICTED)) {
             return null;
-        } else if (!"".equals(allowed.trim())) {
-            // allow external http(s) access to ogc, w3c, and
-            return new String[0];
+        } else if (allowed.trim().isEmpty()) {
+            return DEFAULT_LIST;
         } else {
-            return allowed.split("\\s*,\\s*|\\s+");
+            Set<String> allowedList = new HashSet<>(Arrays.asList(DEFAULT_LIST));
+            for (String domain : allowed.split("\\s*,\\s*|\\s+")) {
+                if (!domain.isEmpty()) {
+                    allowedList.add(domain);
+                }
+            }
+            return allowedList.toArray(new String[allowedList.size()]);
         }
     }
 }

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -258,6 +258,11 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
                     return path.matches(".*modules[\\\\/]extension[\\\\/]xsd[\\\\/].*\\.xsd")
                             || path.matches(".*modules[\\\\/]ogc[\\\\/].*\\.xsd");
                 }
+
+                @Override
+                public String toString() {
+                    return "PreventLocalEntityResolver";
+                }
             };
 
     @Override

--- a/src/main/src/test/java/org/geoserver/util/EntityResolverProviderTest.java
+++ b/src/main/src/test/java/org/geoserver/util/EntityResolverProviderTest.java
@@ -1,0 +1,124 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public class EntityResolverProviderTest {
+
+    @Test
+    public void testAllowListDefaults() throws Exception {
+        // include defaults if allow list is empty
+        String allowed[] = EntityResolverProvider.entityResolutionAllowlist("");
+        assertNotNull("defaults for empty", allowed);
+        assertEquals(4, allowed.length);
+        assertTrue(Arrays.stream(allowed).anyMatch(AllowListEntityResolver.W3C::equals));
+        assertTrue(Arrays.stream(allowed).anyMatch(AllowListEntityResolver.INSPIRE::equals));
+        assertTrue(Arrays.stream(allowed).anyMatch(AllowListEntityResolver.OGC1::equals));
+        assertTrue(Arrays.stream(allowed).anyMatch(AllowListEntityResolver.OGC2::equals));
+    }
+
+    @Test
+    public void testAllowListUnrestriced() throws Exception {
+        String allowed[] = EntityResolverProvider.entityResolutionAllowlist("*");
+        assertNull("* for Unrestricted", allowed);
+
+        allowed = EntityResolverProvider.entityResolutionAllowlist(null);
+        assertNull("null for Unrestricted", allowed);
+    }
+
+    @Test
+    public void testAllowListDomains() throws Exception {
+        String allowed[] = EntityResolverProvider.entityResolutionAllowlist("how2map.com");
+        // confirm allowed includes the defaults
+        assertNotNull(allowed);
+        assertEquals(5, allowed.length);
+        assertTrue(Arrays.stream(allowed).anyMatch(AllowListEntityResolver.W3C::equals));
+        assertTrue(Arrays.stream(allowed).anyMatch(AllowListEntityResolver.INSPIRE::equals));
+        assertTrue(Arrays.stream(allowed).anyMatch(AllowListEntityResolver.OGC1::equals));
+        assertTrue(Arrays.stream(allowed).anyMatch(AllowListEntityResolver.OGC2::equals));
+        // in addition to the provided domain
+        assertTrue(Arrays.stream(allowed).anyMatch("how2map.com"::equals));
+    }
+
+    @Test
+    public void testNoWildcard() throws Exception {
+        // AllowListEntityResolver uses '*' to allow all http content (null returned)
+        String everything[] =
+                EntityResolverProvider.entityResolutionAllowlist(
+                        AllowListEntityResolver.UNRESTRICTED);
+        assertNull("* allows everything", everything);
+
+        // but wild cards such as `foo*bar` are not supported, strings are quoted and not intended
+        // to be a RegEx
+        String allowed[] = EntityResolverProvider.entityResolutionAllowlist("foo*bar");
+        assertNotNull(allowed);
+        assertTrue(Arrays.stream(allowed).anyMatch("foo*bar"::equals));
+    }
+
+    /**
+     * Test behaviour of EntityResolveProvider in response to configuration.
+     *
+     * <p>EntityResolver returns {@code null} when the provided URI is *allowed*, Returns an
+     * Inputstream if the content is provided, or throws an Exception if the URI is not allowed.
+     */
+    @Test
+    public void testEntityResolverDefaultBehaviour() throws Exception {
+        EntityResolverProvider provider = new EntityResolverProvider(null);
+        provider.setEntityResolver(new AllowListEntityResolver(null));
+        EntityResolver resolver = provider.getEntityResolver();
+
+        // Confirm schema is available from public location
+        // (this is a default from AllowListEntiryResolver)
+        InputSource filter =
+                resolver.resolveEntity(null, "http://schemas.opengis.net/filter/1.1.0/filter.xsd");
+        assertNull("Public Filter 1.1.0 connection allowed", filter);
+
+        // Confirm schema is available from jars, as is the case for those included in GeoTools
+        InputSource filterJar =
+                resolver.resolveEntity(
+                        null, "jar:file:/some/path/gs-main.jar!schemas/filter/1.1.0/filter.xsd");
+        assertNull("JAR Filter 1.1.0 connection allowed", filterJar);
+
+        // Confirm schema is available when war is unpacked into JBoss virtual filesystem
+        InputSource filterJBoss =
+                resolver.resolveEntity(
+                        null,
+                        "vfsfile:/home/userone/jboss-eap-5.1/jboss-as/server/default_WAR/deploy/geoserver.war/WEB-INF/lib/gs-main.jar!/filter/1.1.0/filter.xsd");
+        assertNull("JBoss Virtual File System Filter 1.1.0 connection allowed", filterJBoss);
+
+        // confirm schema CANNOT be accessed from a random website http address
+        // (such as an external geoserver location mentioned below)
+        try {
+            InputSource external =
+                    resolver.resolveEntity(
+                            null,
+                            "https://how2map.geocat.live/geoserver/schemas/wfs/1.0.0/WFS-basic.xsd");
+            assertNotNull("Website Filter 1.1.0 not allowed", external);
+            fail("Filter 1.1.0 is should not be provided built-in");
+        } catch (SAXException e) {
+            // Confirm the exception is clear, and contains the URI for folks to troubleshoot their
+            // xml document
+            assertTrue(
+                    "External XSD not allowed",
+                    e.getMessage().startsWith("Entity resolution disallowed for"));
+            assertTrue(
+                    "External XSD not allowed",
+                    e.getMessage()
+                            .contains(
+                                    "https://how2map.geocat.live/geoserver/schemas/wfs/1.0.0/WFS-basic.xsd"));
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-11398](https://badgen.net/badge/JIRA/GEOS-11398/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11398) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport https://github.com/geoserver/geoserver/pull/7668

However since 2.24.x did not have a test case I have adapted the EntityResolverProviderTest to the expectations of 2.24.x branch (2.24.x it defaults to unrestricted http access).