### PR TITLE
[typo] correct spelling of unknown in empty shapefile response

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/response/ShapeZipOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/response/ShapeZipOutputFormat.java
@@ -315,7 +315,7 @@ public class ShapeZipOutputFormat extends WFSGetFeatureOutputFormat
     private void createEmptyZipWarning(File tempDir) throws IOException {
         try (PrintWriter pw = new PrintWriter(new File(tempDir, "README.TXT"))) {
             pw.print(
-                    "The query result is empty, and the geometric type of the features is unknwon:"
+                    "The query result is empty, and the geometric type of the features is unknown:"
                             + "an empty point shapefile has been created to fill the zip file");
         }
     }


### PR DESCRIPTION
This PR fixes a typo in the zipped text file that is returned in lieu of a shapefile when a WFS query yields no results:
'unknwon' corrected to 'unknown'.

Rationale: Spelling was incorrect and this text is intended for human consumption.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [n/a ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

I have run:
`mvn clean install -Dqa`
There were 4 unrelated PMD violations:
```
[INFO] Open Web Service Module ............................ SUCCESS [ 41.925 s]
<?xml version="1.0" encoding="UTF-8"?>
<pmd xmlns="http://pmd.sourceforge.net/report/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd" version="6.42.0" timestamp="2024-07-23T10:45:43.273">
<file name="[snipped]/geoserverfixes/src/rest/src/test/java/org/geoserver/rest/util/IOUtilsTest.java">
<violation beginline="76" endline="80" begincolumn="5" endcolumn="5" rule="JUnit4TestShouldUseBeforeAnnotation" ruleset="Best Practices" package="org.geoserver.rest.util" class="IOUtilsTest" externalInfoUrl="https://pmd.github.io/pmd-6.42.0/pmd_rules_java_bestpractices.html#junit4testshouldusebeforeannotation" priority="3">
JUnit 4 tests that set up tests should use the @Before annotation, JUnit5 tests should use @BeforeEach or @BeforeAll
</violation>
<violation beginline="82" endline="86" begincolumn="5" endcolumn="5" rule="JUnit4TestShouldUseAfterAnnotation" ruleset="Best Practices" package="org.geoserver.rest.util" class="IOUtilsTest" externalInfoUrl="https://pmd.github.io/pmd-6.42.0/pmd_rules_java_bestpractices.html#junit4testshoulduseafterannotation" priority="3">
JUnit 4 tests that clean up tests should use the @After annotation, JUnit5 tests should use @AfterEach or @AfterAll
</violation>
<violation beginline="122" endline="122" begincolumn="9" endcolumn="75" rule="SimplifiableTestAssertion" ruleset="Best Practices" package="org.geoserver.rest.util" class="IOUtilsTest" method="testUpload" externalInfoUrl="https://pmd.github.io/pmd-6.42.0/pmd_rules_java_bestpractices.html#simplifiabletestassertion" priority="3">
Assertion may be simplified using assertSame
</violation>
<violation beginline="131" endline="131" begincolumn="9" endcolumn="76" rule="SimplifiableTestAssertion" ruleset="Best Practices" package="org.geoserver.rest.util" class="IOUtilsTest" method="testUpload" externalInfoUrl="https://pmd.github.io/pmd-6.42.0/pmd_rules_java_bestpractices.html#simplifiabletestassertion" priority="3">
Assertion may be simplified using assertSame
</violation>
</file>
</pmd>
```




For core and extension modules:
- [n/a] New unit tests have been added covering the changes.
- [n/a] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [n/a] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [n/a] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [n/a, no ticket] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).