### PR TITLE
[Backport 2.25.x] [GEOS-11398] Additional entityResolverProviderTest checks

### DIFF
--- a/src/main/src/test/java/org/geoserver/util/EntityResolverProviderTest.java
+++ b/src/main/src/test/java/org/geoserver/util/EntityResolverProviderTest.java
@@ -5,18 +5,25 @@
 package org.geoserver.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Set;
+import org.geotools.util.PreventLocalEntityResolver;
+import org.junit.After;
 import org.junit.Test;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 public class EntityResolverProviderTest {
+    @After
+    public void after() {
+        EntityResolverProvider.setEntityResolver(null);
+    }
 
     @Test
     public void testAllowListDefaults() throws Exception {
@@ -57,6 +64,8 @@ public class EntityResolverProviderTest {
         assertTrue(allowed.contains(AllowListEntityResolver.OGC2));
         // in addition to the provided domain
         assertTrue(allowed.contains("how2map.com"));
+        // and not allow other matches
+        assertFalse(allowed.contains("geocat.net"));
     }
 
     @Test
@@ -75,7 +84,8 @@ public class EntityResolverProviderTest {
     }
 
     /**
-     * Test behaviour of EntityResolveProvider in response to configuration.
+     * Test behaviour of EntityResolveProvider in response to default configuration (if
+     * ENTITY_RESOLUTION_ALLOWLIST is unset or empty).
      *
      * <p>EntityResolver returns {@code null} when the provided URI is *allowed*, Returns an
      * Inputstream if the content is provided, or throws an Exception if the URI is not allowed.
@@ -125,6 +135,84 @@ public class EntityResolverProviderTest {
                     e.getMessage()
                             .contains(
                                     "https://how2map.geocat.live/geoserver/schemas/wfs/1.0.0/WFS-basic.xsd"));
+        }
+
+        // not allowed to access local file system
+        try {
+            InputSource filesystem =
+                    resolver.resolveEntity(
+                            null, "file:/var/opt/geoserver/data/www/schemas/WFS-basic.xsd");
+            assertNotNull("Filesystem Filter 1.1.0 not allowed", filesystem);
+            fail("Filter 1.1.0 is should not avalable as a file reference");
+        } catch (SAXException e) {
+            // Confirm the exception is clear, and contains the URI for folks to troubleshoot their
+            // xml document
+            assertTrue(
+                    "Filesystem XSD not allowed",
+                    e.getMessage().startsWith("Entity resolution disallowed for"));
+            assertTrue(
+                    "Filesystem XSD not allowed",
+                    e.getMessage()
+                            .contains("file:/var/opt/geoserver/data/www/schemas/WFS-basic.xsd"));
+        }
+    }
+
+    /**
+     * Test behaviour of EntityResolveProvider in response to configuration to prevent local
+     * filesystem access (as done with ENTITY_RESOLUTION_ALLOWLIST=*)
+     *
+     * <p>EntityResolver returns {@code null} when the provided URI is *allowed*, Returns an
+     * Inputstream if the content is provided, or throws an Exception if the URI is not allowed.
+     */
+    @Test
+    public void testEntityResolverPreventLocal() throws Exception {
+        EntityResolverProvider provider = new EntityResolverProvider(null);
+        provider.setEntityResolver(PreventLocalEntityResolver.INSTANCE);
+        EntityResolver resolver = provider.getEntityResolver();
+
+        // Confirm schema is available from public location
+        // (this is a default from AllowListEntiryResolver)
+        InputSource filter =
+                resolver.resolveEntity(null, "http://schemas.opengis.net/filter/1.1.0/filter.xsd");
+        assertNull("Public Filter 1.1.0 connection allowed", filter);
+
+        // Confirm schema is available from jars, as is the case for those included in GeoTools
+        InputSource filterJar =
+                resolver.resolveEntity(
+                        null, "jar:file:/some/path/gs-main.jar!schemas/filter/1.1.0/filter.xsd");
+        assertNull("JAR Filter 1.1.0 connection allowed", filterJar);
+
+        // Confirm schema is available when war is unpacked into JBoss virtual filesystem
+        InputSource filterJBoss =
+                resolver.resolveEntity(
+                        null,
+                        "vfsfile:/home/userone/jboss-eap-5.1/jboss-as/server/default_WAR/deploy/geoserver.war/WEB-INF/lib/gs-main.jar!/filter/1.1.0/filter.xsd");
+        assertNull("JBoss Virtual File System Filter 1.1.0 connection allowed", filterJBoss);
+
+        // confirm that by default can access any random website http address
+        InputSource external =
+                resolver.resolveEntity(
+                        null,
+                        "https://how2map.geocat.live/geoserver/schemas/wfs/1.0.0/WFS-basic.xsd");
+        assertNull("Website Filter 1.1.0 allowed", external);
+
+        // not allowed to access local file system
+        try {
+            InputSource filesystem =
+                    resolver.resolveEntity(
+                            null, "file:/var/opt/geoserver/data/www/schemas/WFS-basic.xsd");
+            assertNotNull("Filesystem Filter 1.1.0 not allowed", filesystem);
+            fail("Filter 1.1.0 is should not avalable as a file reference");
+        } catch (SAXException e) {
+            // Confirm the exception is clear, and contains the URI for folks to troubleshoot their
+            // xml document
+            assertTrue(
+                    "Filesystem XSD not allowed",
+                    e.getMessage().startsWith("Entity resolution disallowed for"));
+            assertTrue(
+                    "Filesystem XSD not allowed",
+                    e.getMessage()
+                            .contains("file:/var/opt/geoserver/data/www/schemas/WFS-basic.xsd"));
         }
     }
 }


### PR DESCRIPTION
[![GEOS-11398](https://badgen.net/badge/JIRA/GEOS-11398/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11398) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7680
 **Authored by:** @jodygarnett