### PR TITLE
[Backport 2.25.x] [GEOS-11464] Update Jackson 2 libs from 2.17.1 to 2.17.2

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -137,7 +137,7 @@
     <git.commit.runOnlyOnce>true</git.commit.runOnlyOnce>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>
     <jackson1.version>1.9.13</jackson1.version>
-    <jackson2.version>2.17.1</jackson2.version>
+    <jackson2.version>2.17.2</jackson2.version>
     <jackson2.databind.version>${jackson2.version}</jackson2.databind.version>
     <compress-lzf.version>1.0.3</compress-lzf.version>
     <marlin.version>0.9.3</marlin.version>


### PR DESCRIPTION
Backport #7767
 **Authored by:** @mprins