### PR TITLE
[GEOS-11443] REST API does not take effect immediately due to 10 minute authentication cache

### DIFF
--- a/doc/en/api/1.0.0/reload.yaml
+++ b/doc/en/api/1.0.0/reload.yaml
@@ -25,8 +25,8 @@ paths:
       operationId: putReset
       tags:
        - "Reload"
-      summary: Reset all store, raster, and schema caches. 
-      description: Resets all store, raster, and schema caches. This operation is used to force GeoServer to drop all caches and store connections and reconnect to each of them the next time they are needed by a request. This is useful in case the stores themselves cache some information about the data structures they manage that may have changed in the meantime.
+      summary: Reset all authentication, store, raster, and schema caches. 
+      description: Resets all authentication, store, raster, and schema caches. This operation is used to force GeoServer to drop all caches and store connections and reconnect to each of them the next time they are needed by a request. This is useful in case the stores themselves cache some information about the data structures they manage that may have changed in the meantime.
       responses:
         200:
           description: OK
@@ -34,8 +34,8 @@ paths:
       operationId: postReset
       tags:
        - "Reload"
-      summary: Reset all store, raster, and schema caches. 
-      description: Resets all store, raster, and schema caches. This operation is used to force GeoServer to drop all caches and store connections and reconnect to each of them the next time they are needed by a request. This is useful in case the stores themselves cache some information about the data structures they manage that may have changed in the meantime.
+      summary: Reset all authentication, store, raster, and schema caches. 
+      description: Resets all authentication, store, raster, and schema caches. This operation is used to force GeoServer to drop all caches and store connections and reconnect to each of them the next time they are needed by a request. This is useful in case the stores themselves cache some information about the data structures they manage that may have changed in the meantime.
       responses:
         200:
           description: OK

--- a/doc/en/user/source/rest/api/reset.rst
+++ b/doc/en/user/source/rest/api/reset.rst
@@ -3,7 +3,7 @@
 Resource reset 
 ==============
 
-Resets all store, raster, and schema caches. This operation is used to force GeoServer to drop all caches and store connections and reconnect to each of them the next time they are needed by a request. This is useful in case the stores themselves cache some information about the data structures they manage that may have changed in the meantime.
+Resets all authentication, store, raster, and schema caches. This operation is used to force GeoServer to drop all caches and store connections and reconnect to each of them the next time they are needed by a request. This is useful in case the stores themselves cache some information about the data structures they manage that may have changed in the meantime.
 
 ``/reset``
 ----------
@@ -22,12 +22,12 @@ Resets all store, raster, and schema caches. This operation is used to force Geo
      - 
      - 
    * - POST
-     - Reset all store, raster, and schema caches
+     - Reset all authentication, store, raster, and schema caches
      - 200
      - 
      - 
    * - PUT
-     - Reset all store, raster, and schema caches
+     - Reset all authentication, store, raster, and schema caches
      - 200
      - 
      - 

--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -358,4 +358,8 @@
   <bean id="xmlViewParamsFormatParser" class="org.geoserver.ows.kvp.XMLViewParamsFormatParser">
   </bean>
 
+  <bean id="authCacheLifecycleHandler" class="org.geoserver.security.auth.GuavaAuthenticationCacheImpl">
+    <constructor-arg value="1000"/>
+  </bean>
+
 </beans>

--- a/src/main/src/main/java/applicationSecurityContext.xml
+++ b/src/main/src/main/java/applicationSecurityContext.xml
@@ -183,6 +183,4 @@
     <constructor-arg ref="dataDirectory"/>
   </bean>
 
-  <bean id="AuthenticationCacheImpl" class="org.geoserver.security.auth.AuthenticationCacheImpl" primary="true"/>
-
 </beans>

--- a/src/main/src/main/java/applicationSecurityContext.xml
+++ b/src/main/src/main/java/applicationSecurityContext.xml
@@ -183,6 +183,6 @@
     <constructor-arg ref="dataDirectory"/>
   </bean>
 
-  <bean id="AuthenticationCacheImpl" class="org.geoserver.security.auth.AuthenticationCacheImpl" />
+  <bean id="AuthenticationCacheImpl" class="org.geoserver.security.auth.AuthenticationCacheImpl" primary="true"/>
 
 </beans>

--- a/src/main/src/main/java/applicationSecurityContext.xml
+++ b/src/main/src/main/java/applicationSecurityContext.xml
@@ -182,4 +182,7 @@
   <bean id="styleUrlChecker" class="org.geoserver.security.urlchecks.StyleURLChecker">
     <constructor-arg ref="dataDirectory"/>
   </bean>
+
+  <bean id="AuthenticationCacheImpl" class="org.geoserver.security.auth.AuthenticationCacheImpl" />
+
 </beans>

--- a/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
+++ b/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
@@ -693,6 +693,17 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         return authCache;
     }
 
