### PR TITLE
[Backport 2.25.x] [GEOS-10690] Taskmanager community module: fix assembly

### DIFF
--- a/src/community/taskmanager/core/src/assembly/assembly.xml
+++ b/src/community/taskmanager/core/src/assembly/assembly.xml
@@ -24,6 +24,12 @@
         <include>*quartz*.jar</include>
         <include>*postgis*.jar</include>
         <include>h2-*.jar</include>
+        <include>antlr-*.jar</include>
+        <include>classmate-*.jar</include>
+        <include>dom4j-*.jar</include>
+        <include>jboss-logging-*.jar</include>
+        <include>jboss-transaction-*.jar</include>
+        <include>spring-orm-*.jar</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
[![GEOS-10690](https://badgen.net/badge/JIRA/GEOS-10690/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10690) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7761
 **Authored by:** @NielsCharlier