### PR TITLE
[Backport 2.25.x] [GEOS-11438] OpenSearch for EO/STAC lack the service configuration panel

### DIFF
--- a/src/community/oseo/oseo-assembly/pom.xml
+++ b/src/community/oseo/oseo-assembly/pom.xml
@@ -35,6 +35,11 @@
       <artifactId>gs-oseo-stac</artifactId>
       <version>${gs.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-web-oseo</artifactId>
+      <version>${gs.version}</version>
+    </dependency>
 
   </dependencies>
 </project>


### PR DESCRIPTION
[![GEOS-11438](https://badgen.net/badge/JIRA/GEOS-11438/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11438) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7735
 **Authored by:** @aaime