+    /**
+     * Used to supply an authentication cache (for testing) in GeoServerSystemTestSupport
+     *
+     * @param authCache
+     */
+    public void setAuthenticationCache(AuthenticationCache authCache) {
+        synchronized (this) {
+            this.authCache = authCache;
+        }
+    }
+
     AuthenticationCache lookupAuthenticationCache() {
         AuthenticationCache authCache = GeoServerExtensions.bean(AuthenticationCache.class);
         return authCache != null ? authCache : new GuavaAuthenticationCacheImpl(1000);

--- a/src/main/src/main/java/org/geoserver/security/auth/AuthenticationCache.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/AuthenticationCache.java
@@ -46,4 +46,6 @@ public interface AuthenticationCache {
 
     /** timeToIdleSeconds and timeToLiveSeconds are derived from the cache global settings */
     public void put(String filterName, String cacheKey, Authentication auth);
+
+    void onReset();
 }

--- a/src/main/src/main/java/org/geoserver/security/auth/AuthenticationCache.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/AuthenticationCache.java
@@ -27,7 +27,7 @@ public interface AuthenticationCache {
     /** Clears all cache entries for filterName */
     public void removeAll(String filterName);
 
-    /** Clears a specific chache entry */
+    /** Clears a specific cache entry */
     public void remove(String filterName, String cacheKey);
 
     /** */

--- a/src/main/src/main/java/org/geoserver/security/auth/AuthenticationCacheImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/AuthenticationCacheImpl.java
@@ -38,4 +38,7 @@ public class AuthenticationCacheImpl implements AuthenticationCache {
 
     @Override
     public void put(String filterName, String cacheKey, Authentication auth) {}
+
+    @Override
+    public void onReset() {}
 }

--- a/src/main/src/main/java/org/geoserver/security/auth/GeoServerRootAuthenticationProvider.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/GeoServerRootAuthenticationProvider.java
@@ -51,8 +51,8 @@ public class GeoServerRootAuthenticationProvider extends GeoServerAuthentication
                 (UsernamePasswordAuthenticationToken) authentication;
 
         // check if name is root
-        if (GeoServerUser.ROOT_USERNAME.equals(SecurityUtils.getUsername(token.getPrincipal()))
-                == false) return null;
+        if (!GeoServerUser.ROOT_USERNAME.equals(SecurityUtils.getUsername(token.getPrincipal())))
+            return null;
 
         // check password
         if (token.getCredentials() != null) {

--- a/src/main/src/main/java/org/geoserver/security/auth/GuavaAuthenticationCacheImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/GuavaAuthenticationCacheImpl.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geoserver.config.impl.GeoServerLifecycleHandler;
 import org.geotools.util.logging.Logging;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
@@ -26,7 +27,8 @@ import org.springframework.security.core.Authentication;
  *
  * @author Mauro Bartolomeoli (mauro.bartolomeoli at geo-solutions.it)
  */
-public class GuavaAuthenticationCacheImpl implements AuthenticationCache, DisposableBean {
+public class GuavaAuthenticationCacheImpl
+        implements AuthenticationCache, GeoServerLifecycleHandler, DisposableBean {
 
     /** Default eviction interval (double of the idle time). */
     public static final int DEFAULT_CLEANUP_TIME = DEFAULT_IDLE_TIME * 2;
@@ -242,4 +244,18 @@ public class GuavaAuthenticationCacheImpl implements AuthenticationCache, Dispos
     public void destroy() {
         scheduler.shutdown();
     }
+
+    @Override
+    public void onReset() {
+        removeAll();
+    }
+
+    @Override
+    public void onDispose() {}
+
+    @Override
+    public void beforeReload() {}
+
+    @Override
+    public void onReload() {}
 }

--- a/src/main/src/main/java/org/geoserver/security/auth/LRUAuthenticationCacheImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/LRUAuthenticationCacheImpl.java
@@ -148,4 +148,9 @@ public class LRUAuthenticationCacheImpl implements AuthenticationCache {
     public void put(String filterName, String cacheKey, Authentication auth) {
         put(filterName, cacheKey, auth, timeToIdleSeconds, timeToLiveSeconds);
     }
+
+    @Override
+    public void onReset() {
+        removeAll();
+    }
 }

--- a/src/main/src/main/java/org/geoserver/security/auth/UsernamePasswordAuthenticationProvider.java
+++ b/src/main/src/main/java/org/geoserver/security/auth/UsernamePasswordAuthenticationProvider.java
@@ -95,7 +95,7 @@ public class UsernamePasswordAuthenticationProvider extends GeoServerAuthenticat
             ((GeoServerWebAuthenticationDetails) auth.getDetails())
                     .setUserGroupServiceName(userGroupServiceName);
         }
-        if (auth.getAuthorities().contains(GeoServerRole.AUTHENTICATED_ROLE) == false) {
+        if (!auth.getAuthorities().contains(GeoServerRole.AUTHENTICATED_ROLE)) {
             List<GrantedAuthority> roles = new ArrayList<>();
             roles.addAll(auth.getAuthorities());
             roles.add(GeoServerRole.AUTHENTICATED_ROLE);

--- a/src/main/src/test/java/org/geoserver/security/auth/AbstractAuthenticationProviderTest.java
+++ b/src/main/src/test/java/org/geoserver/security/auth/AbstractAuthenticationProviderTest.java
@@ -71,12 +71,6 @@ public abstract class AbstractAuthenticationProviderTest extends AbstractSecurit
     @Override
     protected void setUpSpring(List<String> springContextLocations) {
         super.setUpSpring(springContextLocations);
-        springContextLocations.add(
-                AbstractAuthenticationProviderTest.class
-                        .getResource(
-                                AbstractAuthenticationProviderTest.class.getSimpleName()
-                                        + "-context.xml")
-                        .toString());
     }
 
     protected TestingAuthenticationCache getCache() {

--- a/src/main/src/test/java/org/geoserver/security/auth/TestingAuthenticationCache.java
+++ b/src/main/src/test/java/org/geoserver/security/auth/TestingAuthenticationCache.java
@@ -118,4 +118,9 @@ public class TestingAuthenticationCache implements AuthenticationCache {
             throw new RuntimeException(ex);
         }
     }
+
+    @Override
+    public void onReset() {
+        removeAll();
+    }
 }

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -114,6 +114,7 @@ import org.geoserver.security.GeoServerRoleStore;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.GeoServerUserGroupService;
 import org.geoserver.security.GeoServerUserGroupStore;
+import org.geoserver.security.auth.TestingAuthenticationCache;
 import org.geoserver.security.impl.DataAccessRule;
 import org.geoserver.security.impl.DataAccessRuleDAO;
 import org.geoserver.security.impl.GeoServerRole;
@@ -343,6 +344,7 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
             // Allow resolution of XSDs from local file system
             EntityResolverProvider.setEntityResolver(RESOLVE_DISABLED_PROVIDER_DEVMODE);
 
+            getSecurityManager().setAuthenticationCache(new TestingAuthenticationCache());
             onSetUp(testData);
         }
     }

--- a/src/restconfig/src/main/java/org/geoserver/rest/CatalogReloadController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/CatalogReloadController.java
@@ -5,11 +5,13 @@
 package org.geoserver.rest;
 
 import org.geoserver.config.GeoServer;
+import org.geoserver.platform.GeoServerExtensions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.geoserver.security.GeoServerSecurityManager;
 
 /** Catalog reload controller */
 @RestController
@@ -33,5 +35,6 @@ public class CatalogReloadController extends AbstractGeoServerController {
             method = {RequestMethod.POST, RequestMethod.PUT})
     public void reset() {
         geoServer.reset();
+        GeoServerExtensions.bean(GeoServerSecurityManager.class).getAuthenticationCache().removeAll();
     }
 }

--- a/src/restconfig/src/main/java/org/geoserver/rest/CatalogReloadController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/CatalogReloadController.java
@@ -5,8 +5,6 @@
 package org.geoserver.rest;
 
 import org.geoserver.config.GeoServer;
-import org.geoserver.platform.GeoServerExtensions;
-import org.geoserver.security.GeoServerSecurityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,8 +33,5 @@ public class CatalogReloadController extends AbstractGeoServerController {
             method = {RequestMethod.POST, RequestMethod.PUT})
     public void reset() {
         geoServer.reset();
-        GeoServerExtensions.bean(GeoServerSecurityManager.class)
-                .getAuthenticationCache()
-                .removeAll();
     }
 }

