### PR TITLE
[GEOS-11430] CiteComplianceHack not correctly parsing the context

### DIFF
--- a/src/main/src/main/java/org/geoserver/ows/CiteComplianceHack.java
+++ b/src/main/src/main/java/org/geoserver/ows/CiteComplianceHack.java
@@ -62,6 +62,7 @@ public class CiteComplianceHack implements HandlerInterceptor {
         // set request / response
         req.setHttpRequest(request);
         req.setHttpResponse(response);
+        Dispatcher.initRequestContext(req);
 
         // find the service
         try {
@@ -71,8 +72,7 @@ public class CiteComplianceHack implements HandlerInterceptor {
                     Level.FINE, "Exception while looking for the 'Service' from the request", ex1);
             // load from the context
             try {
-                UriComponentsBuilder builder =
-                        UriComponentsBuilder.fromUriString(request.getServletPath());
+                UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(req.path);
                 if (builder != null
                         && builder.build() != null
                         && builder.build().getPath() != null) {

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -385,6 +385,12 @@ public class Dispatcher extends AbstractController {
                 request.getInput().reset();
             }
         }
+        initRequestContext(request);
+
+        return fireInitCallback(request);
+    }
+
+    public static void initRequestContext(Request request) {
         // parse the request path into two components. (1) the 'path' which
         // is the string after the last '/', and the 'context' which is the
         // string before the last '/'
@@ -414,8 +420,6 @@ public class Dispatcher extends AbstractController {
 
         request.setContext(context);
         request.setPath(path);
-
-        return fireInitCallback(request);
     }
 
     private boolean isForm(String contentType) {

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -390,6 +390,25 @@ public class Dispatcher extends AbstractController {
         return fireInitCallback(request);
     }
 
+    /**
+     * Initializes the request context by parsing the request path into two components:
+     * the 'context' and the 'path'. The 'context' is the part of the URI before the last '/' and
+     * the 'path' is the part after the last '/'.
+     *
+     * <p>This method processes the given {@link Request} object to extract and set the context
+     * and path based on the HTTP request URI. Leading and trailing slashes are stripped from
+     * the request path before the context and path are determined.</p>
+     *
+     * @param request the {@link Request} object whose context and path need to be initialized.
+     * @throws NullPointerException if the {@link Request} or its HTTP request is null.
+     *
+     * <pre>
+     * Example:
+     * If the request URI is "/app/resource/item", then:
+     * - context: "app/resource"
+     * - path: "item"
+     * </pre>
+     */
     public static void initRequestContext(Request request) {
         // parse the request path into two components. (1) the 'path' which
         // is the string after the last '/', and the 'context' which is the

--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -391,18 +391,17 @@ public class Dispatcher extends AbstractController {
     }
 
     /**
-     * Initializes the request context by parsing the request path into two components:
-     * the 'context' and the 'path'. The 'context' is the part of the URI before the last '/' and
-     * the 'path' is the part after the last '/'.
+     * Initializes the request context by parsing the request path into two components: the
+     * 'context' and the 'path'. The 'context' is the part of the URI before the last '/' and the
+     * 'path' is the part after the last '/'.
      *
-     * <p>This method processes the given {@link Request} object to extract and set the context
-     * and path based on the HTTP request URI. Leading and trailing slashes are stripped from
-     * the request path before the context and path are determined.</p>
+     * <p>This method processes the given {@link Request} object to extract and set the context and
+     * path based on the HTTP request URI. Leading and trailing slashes are stripped from the
+     * request path before the context and path are determined.
      *
      * @param request the {@link Request} object whose context and path need to be initialized.
      * @throws NullPointerException if the {@link Request} or its HTTP request is null.
-     *
-     * <pre>
+     *     <pre>
      * Example:
      * If the request URI is "/app/resource/item", then:
      * - context: "app/resource"

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesSystemTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesSystemTest.java
@@ -335,10 +335,12 @@ public class CapabilitiesSystemTest extends WMSTestSupport {
             dom = getAsDOM("wms?request=GetCapabilities&version=1.3.0");
             checkLegacyException(dom, ServiceException.MISSING_PARAMETER_VALUE, "service");
 
-            dom = getAsDOM("wcs/wms?request=GetCapabilities&version=1.3.0");
+            // The testSetupData adds a Workspace named "wcs". Going to reuse it for the tests.
+            final String testWorkspace = "wcs";
+            dom = getAsDOM(testWorkspace + "/wms?request=GetCapabilities&version=1.3.0");
             checkLegacyException(dom, ServiceException.MISSING_PARAMETER_VALUE, "service");
 
-            dom = getAsDOM("wcs/wms/?request=GetCapabilities&version=1.3.0");
+            dom = getAsDOM(testWorkspace + "/wms/?request=GetCapabilities&version=1.3.0");
             checkLegacyException(dom, ServiceException.MISSING_PARAMETER_VALUE, "service");
         } finally {
             wms.setCiteCompliant(false);

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesSystemTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/CapabilitiesSystemTest.java
@@ -334,6 +334,12 @@ public class CapabilitiesSystemTest extends WMSTestSupport {
 
             dom = getAsDOM("wms?request=GetCapabilities&version=1.3.0");
             checkLegacyException(dom, ServiceException.MISSING_PARAMETER_VALUE, "service");
+
+            dom = getAsDOM("wcs/wms?request=GetCapabilities&version=1.3.0");
+            checkLegacyException(dom, ServiceException.MISSING_PARAMETER_VALUE, "service");
+
+            dom = getAsDOM("wcs/wms/?request=GetCapabilities&version=1.3.0");
+            checkLegacyException(dom, ServiceException.MISSING_PARAMETER_VALUE, "service");
         } finally {
             wms.setCiteCompliant(false);
             gs.save(wms);


### PR DESCRIPTION
[![GEOS-11430](https://badgen.net/badge/JIRA/GEOS-11430/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11430) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

References: https://osgeo-org.atlassian.net/browse/GEOS-11430

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->