### PR TITLE
Update Logging Statement for WMS Store Deletion

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMSStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMSStoreController.java
@@ -203,7 +203,7 @@ public class WMSStoreController extends AbstractCatalogController {
         }
         clear(cs);
 
-        LOGGER.info("DELETE wms store '" + storeName + "' from workspace '" + workspaceName +"'");
+        LOGGER.info("DELETE wms store '" + storeName + "' from workspace '" + workspaceName + "'");
     }
 
     void clear(WMSStoreInfo info) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMSStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMSStoreController.java
@@ -203,7 +203,7 @@ public class WMSStoreController extends AbstractCatalogController {
         }
         clear(cs);
 
-        LOGGER.info("DELETE wms store " + workspaceName + "," + storeName);
+        LOGGER.info("DELETE wms store '" + storeName + "' from workspace '" + workspaceName +"'");
     }
 
     void clear(WMSStoreInfo info) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMSStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMSStoreController.java
@@ -203,7 +203,7 @@ public class WMSStoreController extends AbstractCatalogController {
         }
         clear(cs);
 
-        LOGGER.info("DELETE wms store " + workspaceName + ":s" + workspaceName);
+        LOGGER.info("DELETE wms store " + workspaceName + "," + storeName);
     }
 
     void clear(WMSStoreInfo info) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMTSStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMTSStoreController.java
@@ -207,7 +207,7 @@ public class WMTSStoreController extends AbstractCatalogController {
         }
         clear(cs);
 
-        LOGGER.info("DELETE wmts store " + workspaceName + "," + storeName);
+        LOGGER.info("DELETE wmts store '" + storeName + "' from workspace '" + workspaceName +"'");
     }
 
     void clear(WMTSStoreInfo info) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMTSStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMTSStoreController.java
@@ -207,7 +207,7 @@ public class WMTSStoreController extends AbstractCatalogController {
         }
         clear(cs);
 
-        LOGGER.info("DELETE wmts store " + workspaceName + ":s" + workspaceName);
+        LOGGER.info("DELETE wmts store " + workspaceName + "," + storeName);
     }
 
     void clear(WMTSStoreInfo info) {

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMTSStoreController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WMTSStoreController.java
@@ -207,7 +207,7 @@ public class WMTSStoreController extends AbstractCatalogController {
         }
         clear(cs);
 
-        LOGGER.info("DELETE wmts store '" + storeName + "' from workspace '" + workspaceName +"'");
+        LOGGER.info("DELETE wmts store '" + storeName + "' from workspace '" + workspaceName + "'");
     }
 
     void clear(WMTSStoreInfo info) {


### PR DESCRIPTION
# Description
This PR addresses an issue in the geoserver_WMSStoreController_wmsStoreDelete.java file where the logging statement in the wmsStoreDelete method redundantly concatenated the workspace name twice, leading to unclear and inconsistent log messages. The change improves the clarity and accuracy of the logging statement to better reflect the operation being performed.

## Reason for change
The previous logging statement did not accurately represent the action being logged, as it redundantly included the workspace name and omitted the store name. This inconsistency could lead to confusion when interpreting log messages. The updated statement enhances the readability and usefulness of the logs by clearly indicating the specific store being deleted.