--- a/src/restconfig/src/main/java/org/geoserver/rest/CatalogReloadController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/CatalogReloadController.java
@@ -6,12 +6,12 @@ package org.geoserver.rest;
 
 import org.geoserver.config.GeoServer;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.GeoServerSecurityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import org.geoserver.security.GeoServerSecurityManager;
 
 /** Catalog reload controller */
 @RestController
@@ -35,6 +35,8 @@ public class CatalogReloadController extends AbstractGeoServerController {
             method = {RequestMethod.POST, RequestMethod.PUT})
     public void reset() {
         geoServer.reset();
-        GeoServerExtensions.bean(GeoServerSecurityManager.class).getAuthenticationCache().removeAll();
+        GeoServerExtensions.bean(GeoServerSecurityManager.class)
+                .getAuthenticationCache()
+                .removeAll();
     }
 }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/auth/AbstractAuthenticationProviderTest-context.xml
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/auth/AbstractAuthenticationProviderTest-context.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
-<beans>
-  <bean id="testAuthCache" class="org.geoserver.security.auth.TestingAuthenticationCache">
-  </bean>
-</beans>


### PR DESCRIPTION
[![GEOS-11443](https://badgen.net/badge/JIRA/GEOS-11443/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11443) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

From my experience with the GeoServer REST API, e.g. adding a user to a group [GeoServer API Docs](https://docs.geoserver.org/stable/en/api/#1.0.0/usergroup.yaml) , the change happens and is written to disk immediately, however there is a 10 minute authentication cache that prevents the change from being **effective** immediately.

If I am impatient, I typically reload the configuration or use the AuthKey synchronise button to clear the 10 min auth cache. I am aware of the reload API endpoint [GeoServer API Docs](https://docs.geoserver.org/stable/en/api/#1.0.0/reload.yaml)  but that is a bit drastic.  
The reset endpoint does not appear to clear the auth cache.  This now fixes that.

A better solution than my previous attempt: https://github.com/geoserver/geoserver/pull/7746

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->