### PR TITLE
[GEOS-11446] [INSPIRE] Incorrect behavior for unsupported languages

### DIFF
--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/LanguagesDispatcherCallback.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/LanguagesDispatcherCallback.java
@@ -7,10 +7,8 @@ package org.geoserver.inspire;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 import org.geoserver.ows.AbstractDispatcherCallback;
 import org.geoserver.ows.Request;
-import org.geoserver.platform.ServiceException;
 
 public class LanguagesDispatcherCallback extends AbstractDispatcherCallback {
 
@@ -29,21 +27,8 @@ public class LanguagesDispatcherCallback extends AbstractDispatcherCallback {
             try {
                 Properties mappings = InspireDirectoryManager.get().getLanguagesMappings();
                 String isoLang = mappings.getProperty(value);
-                String supportedLanguages =
-                        mappings.keySet().stream()
-                                .map(s -> s.toString())
-                                .collect(Collectors.joining(","));
-                if (isoLang == null) {
-                    value = value == null || value.equals("") ? "empty" : value;
-                    throw new ServiceException(
-                            "A Language parameter was provided in the request but it cannot be resolved to an ISO lang code."
-                                    + " Parameter value is "
-                                    + value
-                                    + " while supported languages are "
-                                    + supportedLanguages);
-                }
                 rawKvp.put(ACCEPT_LANGUAGES_PARAM, isoLang);
-                rawKvp.put(LANGUAGE_PARAM, isoLang);
+                rawKvp.put(LANGUAGE_PARAM, isoLang != null ? isoLang : "");
                 if (request.getKvp() != null) {
                     request.getKvp().put(ACCEPT_LANGUAGES_PARAM, isoLang);
                     request.getKvp().put(LANGUAGE_PARAM, isoLang);

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/ServicesUtils.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/ServicesUtils.java
@@ -116,7 +116,7 @@ public final class ServicesUtils {
                 value = getIfSupported(reqLang, languages);
             }
         }
-        if (value == null) value = defaultLanguage;
+        if (value == null || value.isEmpty()) value = defaultLanguage;
         return value;
     }
 

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
@@ -8,9 +8,9 @@ package org.geoserver.inspire.wms;
 import static org.geoserver.inspire.InspireMetadata.CREATE_EXTENDED_CAPABILITIES;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_TYPE;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_URL;
+import static org.geoserver.inspire.InspireSchema.DLS_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.VS_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.VS_SCHEMA;
-import static org.geoserver.inspire.InspireSchema.DLS_NAMESPACE;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
@@ -10,6 +10,7 @@ import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_TYPE;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_URL;
 import static org.geoserver.inspire.InspireSchema.VS_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.VS_SCHEMA;
+import static org.geoserver.inspire.InspireSchema.DLS_NAMESPACE;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -56,6 +57,8 @@ public class WMSExtendedCapabilitiesProvider implements ExtendedCapabilitiesProv
     @Override
     public void registerNamespaces(NamespaceSupport namespaces) {
         ServicesUtils.registerNameSpaces(namespaces);
+        // IGN : We add another xmlns for inspire_dls
+        namespaces.declarePrefix("inspire_dls", DLS_NAMESPACE);
     }
 
     @Override

--- a/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
+++ b/src/extension/inspire/src/main/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesProvider.java
@@ -8,7 +8,6 @@ package org.geoserver.inspire.wms;
 import static org.geoserver.inspire.InspireMetadata.CREATE_EXTENDED_CAPABILITIES;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_TYPE;
 import static org.geoserver.inspire.InspireMetadata.SERVICE_METADATA_URL;
-import static org.geoserver.inspire.InspireSchema.DLS_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.VS_NAMESPACE;
 import static org.geoserver.inspire.InspireSchema.VS_SCHEMA;
 
@@ -57,8 +56,6 @@ public class WMSExtendedCapabilitiesProvider implements ExtendedCapabilitiesProv
     @Override
     public void registerNamespaces(NamespaceSupport namespaces) {
         ServicesUtils.registerNameSpaces(namespaces);
-        // IGN : We add another xmlns for inspire_dls
-        namespaces.declarePrefix("inspire_dls", DLS_NAMESPACE);
     }
 
     @Override

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wcs/WCSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wcs/WCSExtendedCapabilitiesTest.java
@@ -372,4 +372,38 @@ public class WCSExtendedCapabilitiesTest extends GeoServerSystemTestSupport {
         nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguage");
         assertEquals("Number of Supported Languages", 2, nodeList.getLength());
     }
+
+    @Test
+    public void testUnSupportedLanguages() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WCSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        metadata.put(OTHER_LANGUAGES.key, "ita,eng");
+        metadata.put(
+                SPATIAL_DATASET_IDENTIFIER_TYPE.key,
+                "one,http://www.geoserver.org/one;two,http://www.geoserver.org/two,http://metadata.geoserver.org/id?two");
+        getGeoServer().save(serviceInfo);
+        final Document dom = getAsDOM(WCS_2_0_0_GETCAPREQUEST + "&LANGUAGE=unsupported");
+
+        final Element suppLangs =
+                (Element)
+                        dom.getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguages").item(0);
+
+        NodeList nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "DefaultLanguage");
+        assertEquals("Number of DefaultLanguage elements", 1, nodeList.getLength());
+        nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguage");
+        assertEquals("Number of Supported Languages", 2, nodeList.getLength());
+
+        final String responseLanguage =
+                dom.getElementsByTagNameNS(COMMON_NAMESPACE, "ResponseLanguage")
+                        .item(0)
+                        .getFirstChild()
+                        .getFirstChild()
+                        .getNodeValue();
+        assertEquals("Unsupported LANGUAGE returns the Default one", "fre", responseLanguage);
+    }
 }

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wfs/WFSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wfs/WFSExtendedCapabilitiesTest.java
@@ -423,4 +423,49 @@ public class WFSExtendedCapabilitiesTest extends GeoServerSystemTestSupport {
         nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguage");
         assertEquals("Number of Supported Languages", 2, nodeList.getLength());
     }
