### PR TITLE
[Backport 2.25.x] [GEOS-111441] DisabledServiceResourceFilter spams debugging logs with property accesses

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/DisabledServiceResourceFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/DisabledServiceResourceFilter.java
@@ -13,9 +13,11 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.config.impl.GeoServerLifecycleHandler;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geotools.util.SuppressFBWarnings;
 
 /**
  * Disables defined services on layer by configuration.
@@ -24,7 +26,13 @@ import org.geoserver.platform.GeoServerExtensions;
  *
  * @author Fernando Mino, Geosolutions
  */
-public class DisabledServiceResourceFilter extends AbstractCatalogFilter {
+public class DisabledServiceResourceFilter extends AbstractCatalogFilter
+        implements GeoServerLifecycleHandler {
+
+    /** Property set in context/environment/system for default disabled services. */
+    public static String PROPERTY = "org.geoserver.service.disabled";
+
+    protected static List<String> DEFAULT_SERVICE_TYPES;
 
     private boolean isFilterSubject() {
         return request() != null
@@ -55,12 +63,16 @@ public class DisabledServiceResourceFilter extends AbstractCatalogFilter {
     }
 
     private static List<String> defaultDisabledServiceTypes() {
-        List<String> list = null;
-        String globalEnv = GeoServerExtensions.getProperty("org.geoserver.service.disabled");
-        if (isNotBlank(globalEnv)) {
-            list = Arrays.asList(globalEnv.split(","));
+        if (DEFAULT_SERVICE_TYPES == null) {
+            String globalEnv = GeoServerExtensions.getProperty(PROPERTY);
+            if (isNotBlank(globalEnv)) {
+                DEFAULT_SERVICE_TYPES = Arrays.asList(globalEnv.split(","));
+            } else {
+                DEFAULT_SERVICE_TYPES = Collections.emptyList();
+            }
         }
-        return list == null ? Collections.emptyList() : list;
+
+        return DEFAULT_SERVICE_TYPES;
     }
 
     /**
@@ -87,5 +99,23 @@ public class DisabledServiceResourceFilter extends AbstractCatalogFilter {
             disabledServices = defaultDisabledServiceTypes();
         }
         return disabledServices;
+    }
+
+    @Override
+    @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD") // Spring singleton anyways
+    public void onReset() {
+        DEFAULT_SERVICE_TYPES = null;
+    }
+
+    @Override
+    public void onDispose() {}
+
+    @Override
+    public void beforeReload() {}
+
+    @Override
+    @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD") // Spring singleton anyways
+    public void onReload() {
+        DEFAULT_SERVICE_TYPES = null;
     }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/WFSDisabledTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/WFSDisabledTest.java
@@ -12,7 +12,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.security.DisabledServiceResourceFilter;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -21,6 +23,11 @@ import org.w3c.dom.Document;
 public class WFSDisabledTest extends WFSTestSupport {
 
     @Rule public final EnvironmentVariables enviromentVariables = new EnvironmentVariables();
+
+    @Before
+    public void resetConfiguration() {
+        getGeoServer().reset();
+    }
 
     @Test
     public void testDisabledServiceResponse() throws Exception {
@@ -66,7 +73,7 @@ public class WFSDisabledTest extends WFSTestSupport {
     @Test
     public void testLayerEnvDisabledServiceResponse() throws Exception {
         enableWFS();
-        enviromentVariables.set("org.geoserver.service.disabled", "WFS,WPS");
+        enviromentVariables.set(DisabledServiceResourceFilter.PROPERTY, "WFS,WPS");
         String layerName = "cite:RoadSegments";
         Document doc =
                 getAsDOM(
@@ -82,7 +89,7 @@ public class WFSDisabledTest extends WFSTestSupport {
 
     @After
     public void clearEnviromentVariables() {
-        enviromentVariables.clear("org.geoserver.service.disabled");
+        enviromentVariables.clear(DisabledServiceResourceFilter.PROPERTY);
     }
 
     /** Tests WFS service enabled on layer-resource */


### PR DESCRIPTION
[![GEOS-111441](https://badgen.net/badge/JIRA/GEOS-111441/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-111441) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7739
 **Authored by:** @aaime