### PR TITLE
[GEOS-11271] Upgrade spring-security to 5.8

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/RESTfulDefinitionSourceDelegateMap.java
+++ b/src/main/src/main/java/org/geoserver/security/RESTfulDefinitionSourceDelegateMap.java
@@ -15,18 +15,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geotools.util.logging.Logging;
 import org.springframework.security.access.ConfigAttribute;
-import org.springframework.security.web.FilterInvocation;
-import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
 import org.springframework.util.StringUtils;
 
 /** @author Chris Berry http://opensource.atlassian.com/projects/spring/browse/SEC-531 */
-public class RESTfulPathBasedFilterInvocationDefinitionMap
-        implements FilterInvocationSecurityMetadataSource {
+public class RESTfulDefinitionSourceDelegateMap {
 
-    private static Logger log =
-            Logging.getLogger(RESTfulPathBasedFilterInvocationDefinitionMap.class);
+    private static Logger log = Logging.getLogger(RESTfulDefinitionSourceDelegateMap.class);
 
     // ~ Instance fields
     // ================================================================================================
@@ -34,13 +30,6 @@ public class RESTfulPathBasedFilterInvocationDefinitionMap
     private Collection<EntryHolder> requestMap = new ArrayList<>();
     private PathMatcher pathMatcher = new AntPathMatcher();
     private boolean convertUrlToLowercaseBeforeComparison = false;
-
-    // ~ Methods
-    // ========================================================================================================
-    @Override
-    public boolean supports(Class<?> clazz) {
-        return FilterInvocation.class.isAssignableFrom(clazz);
-    }
 
     public void addSecureUrl(
             String antPath, String[] httpMethods, Collection<ConfigAttribute> attrs) {
@@ -57,12 +46,6 @@ public class RESTfulPathBasedFilterInvocationDefinitionMap
         }
     }
 
-    public void addSecureUrl(String antPath, Collection<ConfigAttribute> attrs) {
-        throw new IllegalArgumentException(
-                "addSecureUrl(String, Collection<ConfigAttribute> ) is INVALID for RESTfulDefinitionSource");
-    }
-
-    @Override
     public Collection<ConfigAttribute> getAllConfigAttributes() {
         Set<ConfigAttribute> set = new HashSet<>();
 
@@ -74,10 +57,6 @@ public class RESTfulPathBasedFilterInvocationDefinitionMap
         // return set.iterator();
     }
 
-    public int getMapSize() {
-        return this.requestMap.size();
-    }
-
     public boolean isConvertUrlToLowercaseBeforeComparison() {
         return convertUrlToLowercaseBeforeComparison;
     }
@@ -85,24 +64,6 @@ public class RESTfulPathBasedFilterInvocationDefinitionMap
     public void setConvertUrlToLowercaseBeforeComparison(
             boolean convertUrlToLowercaseBeforeComparison) {
         this.convertUrlToLowercaseBeforeComparison = convertUrlToLowercaseBeforeComparison;
-    }
-
-    @Override
-    public Collection<ConfigAttribute> getAttributes(Object object)
-            throws IllegalArgumentException {
-        if ((object == null) || !this.supports(object.getClass())) {
-            throw new IllegalArgumentException("Object must be a FilterInvocation");
-        }
-
-        String url = ((FilterInvocation) object).getRequestUrl();
-        String method = ((FilterInvocation) object).getHttpRequest().getMethod();
-
-        return this.lookupAttributes(url, method);
-    }
-
-    public Collection<ConfigAttribute> lookupAttributes(String url) {
-        throw new IllegalArgumentException(
-                "lookupAttributes(String url) is INVALID for RESTfulDefinitionSource");
     }
 
     public Collection<ConfigAttribute> lookupAttributes(String url, String httpMethod) {
@@ -127,9 +88,9 @@ public class RESTfulPathBasedFilterInvocationDefinitionMap
             }
         }
 
