### PR TITLE
[Backport 2.25.x] [GEOS-11413] STAC uses inefficient dabase queries when asking for collections in JSON format

### DIFF
--- a/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/store/JDBCProductFeatureStore.java
+++ b/src/community/oseo/oseo-core/src/main/java/org/geoserver/opensearch/eo/store/JDBCProductFeatureStore.java
@@ -108,6 +108,12 @@ public class JDBCProductFeatureStore extends AbstractMappingStore {
     }
 
     @Override
+    protected boolean needsJoins(Query query) {
+        return super.needsJoins(query)
+                || hasOutputProperty(query, OpenSearchAccess.QUICKLOOK_PROPERTY_NAME, false);
+    }
+
+    @Override
     protected void mapPropertiesToComplex(
             ComplexFeatureBuilder builder, SimpleFeature fi, Map<String, Object> mapperState) {
         // JSONB Keys are Unsorted, so we sort them here

--- a/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/CollectionLayerTest.java
+++ b/src/community/oseo/oseo-rest/src/test/java/org/geoserver/opensearch/rest/CollectionLayerTest.java
@@ -768,7 +768,7 @@ public class CollectionLayerTest extends OSEORestTestSupport {
                         .collect(Collectors.toList());
         assertEquals(1, styles.size());
         assertEquals("test123", styles.get(0).getAttribute("name"));
-        assertEquals("test123", styles.get(0).getAttribute("title"));
+        assertEquals("gs:test123", styles.get(0).getAttribute("title"));
     }
 
     @Nullable


### PR DESCRIPTION
[![GEOS-11413](https://badgen.net/badge/JIRA/GEOS-11413/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11413) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7690
 **Authored by:** @aaime