### PR TITLE
[GEOS-11443] REST API does not take effect immediately due to 10 minute authentication cache

### DIFF
--- a/src/main/src/main/java/applicationSecurityContext.xml
+++ b/src/main/src/main/java/applicationSecurityContext.xml
@@ -182,4 +182,7 @@
   <bean id="styleUrlChecker" class="org.geoserver.security.urlchecks.StyleURLChecker">
     <constructor-arg ref="dataDirectory"/>
   </bean>
+
+  <bean id="AuthenticationCacheImpl" class="org.geoserver.security.auth.AuthenticationCacheImpl" />
+
 </beans>

--- a/src/main/src/main/java/org/geoserver/security/auth/AuthenticationCache.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/AuthenticationCache.java
@@ -27,7 +27,7 @@ public interface AuthenticationCache {
     /** Clears all cache entries for filterName */
     public void removeAll(String filterName);
 
-    /** Clears a specific chache entry */
+    /** Clears a specific cache entry */
     public void remove(String filterName, String cacheKey);
 
     /** */

--- a/src/main/src/main/java/org/geoserver/security/auth/GeoServerRootAuthenticationProvider.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/GeoServerRootAuthenticationProvider.java
@@ -51,8 +51,8 @@ public class GeoServerRootAuthenticationProvider extends GeoServerAuthentication
                 (UsernamePasswordAuthenticationToken) authentication;
 
         // check if name is root
-        if (GeoServerUser.ROOT_USERNAME.equals(SecurityUtils.getUsername(token.getPrincipal()))
-                == false) return null;
+        if (!GeoServerUser.ROOT_USERNAME.equals(SecurityUtils.getUsername(token.getPrincipal())))
+            return null;
 
         // check password
         if (token.getCredentials() != null) {

--- a/src/main/src/main/java/org/geoserver/security/auth/UsernamePasswordAuthenticationProvider.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/UsernamePasswordAuthenticationProvider.java
@@ -95,7 +95,7 @@ public class UsernamePasswordAuthenticationProvider extends GeoServerAuthenticat
             ((GeoServerWebAuthenticationDetails) auth.getDetails())
                     .setUserGroupServiceName(userGroupServiceName);
         }
-        if (auth.getAuthorities().contains(GeoServerRole.AUTHENTICATED_ROLE) == false) {
+        if (!auth.getAuthorities().contains(GeoServerRole.AUTHENTICATED_ROLE)) {
             List<GrantedAuthority> roles = new ArrayList<>();
             roles.addAll(auth.getAuthorities());
             roles.add(GeoServerRole.AUTHENTICATED_ROLE);


### PR DESCRIPTION
[![GEOS-11443](https://badgen.net/badge/JIRA/GEOS-11443/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11443) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

From my experience with the GeoServer REST API, e.g. adding a user to a group [GeoServer API Docs](https://docs.geoserver.org/stable/en/api/#1.0.0/usergroup.yaml) , the change happens and is written to disk immediately, however there is a 10 minute authentication cache that prevents the change from being **effective** immediately.

If I am impatient, I typically reload the configuration or use the AuthKey synchronise button to clear the 10 min auth cache. I am aware of the reload API endpoint [GeoServer API Docs](https://docs.geoserver.org/stable/en/api/#1.0.0/reload.yaml)  but that is a bit drastic.  
The reset endpoint does not appear to clear the auth cache.

I have found that adding this bean to `src/main/java/applicationSecurityContext.xml` fixes the problem

`<bean id="AuthenticationCacheImpl" class="org.geoserver.security.auth.AuthenticationCacheImpl" />`

but I am unsure of the side effects of this.  Could I please get a review @aaime @jodygarnett 


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->