### PR TITLE
[GEOS-11413] STAC uses inefficient dabase queries when asking for collections in JSON format

### DIFF
--- a/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/store/JDBCProductFeatureStore.java
+++ b/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/store/JDBCProductFeatureStore.java
@@ -108,6 +108,12 @@ public class JDBCProductFeatureStore extends AbstractMappingStore {
     }
 
     @Override
+    protected boolean needsJoins(Query query) {
+        return super.needsJoins(query)
+                || hasOutputProperty(query, OpenSearchAccess.QUICKLOOK_PROPERTY_NAME, false);
+    }
+
+    @Override
     protected void mapPropertiesToComplex(
             ComplexFeatureBuilder builder, SimpleFeature fi, Map<String, Object> mapperState) {
         // JSONB Keys are Unsorted, so we sort them here

--- a/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/CollectionLayerTest.java
+++ b/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/CollectionLayerTest.java
@@ -768,7 +768,7 @@ public class CollectionLayerTest extends OSEORestTestSupport {
                         .collect(Collectors.toList());
         assertEquals(1, styles.size());
         assertEquals("test123", styles.get(0).getAttribute("name"));
-        assertEquals("test123", styles.get(0).getAttribute("title"));
+        assertEquals("gs:test123", styles.get(0).getAttribute("title"));
     }
 
     @Nullable


### PR DESCRIPTION
[![GEOS-11413](https://badgen.net/badge/JIRA/GEOS-11413/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11413) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->