### PR TITLE
[GEOS-11280] Short-circuit request processing upon ClientStreamAbortedException when SKIP_MISCONFIGURED_LAYERS is true

### DIFF
--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10CapsTransformer.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10CapsTransformer.java
@@ -32,6 +32,7 @@ import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.config.SettingsInfo;
+import org.geoserver.ows.ClientStreamAbortedException;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.wcs.WCSInfo;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
@@ -573,6 +574,8 @@ public class Wcs10CapsTransformer extends TransformerBase {
                     handleCoverageOfferingBrief(cvInfo);
                     commit();
                 } catch (Exception e) {
+                    // abort processing if the user closed the connection
+                    ClientStreamAbortedException.rethrowUncheked(e);
                     if (skipMisconfigured) {
                         reset();
                         LOGGER.log(

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10DescribeCoverageTransformer.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/response/Wcs10DescribeCoverageTransformer.java
@@ -36,6 +36,7 @@ import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.ResourcePool;
 import org.geoserver.catalog.util.ReaderDimensionsAccessor;
 import org.geoserver.config.ResourceErrorHandling;
+import org.geoserver.ows.ClientStreamAbortedException;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.wcs.WCSInfo;
 import org.geotools.api.coverage.grid.GridEnvelope;
@@ -190,6 +191,8 @@ public class Wcs10DescribeCoverageTransformer extends TransformerBase {
                     handleCoverageOffering(coverage);
                     commit();
                 } catch (Exception e) {
+                    // abort processing if the user closed the connection
+                    ClientStreamAbortedException.rethrowUncheked(e);
                     if (skipMisconfiguredThisTime) {
                         reset();
                     } else {

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/response/WCSCapsTransformer.java
@@ -28,6 +28,7 @@ import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.config.SettingsInfo;
+import org.geoserver.ows.ClientStreamAbortedException;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.wcs.WCSInfo;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -408,6 +409,8 @@ public class WCSCapsTransformer extends TransformerBase {
                     handleCoverageSummary(cv);
                     commit();
                 } catch (Exception e) {
+                    // abort processing if the user closed the connection
+                    ClientStreamAbortedException.rethrowUncheked(e);
                     if (skipMisconfigured) {
                         reset();
                         LOGGER.log(

--- a/src/wfs/src/main/java/org/geoserver/wfs/CapabilitiesTransformer.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/CapabilitiesTransformer.java
@@ -36,6 +36,7 @@ import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.data.InternationalContentHelper;
+import org.geoserver.ows.ClientStreamAbortedException;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.ows.URLMangler.URLType;
@@ -812,6 +813,8 @@ public abstract class CapabilitiesTransformer extends TransformerBase {
                         handleFeatureType(ftype);
                         commit();
                     } catch (RuntimeException e) {
+                        // abort processing if the user closed the connection
+                        ClientStreamAbortedException.rethrowUncheked(e);
                         if (skipMisconfigured) {
                             reset();
                             LOGGER.log(
@@ -1721,6 +1724,8 @@ public abstract class CapabilitiesTransformer extends TransformerBase {
                             featureType(featureType, crs);
                             commit();
                         } catch (RuntimeException ex) {
+                            // abort processing if the user closed the connection
+                            ClientStreamAbortedException.rethrowUncheked(ex);
                             if (skipMisconfigured) {
                                 reset();
                                 LOGGER.log(

--- a/src/wfs/src/main/java/org/geoserver/wfs/DescribeFeatureType.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/DescribeFeatureType.java
@@ -16,6 +16,7 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.config.ResourceErrorHandling;
+import org.geoserver.ows.ClientStreamAbortedException;
 import org.geoserver.platform.ServiceException;
 import org.geoserver.wfs.request.DescribeFeatureTypeRequest;
 import org.geotools.util.logging.Logging;
@@ -114,6 +115,8 @@ public class DescribeFeatureType {
                         ftInfo.getFeatureType(); // check that we can get a connection to this ftype
                         requested.add(ftInfo);
                     } catch (IOException ioe) {
+                        // abort processing if the user closed the connection
+                        ClientStreamAbortedException.rethrowUncheked(ioe);
                         if (skipMisconfigured) {
                             LOGGER.log(
                                     Level.WARNING,

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -60,6 +60,7 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.crs.CapabilitiesCRSProvider;
 import org.geoserver.data.InternationalContentHelper;
+import org.geoserver.ows.ClientStreamAbortedException;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.ServiceException;
@@ -1108,6 +1109,8 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                 handleLayer(layer, isRoot);
                 commit();
             } catch (Exception e) {
+                // abort processing if the user closed the connection
+                ClientStreamAbortedException.rethrowUncheked(e);
                 // report what layer we failed on to help the admin locate and fix it
 
                 if (skipping) {
@@ -1415,6 +1418,8 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                         handleLayerGroup(group, isRoot);
                         commit();
                     } catch (Exception e) {
+                        // abort processing if the user closed the connection
+                        ClientStreamAbortedException.rethrowUncheked(e);
                         // report what layer we failed on to help the admin locate and fix it
                         if (skipping) {
                             if (group != null) {

--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/GetCapabilitiesTransformer.java
@@ -66,6 +66,7 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.crs.CapabilitiesCRSProvider;
 import org.geoserver.data.InternationalContentHelper;
+import org.geoserver.ows.ClientStreamAbortedException;
 import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.ServiceException;
@@ -1021,6 +1022,8 @@ public class GetCapabilitiesTransformer extends TransformerBase {
                         handleLayer(layer, isRoot);
                         commit();
                     } catch (Exception e) {
+                        // abort processing if the user closed the connection
+                        ClientStreamAbortedException.rethrowUncheked(e);
                         if (skipping) {
                             reset();
                             LOGGER.log(


### PR DESCRIPTION
[![GEOS-11280](https://badgen.net/badge/JIRA/GEOS-11280/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11280) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When `ResourceErrorHandling.SKIP_MISCONFIGURED_LAYERS` is true, and the client closed the connection, the `ClientStreamAbortedException` is ignored and the process continues until it consumed all layers.

This patch makes it short-circuit and lets the `Dispatcher` handle the `ClientStreamAbortedException` gracefully.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->