### PR TITLE
[GEOS-11424] Speed up web-ui WorkspaceAdminComponentAuthorizer

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/WorkspaceAdminComponentAuthorizer.java
+++ b/src/web/core/src/main/java/org/geoserver/web/WorkspaceAdminComponentAuthorizer.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2024 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -6,18 +6,28 @@
 package org.geoserver.web;
 
 import org.geoserver.catalog.Catalog;
-import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.security.ResourceAccessManager;
 import org.geoserver.security.SecureCatalogImpl;
-import org.geoserver.security.WorkspaceAccessLimits;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 
 /**
  * Authorizer that allows access if the user has admin rights to any workspace.
  *
  * @author Justin Deoliveira, OpenGeo
+ * @see ResourceAccessManager#isWorkspaceAdmin(Authentication, Catalog)
  */
+@SuppressWarnings("serial")
 public class WorkspaceAdminComponentAuthorizer extends AdminComponentAuthorizer {
+
+    /**
+     * Key to cache the result of {@link #isWorkspaceAdmin(Authentication)} on the request's {@link
+     * RequestAttributes} in {@link RequestAttributes#SCOPE_REQUEST request scope}
+     */
+    static final String REQUEST_CONTEXT_CACHE_KEY = "WORKSPACEADMIN_COMPONENT_AUTHORIZER_VALUE";
+
     @Override
     public boolean isAccessAllowed(Class<?> componentClass, Authentication authentication) {
 
@@ -31,30 +41,48 @@ public class WorkspaceAdminComponentAuthorizer extends AdminComponentAuthorizer 
             return false;
         }
 
-        // TODO: we should cache this result somehow
-        return isWorkspaceAdmin(authentication);
+        // this authorizer may be called several times per request, use a per-request cached value
+        Boolean workspaceAdmin = getCachedValue();
+        if (null == workspaceAdmin) {
+            workspaceAdmin = isWorkspaceAdmin(authentication);
+            setCachedValue(workspaceAdmin.booleanValue());
+        }
+        return workspaceAdmin;
     }
 
     /** Check if the current user has any admin privilege on at least one workspace. */
     boolean isWorkspaceAdmin(Authentication authentication) {
+        ResourceAccessManager manager = getAccessManager();
+        return null != manager && manager.isWorkspaceAdmin(authentication, getCatalog());
+    }
 
-        Catalog catalog = getSecurityManager().getCatalog();
+    private Catalog getCatalog() {
+        return getSecurityManager().getCatalog();
+    }
 
+    ResourceAccessManager getAccessManager() {
         // the secure catalog builds and owns the ResourceAccessManager
         SecureCatalogImpl secureCatalog =
                 GeoServerApplication.get().getBeanOfType(SecureCatalogImpl.class);
-        ResourceAccessManager manager = secureCatalog.getResourceAccessManager();
+        if (null == secureCatalog) return null;
+        return secureCatalog.getResourceAccessManager();
+    }
 
-        if (manager != null) {
-            for (WorkspaceInfo workspace : catalog.getWorkspaces()) {
-                WorkspaceAccessLimits accessLimits =
-                        manager.getAccessLimits(authentication, workspace);
-                if (accessLimits != null && accessLimits.isAdminable()) {
-                    return true;
-                }
-            }
+    void setCachedValue(boolean workspaceAdmin) {
+        RequestAttributes atts = RequestContextHolder.getRequestAttributes();
+        if (null != atts) {
+            atts.setAttribute(
+                    REQUEST_CONTEXT_CACHE_KEY, workspaceAdmin, RequestAttributes.SCOPE_REQUEST);
         }
+    }
 
-        return false;
+    @Nullable
+    Boolean getCachedValue() {
+        RequestAttributes atts = RequestContextHolder.getRequestAttributes();
+        if (null != atts) {
+            return (Boolean)
+                    atts.getAttribute(REQUEST_CONTEXT_CACHE_KEY, RequestAttributes.SCOPE_REQUEST);
+        }
+        return null;
     }
 }

