### PR TITLE
[GEOS-11111] Open search for EO community module: STAC search page has wrong self link

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/PaginationLinksBuilder.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/PaginationLinksBuilder.java
@@ -7,7 +7,6 @@ package org.geoserver.ogcapi;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import javax.servlet.http.HttpServletRequest;
 import org.geoserver.ows.URLMangler;
 import org.geoserver.ows.util.ResponseUtils;
 
@@ -59,6 +58,7 @@ public class PaginationLinksBuilder {
         return kvp;
     }
 
+    /** Returns a HREF to the next page */
     public String getNext() {
         Map<String, Object> kvp = getNextMap(true);
         if (kvp == null) return null;
@@ -66,11 +66,7 @@ public class PaginationLinksBuilder {
         return buildURL(kvp);
     }
 
-    /**
-     * Map of KVP for the previous link. Can be used in POST links generation.
-     *
-     * @return
-     */
+    /** Map of KVP for the next link. Can be used in POST links generation. */
     public Map<String, Object> getNextMap(boolean includeQueryMap) {
         // if nothing is returned or we returned less than a page, there is no next page
         if (returned == 0 || (startIndex + returned >= matched)) return null;
@@ -82,12 +78,11 @@ public class PaginationLinksBuilder {
         return kvp;
     }
 
+    /** Returns a HREF to the current page. */
     public String getSelf() {
-        HttpServletRequest request = APIRequestInfo.get().getRequest();
-        StringBuffer sb = request.getRequestURL();
-        String queryString = request.getQueryString();
-        if (queryString != null && !queryString.isEmpty()) sb.append("?").append(queryString);
-        return sb.toString();
+        Map<String, Object> kvp = new LinkedHashMap<>();
+        kvp.putAll(APIRequestInfo.get().getSimpleQueryMap());
+        return buildURL(kvp);
     }
 
     private String buildURL(Map<String, Object> kvp) {

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/SearchTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/SearchTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import net.minidev.json.JSONArray;
+import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.ogcapi.OGCAPIMediaTypes;
 import org.geotools.api.filter.Filter;
@@ -83,7 +84,7 @@ public class SearchTest extends STACTestSupport {
             assertTrue(link.read("merge"));
         } else {
             assertEquals(
-                    "http://localhost:8080/geoserver/ogc/stac/v1/search?collections=SAS1,LANDSAT8",
+                    "http://localhost:8080/geoserver/ogc/stac/v1/search?collections=SAS1%2CLANDSAT8",
                     link.read("href"));
         }
     }
@@ -327,8 +328,8 @@ public class SearchTest extends STACTestSupport {
     @Test
     public void testPagingLinksFirst() throws Exception {
         String requestPath =
-                "ogc/stac/v1/search?collections=SAS1,LANDSAT8"
-                        + "&filter=eo:cloud_cover=0&filter-lang=cql-text&limit=1";
+                "ogc/stac/v1/search?collections=SAS1%2CLANDSAT8"
+                        + "&filter=eo%3Acloud_cover%3D0&filter-lang=cql-text&limit=1";
         DocumentContext doc = getAsJSONPath(requestPath, 200);
         assertEquals(Integer.valueOf(4), doc.read("numberMatched"));
         assertEquals(Integer.valueOf(1), doc.read("numberReturned"));
@@ -352,8 +353,8 @@ public class SearchTest extends STACTestSupport {
     @Test
     public void testPagingLinksSecond() throws Exception {
         String requestPath =
-                "ogc/stac/v1/search?collections=SAS1,LANDSAT8"
-                        + "&filter=eo:cloud_cover=0&filter-lang=cql-text&limit=1&startIndex=1";
+                "ogc/stac/v1/search?collections=SAS1%2CLANDSAT8"
+                        + "&filter=eo%3Acloud_cover%3D0&filter-lang=cql-text&limit=1&startIndex=1";
         DocumentContext doc = getAsJSONPath(requestPath, 200);
         assertEquals(Integer.valueOf(4), doc.read("numberMatched"));
         assertEquals(Integer.valueOf(1), doc.read("numberReturned"));
@@ -384,8 +385,8 @@ public class SearchTest extends STACTestSupport {
     @Test
     public void testPagingLinksLast() throws Exception {
         String requestPath =
-                "ogc/stac/v1/search?collections=SAS1,LANDSAT8"
-                        + "&filter=eo:cloud_cover=0&filter-lang=cql-text&limit=1&startIndex=2";
+                "ogc/stac/v1/search?collections=SAS1%2CLANDSAT8"
+                        + "&filter=eo%3Acloud_cover%3D0&filter-lang=cql-text&limit=1&startIndex=2";
         DocumentContext doc = getAsJSONPath(requestPath, 200);
         assertEquals(Integer.valueOf(4), doc.read("numberMatched"));
         assertEquals(Integer.valueOf(1), doc.read("numberReturned"));
@@ -775,5 +776,47 @@ public class SearchTest extends STACTestSupport {
         List<String> collections = Arrays.asList("SAS1");
         Filter filter = getStacService().parseFilter(collections, "s1:ipf_version>2", null);
         assertEquals(2.0, ((Literal) ((IsGreaterThanImpl) filter).getExpression2()).getValue());
+    }
+
+    @Test
+    public void testPagingLinksProxyBase() throws Exception {
+        GeoServerInfo global = getGeoServer().getGlobal();
+        global.getSettings().setProxyBaseUrl("https://thehost/geoserver");
+        getGeoServer().save(global);
+
+        try {
+            String requestPath =
+                    "ogc/stac/v1/search?collections=SAS1%2CLANDSAT8"
+                            + "&filter=eo%3Acloud_cover%3D0&filter-lang=cql-text&limit=1&startIndex=1";
+            DocumentContext doc = getAsJSONPath(requestPath, 200);
+            assertEquals(Integer.valueOf(4), doc.read("numberMatched"));
+            assertEquals(Integer.valueOf(1), doc.read("numberReturned"));
+
+            // three links expected, prev, self and next
+            assertEquals(Integer.valueOf(3), doc.read("links.length()"));
+
+            // prev link (order should be stable, linked hash maps all around)
+            DocumentContext prev = readSingleContext(doc, "links[?(@.rel=='prev')]");
+            assertEquals(OGCAPIMediaTypes.GEOJSON_VALUE, prev.read("type"));
+            assertEquals(
+                    "https://thehost/geoserver/ogc/stac/v1/search?collections=SAS1%2CLANDSAT8&filter=eo%3Acloud_cover%3D0&filter-lang=cql-text&limit=1&startIndex=0",
+                    prev.read("href"));
+
+            // self link
+            DocumentContext self = readSingleContext(doc, "links[?(@.rel=='self')]");
+            assertEquals(OGCAPIMediaTypes.GEOJSON_VALUE, self.read("type"));
+            assertEquals("https://thehost/geoserver/" + requestPath, self.read("href"));
+
+            // next link (order should be stable, linked hash maps all around)
+            DocumentContext next = readSingleContext(doc, "links[?(@.rel=='next')]");
+            assertEquals(OGCAPIMediaTypes.GEOJSON_VALUE, next.read("type"));
+            assertEquals(
+                    "https://thehost/geoserver/ogc/stac/v1/search?collections=SAS1%2CLANDSAT8&filter=eo%3Acloud_cover%3D0&filter-lang=cql-text&limit=1&startIndex=2",
+                    next.read("href"));
+
+        } finally {
+            global.getSettings().setProxyBaseUrl(null);
+            getGeoServer().save(global);
+        }
     }
 }


### PR DESCRIPTION
See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