-        Iterator iter = requestMap.iterator();
+        Iterator<EntryHolder> iter = requestMap.iterator();
         while (iter.hasNext()) {
-            EntryHolder entryHolder = (EntryHolder) iter.next();
+            EntryHolder entryHolder = iter.next();
 
             String antPath = entryHolder.getAntPath();
             String[] methodList = entryHolder.getHttpMethodList();

--- a/src/main/src/main/java/org/geoserver/security/filter/GeoServerSecurityContextPersistenceFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/filter/GeoServerSecurityContextPersistenceFilter.java
@@ -7,6 +7,7 @@
 package org.geoserver.security.filter;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -67,8 +68,9 @@ public class GeoServerSecurityContextPersistenceFilter extends GeoServerComposit
                         }
                         request.setAttribute(FILTER_APPLIED, Boolean.TRUE);
                         try {
-                            SecurityContext securityContext = repo.loadContext(request).get();
-                            SecurityContextHolder.setContext(securityContext);
+                            Supplier<SecurityContext> securityContext =
+                                    repo.loadDeferredContext(request);
+                            SecurityContextHolder.setDeferredContext(securityContext);
                             chain.doFilter(request, response);
                         } finally {
                             SecurityContext contextAfterChainExecution =

--- a/src/main/src/main/java/org/geoserver/security/filter/GeoServerSecurityInterceptorFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/filter/GeoServerSecurityInterceptorFilter.java
@@ -6,54 +6,225 @@
 
 package org.geoserver.security.filter;
 
+import static org.geoserver.platform.GeoServerExtensions.bean;
+
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import org.geoserver.platform.GeoServerExtensions;
+import java.util.Collection;
+import java.util.function.Supplier;
+import javax.servlet.http.HttpServletRequest;
 import org.geoserver.security.config.SecurityInterceptorFilterConfig;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
-import org.springframework.security.access.AccessDecisionVoter;
-import org.springframework.security.access.vote.AffirmativeBased;
-import org.springframework.security.access.vote.AuthenticatedVoter;
-import org.springframework.security.access.vote.RoleVoter;
-import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
-import org.springframework.security.web.access.intercept.FilterSecurityInterceptor;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.SecurityMetadataSource;
+import org.springframework.security.authentication.AuthenticationTrustResolver;
+import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 
 /**
  * Security interceptor filter
  *
  * @author mcr
+ * @author awaterme
  */
 public class GeoServerSecurityInterceptorFilter extends GeoServerCompositeFilter {
+
+    private static final AuthorizationDecision ACCESS_GRANTED = new AuthorizationDecision(true);
+    private static final AuthorizationDecision ACCESS_DENIED = new AuthorizationDecision(false);
+    private static final AuthorizationDecision ACCESS_ABSTAIN = null;
+
+    /**
+     * AuthorizationManager implementation considers the authentication requirements of the
+     * respective request, in contrast to Spring's AuthenticatedAuthorizationManager, which is setup
+     * for one authentication requirement explicitly.<br>
+     * Based on org.springframework.security.access.vote.AuthenticatedVoter, which is deprecated
+     * with Spring Security 5.8.
+     */
+    private static final class AuthenticatedAuthorizationManager
+            implements AuthorizationManager<HttpServletRequest> {
+
+        public static final String IS_AUTHENTICATED_FULLY = "IS_AUTHENTICATED_FULLY";
+
+        public static final String IS_AUTHENTICATED_REMEMBERED = "IS_AUTHENTICATED_REMEMBERED";
+
+        public static final String IS_AUTHENTICATED_ANONYMOUSLY = "IS_AUTHENTICATED_ANONYMOUSLY";
+
+        private SecurityMetadataSource metadata;
+
+        private AuthenticationTrustResolver authenticationTrustResolver =
+                new AuthenticationTrustResolverImpl();
+
+        /** @param metadata */
+        public AuthenticatedAuthorizationManager(SecurityMetadataSource metadata) {
+            super();
+            this.metadata = metadata;
+        }
+
+        private boolean isFullyAuthenticated(Authentication authentication) {
+            return (!this.authenticationTrustResolver.isAnonymous(authentication)
+                    && !this.authenticationTrustResolver.isRememberMe(authentication));
+        }
+
+        private boolean supports(ConfigAttribute attribute) {
+            return (attribute.getAttribute() != null)
+                    && (IS_AUTHENTICATED_FULLY.equals(attribute.getAttribute())
+                            || IS_AUTHENTICATED_REMEMBERED.equals(attribute.getAttribute())
+                            || IS_AUTHENTICATED_ANONYMOUSLY.equals(attribute.getAttribute()));
+        }
+
+        private AuthorizationDecision vote(
+                Authentication authentication,
+                Object object,
+                Collection<ConfigAttribute> attributes) {
+            AuthorizationDecision result = ACCESS_ABSTAIN;
+            for (ConfigAttribute attribute : attributes) {
+                if (this.supports(attribute)) {
+                    result = ACCESS_DENIED;
+                    if (IS_AUTHENTICATED_FULLY.equals(attribute.getAttribute())) {
+                        if (isFullyAuthenticated(authentication)) {
+                            return ACCESS_GRANTED;
+                        }
+                    }
+                    if (IS_AUTHENTICATED_REMEMBERED.equals(attribute.getAttribute())) {
+                        if (this.authenticationTrustResolver.isRememberMe(authentication)
+                                || isFullyAuthenticated(authentication)) {
+                            return ACCESS_GRANTED;
+                        }
+                    }
+                    if (IS_AUTHENTICATED_ANONYMOUSLY.equals(attribute.getAttribute())) {
+                        if (this.authenticationTrustResolver.isAnonymous(authentication)
+                                || isFullyAuthenticated(authentication)
+                                || this.authenticationTrustResolver.isRememberMe(authentication)) {
+                            return ACCESS_GRANTED;
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public AuthorizationDecision check(
+                Supplier<Authentication> authentication, HttpServletRequest request) {
+            Collection<ConfigAttribute> attributes = metadata.getAttributes(request);
+            AuthorizationDecision vote = vote(authentication.get(), request, attributes);
+            return vote;
+        }
+    }
+
+    /**
+     * {@link AuthorizationManager} implementation considers the role requirements of the respective
+     * request, in contrast to Spring's AuthorityAuthorizationManager which is setup for certain
+     * roles explicitly. <br>
+     * Based on org.springframework.security.access.vote.RoleVoter, which is deprecated with Spring
+     * Security 5.8.
+     */
+    private static final class RoleAuthorizationManager
+            implements AuthorizationManager<HttpServletRequest> {
+
+        private SecurityMetadataSource metadata;
+
+        /** @param metadata */
+        public RoleAuthorizationManager(SecurityMetadataSource metadata) {
+            super();
+            this.metadata = metadata;
+        }
+
+        private AuthorizationDecision vote(
+                Authentication authentication,
+                Object object,
+                Collection<ConfigAttribute> attributes) {
+            if (authentication == null) {
+                return ACCESS_DENIED;
+            }
+            AuthorizationDecision result = ACCESS_ABSTAIN;
+            Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+            for (ConfigAttribute attribute : attributes) {
+                if (attribute.getAttribute() != null) {
+                    result = ACCESS_DENIED;
+                    // Attempt to find a matching granted authority
+                    for (GrantedAuthority authority : authorities) {
+                        if (attribute.getAttribute().equals(authority.getAuthority())) {
+                            return ACCESS_GRANTED;
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public AuthorizationDecision check(
+                Supplier<Authentication> authentication, HttpServletRequest request) {
+            Collection<ConfigAttribute> attributes = metadata.getAttributes(request);
+            AuthorizationDecision vote = vote(authentication.get(), request, attributes);
+            return vote;
+        }
+    }
+
+    /**
+     * Compound {@link AuthorizationManager} implementation forwards the check to delegates. <br>
+     * Based on org.springframework.security.access.vote.AffirmativeBased, which is deprecated with
+     * Spring Security 5.8.
+     */
+    private static final class AffirmativeAuthorizationManager
+            implements AuthorizationManager<HttpServletRequest> {
+
+        private AuthorizationManager<HttpServletRequest> delegate1;
+        private AuthorizationManager<HttpServletRequest> delegate2;
+        private boolean allowIfAllAbstainDecisions;
+
+        /**
+         * @param delegate1
+         * @param delegate2
+         * @param allowIfAllAbstainDecisions
+         */
+        public AffirmativeAuthorizationManager(
+                AuthorizationManager<HttpServletRequest> delegate1,
+                AuthorizationManager<HttpServletRequest> delegate2,
+                boolean allowIfAllAbstainDecisions) {
+            super();
+            this.delegate1 = delegate1;
+            this.delegate2 = delegate2;
+            this.allowIfAllAbstainDecisions = allowIfAllAbstainDecisions;
+        }
+
+        @Override
+        public AuthorizationDecision check(
+                Supplier<Authentication> authentication, HttpServletRequest object) {
+            AuthorizationDecision d1 = delegate1.check(authentication, object);
+            AuthorizationDecision d2 = delegate2.check(authentication, object);
+            if (d1 == null && d2 == null) {
+                return allowIfAllAbstainDecisions ? ACCESS_GRANTED : ACCESS_DENIED;
+            }
+            if (d1 != null && d1.isGranted()) {
+                return ACCESS_GRANTED;
+            }
+            if (d2 != null && d2.isGranted()) {
+                return ACCESS_GRANTED;
+            }
+            return ACCESS_DENIED;
+        }
+    }
+
     @Override
     public void initializeFromConfig(SecurityNamedServiceConfig config) throws IOException {
         super.initializeFromConfig(config);
 
         SecurityInterceptorFilterConfig siConfig = (SecurityInterceptorFilterConfig) config;
+        boolean allowIfAllAbstainDecisions = siConfig.isAllowIfAllAbstainDecisions();
+        String sourceName = siConfig.getSecurityMetadataSource();
+        SecurityMetadataSource source = (SecurityMetadataSource) bean(sourceName);
 
-        FilterSecurityInterceptor filter = new FilterSecurityInterceptor();
+        AuthenticatedAuthorizationManager aam = new AuthenticatedAuthorizationManager(source);
+        RoleAuthorizationManager ram = new RoleAuthorizationManager(source);
+        AffirmativeAuthorizationManager am =
+                new AffirmativeAuthorizationManager(aam, ram, allowIfAllAbstainDecisions);
+        AuthorizationFilter filter = new AuthorizationFilter(am);
 
-        filter.setAuthenticationManager(getSecurityManager().authenticationManager());
-
-        List<AccessDecisionVoter<?>> voters = new ArrayList<>();
-        RoleVoter roleVoter = new RoleVoter();
-        roleVoter.setRolePrefix("");
-        voters.add(roleVoter);
-        voters.add(new AuthenticatedVoter());
-        AffirmativeBased accessDecisionManager = new AffirmativeBased(voters);
-        accessDecisionManager.setAllowIfAllAbstainDecisions(
-                siConfig.isAllowIfAllAbstainDecisions());
-        filter.setAccessDecisionManager(accessDecisionManager);
-
-        // TODO, Justin, is this correct
-        filter.setSecurityMetadataSource(
-                (FilterInvocationSecurityMetadataSource)
-                        GeoServerExtensions.bean(siConfig.getSecurityMetadataSource()));
-        try {
-            filter.afterPropertiesSet();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
         getNestedFilters().add(filter);
     }
 }

--- a/src/main/src/main/java/org/geoserver/security/filter/GeoServerSecurityMetadataSource.java
+++ b/src/main/src/main/java/org/geoserver/security/filter/GeoServerSecurityMetadataSource.java
@@ -8,25 +8,33 @@ package org.geoserver.security.filter;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 import org.geoserver.security.GeoServerSecurityFilterChain;
 import org.geoserver.security.impl.GeoServerRole;
+import org.geotools.util.logging.Logging;
+import org.springframework.core.log.LogMessage;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.access.SecurityConfig;
-import org.springframework.security.web.access.intercept.DefaultFilterInvocationSecurityMetadataSource;
+import org.springframework.security.access.SecurityMetadataSource;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
- * Justin, nasty hack to get rid of the spring bean "filterSecurityInterceptor"; I think, there is a
- * better was to solve this.
+ * {@link SecurityMetadataSource} implementation for GeoServer web UI, provides {@link
+ * ConfigAttribute}s with authentication and authorization constraints for evaluation through {@link
+ * GeoServerSecurityInterceptorFilter}.
  *
  * @author mcr
  */
-public class GeoServerSecurityMetadataSource extends DefaultFilterInvocationSecurityMetadataSource {
+public class GeoServerSecurityMetadataSource implements SecurityMetadataSource {
 
     /**
      * Should match
@@ -51,48 +59,83 @@ public class GeoServerSecurityMetadataSource extends DefaultFilterInvocationSecu
                     webChainMatcher1.matches(request) || webChainMatcher2.matches(request);
             if (isOnWebChain == false) return false;
 
-            Map params = request.getParameterMap();
+            Map<String, String[]> params = request.getParameterMap();
             if (params.size() != 2) return false;
 
-            String[] pageClass = (String[]) params.get("wicket:bookmarkablePage");
+            String[] pageClass = params.get("wicket:bookmarkablePage");
             if (pageClass == null || pageClass.length != 1) return false;
 
             if (":org.geoserver.web.GeoServerLoginPage".equals(pageClass[0]) == false) return false;
 
-            String[] error = (String[]) params.get("error");
+            String[] error = params.get("error");
             if (error == null || error.length != 1) return false;
 
             return true;
         }
     };
 
-    static LinkedHashMap<RequestMatcher, Collection<ConfigAttribute>> requestMap;
+    static final Map<RequestMatcher, Collection<ConfigAttribute>> requestMap;
 
     static {
-        requestMap = new LinkedHashMap<>();
+        LinkedHashMap<RequestMatcher, Collection<ConfigAttribute>> map = new LinkedHashMap<>();
 
         // the login page is a public resource
-        requestMap.put(new LoginPageRequestMatcher(), new ArrayList<>());
+        map.put(new LoginPageRequestMatcher(), new ArrayList<>());
         // images,java script,... are public resources
-        requestMap.put(new AntPathRequestMatcher("/web/resources/**"), new ArrayList<>());
+        map.put(new AntPathRequestMatcher("/web/resources/**"), new ArrayList<>());
 
         RequestMatcher matcher = new AntPathRequestMatcher("/config/**");
         List<ConfigAttribute> list = new ArrayList<>();
         list.add(new SecurityConfig(GeoServerRole.ADMIN_ROLE.getAuthority()));
-        requestMap.put(matcher, list);
+        map.put(matcher, list);
 
         matcher = new AntPathRequestMatcher("/**");
         list = new ArrayList<>();
         list.add(new SecurityConfig("IS_AUTHENTICATED_ANONYMOUSLY"));
-        requestMap.put(matcher, list);
+        map.put(matcher, list);
+
+        requestMap = Collections.unmodifiableMap(map);
     };
 
-    public GeoServerSecurityMetadataSource() {
-        super(requestMap);
-        /*
-        <sec:intercept-url pattern="/config/**" access="ROLE_ADMINISTRATOR"/>
-        <sec:intercept-url pattern="/**" access="IS_AUTHENTICATED_ANONYMOUSLY"/>
-        */
+    private Logger logger = Logging.getLogger(GeoServerSecurityMetadataSource.class);
 
+    public GeoServerSecurityMetadataSource() {
+        super();
+    }
+
+    @Override
+    public Collection<ConfigAttribute> getAllConfigAttributes() {
+        Set<ConfigAttribute> allAttributes = new HashSet<>();
+        requestMap.values().forEach(allAttributes::addAll);
+        return allAttributes;
+    }
+
+    @Override
+    public Collection<ConfigAttribute> getAttributes(Object object) {
+        final HttpServletRequest request = (HttpServletRequest) object;
+        int count = 0;
+        for (Map.Entry<RequestMatcher, Collection<ConfigAttribute>> entry : requestMap.entrySet()) {
+            if (entry.getKey().matches(request)) {
+                return entry.getValue();
+            } else {
+                if (this.logger.isLoggable(Level.FINEST)) {
+                    String msg =
+                            LogMessage.format(
+                                            "Did not match request to %s - %s (%d/%d)",
+                                            entry.getKey(),
+                                            entry.getValue(),
+                                            ++count,
+                                            requestMap.size())
+                                    .toString();
+                    this.logger.finest(msg);
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return HttpServletRequest.class.isAssignableFrom(clazz);
     }
 }

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -92,8 +92,8 @@
     <gt.version>32-SNAPSHOT</gt.version>
     <gwc.version>1.26-SNAPSHOT</gwc.version>
     <jts.version>1.19.0</jts.version>
-    <spring.version>5.3.34</spring.version>
-    <spring.security.version>5.7.12</spring.security.version>
+    <spring.version>5.3.37</spring.version>
+    <spring.security.version>5.8.13</spring.security.version>
     <spring-integration.version>5.5.18</spring-integration.version>
     <spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
     <servlet-api.version>3.1.0</servlet-api.version>


### PR DESCRIPTION
[![GEOS-11271](https://badgen.net/badge/JIRA/GEOS-11271/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11271) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Pull request for [GEOS-11271](https://osgeo-org.atlassian.net/browse/GEOS-11271)

Upgrades Spring Security 5.7.12 -> 5.8.13 (latest 5.8.x) and Spring 5.3.34 -> 5.3.37

**Spring Upgrade**
Spring-Security 5.8.13 depends on Spring 5.3.37, so I decided to upgrade Spring, too. The Spring upgrade is  comprising compatible release only, as per [Spring release notes](https://github.com/spring-projects/spring-framework/releases).

**Spring Security Upgrade**
The Spring Security upgrade is the preparation for the switch from deprecated [spring-security-oauth](https://spring.io/projects/spring-security-oauth) project (now https://github.com/spring-attic/spring-security-oauth) to the OAuth funtionality of spring security itself.

**Spring Security Upgrade - Compatibility**
According to the [Spring website](https://docs.spring.io/spring-security/reference/5.8/migration/index.html) "Spring Security 5.8 is fully compatible with Spring Security 5.7".

Checking the [Spring Security release notes](https://github.com/spring-projects/spring-security) I found the following breaking changes, which are not relevant for GeoServer, as far as I can see:

- https://github.com/spring-projects/spring-security/releases/tag/5.8.0-M1
   - SecurityExpressionHandler#createEvaluationContext should defer lookup of Authentication #9667
      - Result: OK, GeoServer is not using SecurityExpressionRoot

- https://github.com/spring-projects/spring-security/releases/tag/5.8.0-RC1
   - Make X-Xss-Protection header value configurable in ServerHttpSecurity #11908
      - Result: Ok, ServerHttpSecurity seems not to be used in GS

**Spring Security Upgrade - Testing Status**
Unit Tests
- "green"

Manual Tests:
- GeoServer application is basically running
- Form-based login is possible
- Basic Auth login is possible, checking WFS GetFeature
- OAuth2 Login with Github is working as before


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).