+
+    @Test
+    public void testUnSupportedLanguages() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WFSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        metadata.put(OTHER_LANGUAGES.key, "ita,eng");
+        metadata.put(
+                SPATIAL_DATASET_IDENTIFIER_TYPE.key,
+                "one,http://www.geoserver.org/one;two,http://www.geoserver.org/two,http://metadata.geoserver.org/id?two");
+        getGeoServer().save(serviceInfo);
+
+        final Document dom = getAsDOM(WFS_1_1_0_GETCAPREQUEST + "&LANGUAGE=unsupported");
+
+        NodeList nodeList = dom.getElementsByTagNameNS(DLS_NAMESPACE, "ExtendedCapabilities");
+        assertEquals("Number of INSPIRE ExtendedCapabilities elements", 1, nodeList.getLength());
+
+        String schemaLocation = dom.getDocumentElement().getAttribute("xsi:schemaLocation");
+        assertSchemaLocationContains(schemaLocation, DLS_NAMESPACE, DLS_SCHEMA);
+
+        final Element extendedCaps = (Element) nodeList.item(0);
+
+        final Element suppLangs =
+                (Element)
+                        extendedCaps
+                                .getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguages")
+                                .item(0);
+
+        nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "DefaultLanguage");
+        assertEquals("Number of DefaultLanguage elements", 1, nodeList.getLength());
+        nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguage");
+        assertEquals("Number of Supported Languages", 2, nodeList.getLength());
+
+        final String responseLanguage =
+                dom.getElementsByTagNameNS(COMMON_NAMESPACE, "ResponseLanguage")
+                        .item(0)
+                        .getFirstChild()
+                        .getFirstChild()
+                        .getNodeValue();
+        assertEquals("Unsupported LANGUAGE returns the Default one", "fre", responseLanguage);
+    }
 }

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
@@ -272,6 +272,27 @@ public class WMSExtendedCapabilitiesTest extends ServicesTestSupport {
         assertNull(supportedLanguage);
     }
 
+    @Test
+    public void testUnSupportedLanguages() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        GrowableInternationalString title = new GrowableInternationalString();
+        title.add(Locale.ITALIAN, "italian title");
+        serviceInfo.setInternationalTitle(title);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        metadata.put(OTHER_LANGUAGES.key, "ita,eng");
+        getGeoServer().save(serviceInfo);
+        final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST + "&LANGUAGE=unsupported");
+
+        final String responseLanguage =
+                dom.getElementsByTagNameNS(COMMON_NAMESPACE, "ResponseLanguage").item(0).getFirstChild().getNextSibling().getFirstChild().getNodeValue();
+        assertEquals("Unsupported LANGUAGE returns the Default one", "fre", responseLanguage);
+    }
+
     private boolean isLangNode(Node el) {
         return el != null && el.getLocalName() != null && el.getLocalName().equals("Language");
     }

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
@@ -5,6 +5,7 @@
  */
 package org.geoserver.inspire.wms;
 
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.geoserver.inspire.InspireMetadata.CREATE_EXTENDED_CAPABILITIES;
 import static org.geoserver.inspire.InspireMetadata.LANGUAGE;
 import static org.geoserver.inspire.InspireMetadata.OTHER_LANGUAGES;
