### PR TITLE
[Backport 2.25.x] Fix typo in datadir-catalog-loader release descriptor (s/dataird/datadir/g)

### DIFF
--- a/src/community/release/ext-datadir-catalog-loader.xml
+++ b/src/community/release/ext-datadir-catalog-loader.xml
@@ -1,5 +1,5 @@
 <assembly>
-  <id>dataidr-catalog-loader-plugin</id>
+  <id>datadir-catalog-loader-plugin</id>
   <formats>
     <format>zip</format>
   </formats>


### PR DESCRIPTION
Backport #7705
 **Authored by:** @groldan