### PR TITLE
Jwt-headers and tomcat

### DIFF
--- a/src/community/jwt-headers/gs-jwt-headers/src/assembly/assembly.xml
+++ b/src/community/jwt-headers/gs-jwt-headers/src/assembly/assembly.xml
@@ -1,5 +1,5 @@
 <assembly>
-    <id>jwt-headers-plugin</id>
+    <id>gs-jwt-headers</id>
     <formats>
         <format>zip</format>
     </formats>
@@ -9,7 +9,7 @@
       <directory>target</directory>
       <outputDirectory></outputDirectory>
       <includes>
-        <include>${artifactId}-${project.version}.jar</include>
+          <include>${artifactId}-${project.version}.jar</include>
       </includes>
     </fileSet>
         <fileSet>
@@ -20,6 +20,9 @@
                 <include>nimbus-jose-jwt-9.37.3*</include>
                 <include>json-path*</include>
                 <include>guava*</include>
+                <include>json-smart*.jar</include>
+                <include>accessors-smart-*.jar</include>
+                <include>asm-*.jar</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/src/community/jwt-headers/gs-jwt-headers/src/main/java/org/geoserver/security/jwtheaders/filter/GeoServerJwtHeadersFilter.java
+++ b/src/community/jwt-headers/gs-jwt-headers/src/main/java/org/geoserver/security/jwtheaders/filter/GeoServerJwtHeadersFilter.java
@@ -78,7 +78,7 @@ public class GeoServerJwtHeadersFilter extends GeoServerPreAuthenticatedUserName
 
         JwtHeadersWebAuthenticationDetails details =
                 (JwtHeadersWebAuthenticationDetails) existingAuth.getDetails();
-        return details.getJwtHeadersConfigId() == this.filterConfig.id;
+        return details.getJwtHeadersConfigId().equals(this.filterConfig.id);
     }
 
     /**
@@ -122,6 +122,9 @@ public class GeoServerJwtHeadersFilter extends GeoServerPreAuthenticatedUserName
 
             HttpServletRequest httpServletRequest = (HttpServletRequest) request;
             httpServletRequest.getSession(false).invalidate();
+            // we re-create the session now because this request might be a redirect, and
+            // tomcat does NOT like session creation during a redirect!
+            httpServletRequest.getSession(true);
         }
 
         if (principleHasChanged(existingAuth, principalName)) {
@@ -131,6 +134,9 @@ public class GeoServerJwtHeadersFilter extends GeoServerPreAuthenticatedUserName
 
             HttpServletRequest httpServletRequest = (HttpServletRequest) request;
             httpServletRequest.getSession(false).invalidate();
+            // we re-create the session now because this request might be a redirect, and
+            // tomcat does NOT like session creation during a redirect!
+            httpServletRequest.getSession(true);
         }
 
         if (request.getAttribute(UserName) == null) {


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

I ran JWT-Headers inside Tomcat and noticed a few minor problems.

1. The `assembly.xml` wasn't including the `json-smart` jar
2. I changed one of the comparisons from `==` to `.equals()`.  This didn't seem to be an issue in jetty, but was a problem in tomcat.
3. Session handling in tomcat and jetty are a bit different.  I noticed a case where there was an authorization change (i.e. adding or removing the jwt headers between requests).  This would trigger  a wicket redirect (i.e. from `/geoserver/` to `/geoserver/web` or something like `/geoserver/web/?4` to `geoserver/web/?0`).  This was fine in Jetty.  However, in tomcat, doing a session creation during a redirect isn't allowed.
   The basic order of events is:
    a. There is a jwt header auth change (either adding or removing the jwt from the headers)
    b. `Jwt-header` notices this and invalidates the session
    c. wicket does a redirect
    d. `GeoServerSecurityContextPersistenceFilter` attempts to save the context in the session
    e. a session is created 
    f. jetty is fine with this.  However, tomcat doesn't allow any content in the response after a redirect.  Tomcat considers the session creation to be "content". It throws an exception.
    SOLUTION - after invalidating the session (i.e. deleting it), immediately create a new one.  This happens before the redirect, so tomcat is happy with it.


<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [n/a] New unit tests have been added covering the changes.
- [n/a] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [n/a] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->