@@ -279,6 +280,8 @@ public class WMSExtendedCapabilitiesTest extends ServicesTestSupport {
         clearInspireMetadata(metadata);
         GrowableInternationalString title = new GrowableInternationalString();
         title.add(Locale.ITALIAN, "italian title");
+        title.add(Locale.FRENCH, "french title");
+        serviceInfo.setDefaultLocale(Locale.FRENCH);
         serviceInfo.setInternationalTitle(title);
         metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
         metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
@@ -296,6 +299,15 @@ public class WMSExtendedCapabilitiesTest extends ServicesTestSupport {
                         .getFirstChild()
                         .getNodeValue();
         assertEquals("Unsupported LANGUAGE returns the Default one", "fre", responseLanguage);
+
+        // title checks for configured i18n title with unsupported language and with default
+
+        // Define the XPath expression
+        String xPathExpression =
+                "//*[local-name()='WMS_Capabilities']/*[local-name()='Service']/*[local-name()='Title']";
+
+        // Assert the value of the Title element
+        assertXpathEvaluatesTo("french title", xPathExpression, dom);
     }
 
     private boolean isLangNode(Node el) {

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wms/WMSExtendedCapabilitiesTest.java
@@ -289,7 +289,12 @@ public class WMSExtendedCapabilitiesTest extends ServicesTestSupport {
         final Document dom = getAsDOM(WMS_1_3_0_GETCAPREQUEST + "&LANGUAGE=unsupported");
 
         final String responseLanguage =
-                dom.getElementsByTagNameNS(COMMON_NAMESPACE, "ResponseLanguage").item(0).getFirstChild().getNextSibling().getFirstChild().getNodeValue();
+                dom.getElementsByTagNameNS(COMMON_NAMESPACE, "ResponseLanguage")
+                        .item(0)
+                        .getFirstChild()
+                        .getNextSibling()
+                        .getFirstChild()
+                        .getNodeValue();
         assertEquals("Unsupported LANGUAGE returns the Default one", "fre", responseLanguage);
     }
 

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/WMTSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/WMTSExtendedCapabilitiesTest.java
@@ -94,4 +94,35 @@ public class WMTSExtendedCapabilitiesTest extends ServicesTestSupport {
         nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguage");
         assertEquals("Number of Supported Languages", 2, nodeList.getLength());
     }
+
+    @Test
+    public void testUnSupportedLanguages() throws Exception {
+        final ServiceInfo serviceInfo = getGeoServer().getService(WMTSInfo.class);
+        final MetadataMap metadata = serviceInfo.getMetadata();
+        clearInspireMetadata(metadata);
+        metadata.put(CREATE_EXTENDED_CAPABILITIES.key, true);
+        metadata.put(SERVICE_METADATA_URL.key, "http://foo.com?bar=baz");
+        metadata.put(SERVICE_METADATA_TYPE.key, "application/vnd.iso.19139+xml");
+        metadata.put(LANGUAGE.key, "fre");
+        metadata.put(OTHER_LANGUAGES.key, "ita,eng");
+        getGeoServer().save(serviceInfo);
+        final Document dom = getAsDOM(WMTS_1_0_0_GETCAPREQUEST + "&LANGUAGE=unsupported");
+        NodeList nodeList = dom.getElementsByTagNameNS(VS_VS_OWS_NAMESPACE, "ExtendedCapabilities");
+        final Element extendedCaps = (Element) nodeList.item(0);
+
+        final Element suppLangs =
+                (Element)
+                        extendedCaps
+                                .getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguages")
+                                .item(0);
+
+        nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "DefaultLanguage");
+        assertEquals("Number of DefaultLanguage elements", 1, nodeList.getLength());
+        nodeList = suppLangs.getElementsByTagNameNS(COMMON_NAMESPACE, "SupportedLanguage");
+        assertEquals("Number of Supported Languages", 2, nodeList.getLength());
+
+        final String responseLanguage =
+                dom.getElementsByTagNameNS(COMMON_NAMESPACE, "ResponseLanguage").item(0).getFirstChild().getNextSibling().getFirstChild().getNodeValue();
+        assertEquals("Unsupported LANGUAGE returns the Default one", "fre", responseLanguage);
+    }
 }

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/WMTSExtendedCapabilitiesTest.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/wmts/WMTSExtendedCapabilitiesTest.java
@@ -122,7 +122,12 @@ public class WMTSExtendedCapabilitiesTest extends ServicesTestSupport {
         assertEquals("Number of Supported Languages", 2, nodeList.getLength());
 
         final String responseLanguage =
-                dom.getElementsByTagNameNS(COMMON_NAMESPACE, "ResponseLanguage").item(0).getFirstChild().getNextSibling().getFirstChild().getNodeValue();
+                dom.getElementsByTagNameNS(COMMON_NAMESPACE, "ResponseLanguage")
+                        .item(0)
+                        .getFirstChild()
+                        .getNextSibling()
+                        .getFirstChild()
+                        .getNodeValue();
         assertEquals("Unsupported LANGUAGE returns the Default one", "fre", responseLanguage);
     }
 }