--- a/src/web/core/src/test/java/org/geoserver/web/WorkspaceAdminComponentAuthorizerTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/WorkspaceAdminComponentAuthorizerTest.java
@@ -1,0 +1,136 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.geoserver.security.ResourceAccessManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class WorkspaceAdminComponentAuthorizerTest extends GeoServerWicketTestSupport {
+
+    private WorkspaceAdminComponentAuthorizer authorizer;
+    private ResourceAccessManager accessManager;
+
+    @Before
+    @SuppressWarnings("serial")
+    public void setUp() {
+        this.accessManager = new WorkspaceAdminComponentAuthorizer().getAccessManager();
+        authorizer =
+                new WorkspaceAdminComponentAuthorizer() {
+                    @Override
+                    ResourceAccessManager getAccessManager() {
+                        return accessManager;
+                    }
+                };
+    }
+
+    @After
+    public void after() {
+        RequestContextHolder.setRequestAttributes(null);
+    }
+
+    private boolean isAccessAllowed(Authentication user) {
+        Class<?> unused = GeoServerBasePage.class;
+        return authorizer.isAccessAllowed(unused, user);
+    }
+
+    @Test
+    public void testGetAccessManager() {
+        authorizer = new WorkspaceAdminComponentAuthorizer();
+        assertNotNull(authorizer.getAccessManager());
+    }
+
+    @Test
+    public void testAdmin() {
+        assertTrue(isAccessAllowed(admin()));
+    }
+
+    @Test
+    public void testNull() {
+        assertFalse(isAccessAllowed(null));
+    }
+
+    @Test
+    public void testNoAccessManager() {
+        this.accessManager = null;
+        assertNull(authorizer.getAccessManager());
+        Authentication user = user("test", "ROLE_1");
+        assertFalse(isAccessAllowed(user));
+    }
+
+    @Test
+    public void testNotAuthenticated() {
+        Authentication user = user("test");
+        user.setAuthenticated(false);
+        assertFalse(isAccessAllowed(user));
+    }
+
+    @Test
+    public void testNotWorkspaceAdmin() {
+        Authentication user = user("test", "ROLE_USER");
+        assertFalse(isAccessAllowed(user));
+    }
+
+    @Test
+    public void testIsWorkspaceAdmin() {
+        Authentication user = user("test", "ROLE_USER");
+        accessManager = mock(ResourceAccessManager.class);
+        when(accessManager.isWorkspaceAdmin(user, getCatalog())).thenReturn(true);
+        assertTrue(isAccessAllowed(user));
+    }
+
+    @Test
+    public void testRequestCache() {
+        Authentication user = user("test", "ROLE_USER");
+        accessManager = mock(ResourceAccessManager.class);
+        when(accessManager.isWorkspaceAdmin(user, getCatalog())).thenReturn(true);
+
+        RequestAttributes atts = new ServletRequestAttributes(new MockHttpServletRequest());
+        RequestContextHolder.setRequestAttributes(atts);
+
+        authorizer = spy(authorizer);
+
+        assertTrue(isAccessAllowed(user));
+        assertTrue(isAccessAllowed(user));
+        assertTrue(isAccessAllowed(user));
+
+        verify(authorizer, times(1)).setCachedValue(true);
+        verify(authorizer, times(1)).isWorkspaceAdmin(user);
+
+        Object cached =
+                atts.getAttribute(
+                        WorkspaceAdminComponentAuthorizer.REQUEST_CONTEXT_CACHE_KEY,
+                        RequestAttributes.SCOPE_REQUEST);
+        assertEquals(Boolean.TRUE, cached);
+    }
+
+    private Authentication admin() {
+        login();
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    private Authentication user(String name, String... roles) {
+        login(name, "pwd", roles);
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+}


### PR DESCRIPTION
[![GEOS-11424](https://badgen.net/badge/JIRA/GEOS-11424/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11424) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Logging in as a user other than `admin`, and having a large amount of workspaces results in potentlially substantial delays in loading almost every webui wicket page, as `WorkspaceAdminComponentAuthorizer` will be run several times, each of them potentially doing a full scan of workspaces, to determine if the user has admin privileges in at least one workspace.

This patch addresses the long-standing TODO comment in `WorkspaceAdminComponentAuthorizer` by caching the result in the `RequestAttributes`, hence performing the check once per request.

Also, moves the logic to a new default method in the `ResourceAccessManager` interface, giving implementations a chance to provide a more efficient check.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->