### PR TITLE
Bump mapfish print 2.3.0 -> 2.3.1

### DIFF
--- a/doc/en/user/source/extensions/printing/protocol.rst
+++ b/doc/en/user/source/extensions/printing/protocol.rst
@@ -255,7 +255,8 @@ Render vector layers. The geometries and the styling comes directly from the spe
 * geoJson (Required) the geoJson to render
 * styleProperty (Defaults to '_style') Name of the property within the features to use as style name. The given property may contain a style object directly.
 * styles (Optional) dictionary of styles. One style is defined as in OpenLayers.Feature.Vector.style.
-* name (Defaults to ``vector``) the layer name.
+* name (Defaults to ``vector``) the layer name. (deprecated: use pdfLayerName instead)
+* pdfLayerName (Defaults to ``vector``) PDF layer name.
 
 WMS
 ---
@@ -271,6 +272,7 @@ Support for the WMS protocol with possibilities to go through a WMS-C service (T
 * format (Required)
 * version (Defaults to ``1.1.1``)
 * useNativeAngle (Defaults to false) it true transform the map angle to customParams.angle for GeoServer, and customParams.map_angle for MapServer.
+* pdfLayerName (Defaults to stringify layers field comma separated) PDF layer name.
 
 WMTS
 ----
@@ -305,6 +307,7 @@ Standard mode:
     }, ...]
 
 * format (Optional, Required id requestEncoding is ``KVP``)
+* pdfLayerName (Defaults to layer field) PDF layer name.
 
 Simple mode:
 
@@ -338,6 +341,7 @@ Support the TMS tile layout.
 * layer (Required)
 * resolutions (Required) Array of resolutions
 * tileOrigin (Optional) Object, tile origin.  Defaults to ``0,0``
+* pdfLayerName (Defaults to layer field) PDF layer name.
 
 Resources:
 
@@ -360,6 +364,7 @@ Support the tile layout z/x/y.<extension>.
 * tileOrigin (Optional) Array, tile origin e.g. ``[420000, 350000]``
 * tileOriginCorner ``tl`` or ``bl`` (Defaults to ``bl``)
 * path_format (Optional) url fragment used to construct the tile location. Can support variable replacement of ``${x}``, ``${y}``, ``${z}`` and ``${extension}``. Defaults to zz/x/y.extension format.  You can use multiple "letters" to indicate a replaceable pattern (aka, ``${zzzz}`` will ensure the z variable is 0 padded to have a length of AT LEAST 4 characters).
+* pdfLayerName (Defaults to "t") PDF layer name.
 
 Osm
 ---
@@ -374,6 +379,7 @@ Support the OSM tile layout.
 * tileSize (Required) Array, tile size e.g. ``[256, 256]``
 * resolutions (Required) Array of resolutions
 * extension (Required) file extension
+* pdfLayerName (Defaults to "t") PDF layer name.
 
 TileCache
 ---------
@@ -389,6 +395,7 @@ Support for the protocol using directly the content of a TileCache directory.
 * tileSize (Required) Array, tile size e.g. ``[256, 256]``
 * resolutions (Required) Array of resolutions
 * extension (Required) file extension
+* pdfLayerName (Defaults to layer field) PDF layer name.
 
 Image
 -----
@@ -398,6 +405,7 @@ Type: image
 * name (Required)
 * baseURL (Required) Service URL
 * extent (Required)
+* pdfLayerName (Defaults to name field) PDF layer name.
 
 MapServer
 ---------
@@ -410,6 +418,7 @@ Support mapserver WMS server.
 * customParams (Optional) Map, additional URL arguments
 * layers (Required)
 * format (Required)
+* pdfLayerName (Defaults to stringify layers field comma separated) PDF layer name.
 
 KaMap
 -----
@@ -426,6 +435,7 @@ Support for the protocol using the KaMap tiling method
 * tileSize (Required) Array, tile size e.g. ``[256, 256]``
 * resolutions (Required) Array of resolutions
 * extension (Required) file extension
+* pdfLayerName (Defaults to map field) PDF layer name.
 
 KaMapCache
 ----------
@@ -445,6 +455,7 @@ Support for the protocol talking directly to a web-accessible ka-Map cache gener
 * tileSize (Required) Array, tile size e.g. ``[256, 256]``
 * resolutions (Required) Array of resolutions
 * extension (Required) file extension
+* pdfLayerName (Defaults to map field) PDF layer name.
 
 Google
 ------
@@ -465,6 +476,7 @@ The google map reader has several custom parameters that can be added to the req
 * maptype (Required) - type of map to display: http://code.google.com/apis/maps/documentation/staticmaps/#MapTypes
 * sensor  (Optional) - specifies whether the application requesting the static map is using a sensor to determine the user's location
 * language (Optional) - language of labels.
+* pdfLayerName (Defaults to "t") PDF layer name.
 * markers (Optional) - add markers to the map: http://code.google.com/apis/maps/documentation/staticmaps/#Markers
 
 .. code-block:: javascript

--- a/src/extension/printing/src/test/resources/test.yaml
+++ b/src/extension/printing/src/test/resources/test.yaml
@@ -139,8 +139,6 @@ layouts:
                 backgroundColor: #A0A0A0
               cell: !text
                 align: center
-                maxWidth: 15
-                maxHeight: 15
                 text: TEXT
         - !text
           font: Helvetica

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -124,7 +124,7 @@
     <interactive.image>false</interactive.image>
     <windows.leniency>true</windows.leniency>
     <gf.version>3.7-SNAPSHOT</gf.version>
-    <mf.version>2.3.0</mf.version>
+    <mf.version>2.3.1</mf.version>
     <jasypt.version>1.9.2</jasypt.version>
     <hibernate-version>3.6.9.Final</hibernate-version>
     <hibernate-generic-dao-version>1.1.0</hibernate-generic-dao-version>


### PR DESCRIPTION
Upgrading mapfish print version, which brings:
* Bump org.jyaml.jyaml 1.3 to com.fasterxml.jackson.dataformat.jackson-dataformat-yaml 2.16.1
--> https://github.com/mapfish/mapfish-print-v2/pull/23
--> bump to jackson 2.17.2
--> removed jyaml dependency, so the vulnerabilty disappeared
* Support custom pdf layer name (sent in request JSON parameter "pdfLayerName")
--> https://github.com/mapfish/mapfish-print-v2/pull/22
--> bump to geotools 31.1

The changes were tested against geoserver 2.25.2.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [X] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).