--- a/src/main/src/main/java/org/geoserver/data/InternationalContentHelper.java
+++ b/src/main/src/main/java/org/geoserver/data/InternationalContentHelper.java
@@ -379,7 +379,7 @@ public class InternationalContentHelper {
                                 .map(l -> l.toLanguageTag())
                                 .collect(Collectors.joining(","));
                 for (Locale locale : requestedLocales) {
-                    if (supportedLocales.contains(locale)) return;
+                    if (locale.toString().isEmpty() || supportedLocales.contains(locale)) return;
                 }
                 throw new UnsupportedOperationException(
                         "Content has been requested in one of the following languages: "

--- a/src/main/src/main/java/org/geoserver/data/InternationalContentHelper.java
+++ b/src/main/src/main/java/org/geoserver/data/InternationalContentHelper.java
@@ -42,7 +42,7 @@ public class InternationalContentHelper {
 
     private Set<Locale> requestedLocales = new LinkedHashSet<>();
 
-    // field that map the AcceptLanguages value *
+    // field that maps the AcceptLanguages value *
     protected boolean anyMatch = false;
 
     // supported locales are those used at least in one field of
@@ -98,7 +98,7 @@ public class InternationalContentHelper {
         if (preferredLanguages != null && preferredLanguages.length > 0) {
             for (String language : preferredLanguages) {
                 Locale locale = null;
-                if (language.equals("*")) {
+                if (language.equals("*") || language.isEmpty()) {
                     this.anyMatch = true;
                     locale = Locale.getDefault();
                 } else if (language.contains("-")) locale = Locale.forLanguageTag(language);
@@ -218,9 +218,9 @@ public class InternationalContentHelper {
      * Get a String value according to the requestedLocales from the InternationalString passed as
      * an argument.
      *
-     * @param internationalString the internationalString from which retrieve the localized value.
-     * @param nullable if false when a localized value is not found for the requested locale a
-     *     message (DID NOT FIND i18n CONTENT FOR THIS ELEMENT) will be returned. Otherwise null
+     * @param internationalString the internationalString from which retrieve the localized value?
+     * @param nullable if false, when a localized value is not found for the requested locale a
+     *     message (DID NOT FIND i18n CONTENT FOR THIS ELEMENT) will be returned. Otherwise, null
      *     will be returned.
      * @return the localized value of the internationalString.
      */
@@ -230,7 +230,7 @@ public class InternationalContentHelper {
             GrowableInternationalString growable =
                     (GrowableInternationalString) internationalString;
             result = getFirstMatchingInternationalValue(growable, requestedLocales);
-            // if client specified * try with the supported locales
+            // if a client specified * try with the supported locales
             if (result == null && anyMatch) {
                 result = growable.toString(GeoServerDefaultLocale.get());
             }

--- a/src/main/src/main/java/org/geoserver/security/impl/DigestAuthUtils.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DigestAuthUtils.java
@@ -19,7 +19,7 @@ import org.springframework.util.StringUtils;
 /**
  * This is an exact copy of org.springframework.security.web.authentication.www.DigestAuthUtils;
  *
- * <p>The Spring class has package visibility, no idea why. The functionally is used for test cases
+ * <p>The Spring class has package visibility, no idea why. The functionality is used for test cases
  * and may be used by a client agent using the geoserver library
  *
  * @author mcr

--- a/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
+++ b/src/ows/src/main/java/org/geoserver/ows/util/RequestUtils.java
@@ -254,7 +254,10 @@ public class RequestUtils {
     public static String[] getLanguageValue(Map<String, Object> rawKvp, String languageParamName) {
         String[] result = null;
         if (rawKvp != null && rawKvp.containsKey(languageParamName)) {
-            String acceptLanguages = rawKvp.get(languageParamName).toString();
+            String acceptLanguages =
+                    rawKvp.get(languageParamName) != null
+                            ? rawKvp.get(languageParamName).toString()
+                            : "";
             if (acceptLanguages != null) {
                 String[] langAr = acceptLanguages.split(" ");
                 if (langAr.length == 1) {


### PR DESCRIPTION
[![GEOS-11446](https://badgen.net/badge/JIRA/GEOS-11446/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11446) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

References: https://osgeo-org.atlassian.net/browse/GEOS-11446

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->