### PR TITLE
[Backport 2.24.x] [GEOS-11464] Update Jackson 2 libs from 2.17.1 to 2.17.2

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -137,7 +137,7 @@
     <git.commit.runOnlyOnce>true</git.commit.runOnlyOnce>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>
     <jackson1.version>1.9.13</jackson1.version>
-    <jackson2.version>2.17.1</jackson2.version>
+    <jackson2.version>2.17.2</jackson2.version>
     <jackson2.databind.version>${jackson2.version}</jackson2.databind.version>
     <compress-lzf.version>1.0.3</compress-lzf.version>
     <marlin.version>0.9.3</marlin.version>


### PR DESCRIPTION
[![GEOS-11464](https://badgen.net/badge/JIRA/GEOS-11464/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11464) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7767
 **Authored by:** @mprins