### PR TITLE
allow getting user name from either user-info or from the id_token

### DIFF
--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/OpenIdConnectFilterConfig.java
@@ -37,6 +37,8 @@ public class OpenIdConnectFilterConfig extends GeoServerOAuth2FilterConfig {
     boolean usePKCE = false;
     boolean enforceTokenValidation = true;
 
+    boolean injectIDTokenPayloadIntoUserInfo = false;
+
     /** Supports extraction of roles among the token claims */
     public static enum OpenIdRoleSource implements RoleSource {
         IdToken,
@@ -151,6 +153,14 @@ public class OpenIdConnectFilterConfig extends GeoServerOAuth2FilterConfig {
 
     public void setEnforceTokenValidation(boolean enforceTokenValidation) {
         this.enforceTokenValidation = enforceTokenValidation;
+    }
+
+    public boolean isInjectIDTokenPayloadIntoUserInfo() {
+        return injectIDTokenPayloadIntoUserInfo;
+    }
+
+    public void setInjectIDTokenPayloadIntoUserInfo(boolean injectIDTokenPayloadIntoUserInfo) {
+        this.injectIDTokenPayloadIntoUserInfo = injectIDTokenPayloadIntoUserInfo;
     }
 
     @Override

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/oauth2oidc/GeoServerAuthenticationProcessingFilter.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/oauth2oidc/GeoServerAuthenticationProcessingFilter.java
@@ -1,0 +1,106 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.oauth2oidc;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+import org.springframework.security.oauth2.client.filter.OAuth2ClientAuthenticationProcessingFilter;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetailsSource;
+import org.springframework.security.oauth2.provider.token.RemoteTokenServices;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+
+/**
+ * This is basically the parent class (OAuth2ClientAuthenticationProcessingFilter), but with a minor
+ * difference: It sends the full access token (including the embedded id_token + refresh token
+ * etc...) to a non-standard (GeoServerTokenServices) tokenServices. This token service has
+ * #loadAuthentication(accessToken) where accessToken is the full access token (with id_token).
+ * Normally, it will call #loadAuthentication(String accessToken) where the access token is just the
+ * (typically) base64 encoded JWT (note - it doesnt have to be a JWT - it can be anything).
+ *
+ * <p>cf GeoserverTokenServices
+ */
+public class GeoServerAuthenticationProcessingFilter
+        extends OAuth2ClientAuthenticationProcessingFilter {
+
+    public OAuth2RestOperations restTemplate;
+    public OAuth2AuthenticationDetailsSource _authenticationDetailsSource;
+    private ResourceServerTokenServices tokenServices;
+
+    public GeoServerAuthenticationProcessingFilter(
+            String defaultFilterProcessesUrl,
+            OAuth2RestOperations oauth2RestTemplate,
+            RemoteTokenServices tokenServices) {
+        super(defaultFilterProcessesUrl);
+        setRestTemplate(oauth2RestTemplate);
+        setTokenServices(tokenServices);
+        _authenticationDetailsSource = new OAuth2AuthenticationDetailsSource();
+    }
+
+    /**
+     * A rest template to be used to obtain an access token.
+     *
+     * @param restTemplate a rest template
+     */
+    public void setRestTemplate(OAuth2RestOperations restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Reference to a CheckTokenServices that can validate an OAuth2AccessToken
+     *
+     * @param tokenServices
+     */
+    public void setTokenServices(ResourceServerTokenServices tokenServices) {
+        this.tokenServices = tokenServices;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(
+            HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException, IOException, ServletException {
+        OAuth2AccessToken accessToken;
+        try {
+            accessToken = restTemplate.getAccessToken();
+        } catch (OAuth2Exception e) {
+            BadCredentialsException bad =
+                    new BadCredentialsException("Could not obtain access token", e);
+            throw bad;
+        }
+        try {
+            OAuth2Authentication result;
+            // BAD - we have 2 different implementations and are handling the difference here.
+            //      REASON - want to have access to the "full" access token (i.e. with the id_token
+            // embedded)
+            if (tokenServices instanceof GeoServerTokenServices) {
+                result = ((GeoServerTokenServices) tokenServices).loadAuthentication(accessToken);
+            } else {
+                result = tokenServices.loadAuthentication(accessToken.getValue());
+            }
+            if (_authenticationDetailsSource != null) {
+                request.setAttribute(
+                        OAuth2AuthenticationDetails.ACCESS_TOKEN_VALUE, accessToken.getValue());
+                request.setAttribute(
+                        OAuth2AuthenticationDetails.ACCESS_TOKEN_TYPE, accessToken.getTokenType());
+                result.setDetails(_authenticationDetailsSource.buildDetails(request));
+            }
+            return result;
+        } catch (InvalidTokenException e) {
+            BadCredentialsException bad =
+                    new BadCredentialsException("Could not obtain user details from token", e);
+            throw bad;
+        }
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/oauth2oidc/GeoServerTokenServices.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/oauth2oidc/GeoServerTokenServices.java
@@ -1,0 +1,69 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.oauth2oidc;
+
+import com.nimbusds.jose.JWSObject;
+import java.text.ParseException;
+import java.util.Map;
+import org.geoserver.security.oauth2.OpenIdConnectFilterConfig;
+import org.geoserver.security.oauth2.services.OpenIdConnectTokenServices;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+/**
+ * This is the same as OpenIdConnectTokenServices, except it adds
+ * #loadAuthentication(OAuth2AccessToken accessToken). This is used by the
+ * GeoserverAuthenticationProcessingFilter.
+ *
+ * <p>The difference is: OpenIdConnectTokenServices: User information (i.e. username) is taken from
+ * the user-info (token validation) endpoint. GeoServerTokenServices: We combine the information in
+ * the id_token with the user-info.
+ *
+ * <p>This is done because some systems have a `usable` username in the ID token and NOT in the
+ * user-info.
+ */
+public class GeoServerTokenServices extends OpenIdConnectTokenServices {
+
+    public GeoServerTokenServices() {}
+
+    public OAuth2Authentication loadAuthentication(OAuth2AccessToken accessToken)
+            throws AuthenticationException, InvalidTokenException {
+        Map<String, Object> checkTokenResponse = checkToken(accessToken.getValue());
+
+        verifyTokenResponse(accessToken.getValue(), checkTokenResponse);
+
+        transformNonStandardValuesToStandardValues(checkTokenResponse);
+
+        injectIDTokenClaims(checkTokenResponse, accessToken);
+
+        return tokenConverter.extractAuthentication(checkTokenResponse);
+    }
+
+    private void injectIDTokenClaims(
+            Map<String, Object> checkTokenResponse, OAuth2AccessToken accessToken) {
+        if (!accessToken.getAdditionalInformation().containsKey("id_token")
+                || (accessToken.getAdditionalInformation().get("id_token") == null)) {
+            return;
+        }
+        var idTokenEncoded = (String) accessToken.getAdditionalInformation().get("id_token");
+        try {
+            var payload = JWSObject.parse(idTokenEncoded).getPayload().toJSONObject();
+            for (var item : payload.entrySet()) {
+                if (checkTokenResponse.containsKey(item.getKey())) continue;
+                checkTokenResponse.put(item.getKey(), item.getValue());
+            }
+        } catch (ParseException e) {
+            e.printStackTrace();
+            return;
+        }
+        return;
+    }
+
+    public void setConfiguration(OpenIdConnectFilterConfig config) {
+        super.setConfiguration(config);
+    }
+}

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/resources/applicationContext.xml
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/resources/applicationContext.xml
@@ -23,10 +23,10 @@
 		<constructor-arg index="1" value="GeoServer Security OpenId Connect Core" />
 	</bean>
 
-	<!-- OAuth2 Security Extension -->
+	<!-- this has the extended functionality that can (if configured) get user id from user-info endpoint or the id token-->
 	<bean id="openIdConnectTokenServices"
-		class="org.geoserver.security.oauth2.services.OpenIdConnectTokenServices">
-	</bean>
+			class="org.geoserver.security.oauth2.oauth2oidc.GeoServerTokenServices">
+    </bean>
 
 	<bean id="openIdConnectBearerTokenValidator" class="org.geoserver.security.oauth2.bearer.MultiTokenValidator">
 		<constructor-arg>


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

DO NOT MERGE - EXPERIMENT  

An issue was reported when using AD FS - the user-info (check token) endpoint didnt have the username in it.  However, the username is available in the id_token (but not in the access token).

The SSO process goes as follows:
1. get the CODE from the remote IDP
2. GS hands in the CODE to get an AccessToken, ID Token (and a refresh token) + some other info like expiry.
3. The AccessToken is used to go to the user-info (check token) endpoint, which returns a json map.
4. The user id is extracted from the user-info json map
5. Much later, the roles are extracted (according to your configuration: this can come from several different places)


This is an experiment - manually edit your oauth2-openid-connect configuration in your data directory.  Add:

```
  <injectIDTokenPayloadIntoUserInfo>true</injectIDTokenPayloadIntoUserInfo>
```

Restart geoserver.  This will merge the user-info endpoint claims with the id_token claims.  The user name is then taken from this combined `Map`.


----
This is a much bigger hack than I wanted - this is because of the spring OAUTH2/OIDC library has a lot marked `private` and doesn't allow any dependency inject.  This makes normal subclassing difficult.
----
 

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->