### PR TITLE
Hopefully fix random build failure in style controller test

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/StyleController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/StyleController.java
@@ -82,6 +82,7 @@ import org.xml.sax.EntityResolver;
 public class StyleController extends AbstractCatalogController {
 
     private static final Logger LOGGER = Logging.getLogger(StyleController.class);
+    static final String SLD_TEMP_PREFIX = "_sld";
 
     @Autowired
     public StyleController(@Qualifier("catalog") Catalog catalog) {
@@ -593,7 +594,7 @@ public class StyleController extends AbstractCatalogController {
      * @throws IOException if there was an error extracting the archive
      */
     private File unzipSldPackage(InputStream object) throws IOException {
-        File tempDir = Files.createTempDirectory("_sld").toFile();
+        File tempDir = Files.createTempDirectory(SLD_TEMP_PREFIX).toFile();
 
         org.geoserver.util.IOUtils.decompress(object, tempDir);
 

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/StyleControllerTest.java
@@ -6,6 +6,7 @@ package org.geoserver.rest.catalog;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.geoserver.rest.catalog.StyleController.SLD_TEMP_PREFIX;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1258,7 +1259,7 @@ public class StyleControllerTest extends CatalogRESTTestSupport {
     @Test
     public void testPostToWorkspaceSLDPackage() throws Exception {
         File tempDir = new File(System.getProperty("java.io.tmpdir"));
-        int initialSize = tempDir.listFiles().length;
+        int initialSize = tempDir.listFiles(f -> f.getName().startsWith(SLD_TEMP_PREFIX)).length;
 
         Catalog cat = getCatalog();
         assertNull(cat.getStyleByName("gs", "foo"));
@@ -1289,7 +1290,8 @@ public class StyleControllerTest extends CatalogRESTTestSupport {
         assertEquals("gear.png", onlineResource.getAttribute("xlink:href"));
         assertNotNull(getCatalog().getResourceLoader().find("workspaces/gs/styles/gear.png"));
         assertNotNull(getCatalog().getResourceLoader().find("workspaces/gs/styles/foo.sld"));
-        assertEquals(initialSize, tempDir.listFiles().length);
+        int finalSize = tempDir.listFiles(f -> f.getName().startsWith(SLD_TEMP_PREFIX)).length;
+        assertEquals(initialSize, finalSize);
     }
 
     @Test


### PR DESCRIPTION
Looking specifically for the temp directories created by the tested code, rather than counting files in the shared temp directory, where other tests can also put stuff (and other OS processes as well).

Ideally, it would be better to have each module run with a separate test directory, but we cannot get that, as test JVMs are getting re-used across the build.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->