### PR TITLE
[GEOS-11421] Match webui workspace admin functionality in the REST API

### DIFF
--- a/doc/en/user/data/webadmin/workspaces.md
+++ b/doc/en/user/data/webadmin/workspaces.md
@@ -136,7 +136,7 @@ If this information is not provided the global settings will be used. For detail
 
 ### Security {: #workspace_security }
 
-The Security tab allows to set data access rules at workspace level.
+The Security tab allows to set data access rules at workspace level, including admin access for [workspace administrators](../../security/workspaceadmin/index.md).
 
 !!! note
     For more information on data access rules, please see the section on [Data](../../security/webadmin/data.md).

--- a/doc/en/user/production/config.md
+++ b/doc/en/user/production/config.md
@@ -99,15 +99,17 @@ If you would like some users to be able to modify some but not all of your data,
 
 ## GeoServer Workspace Admin Guidance {: #production_config_workspace_admin }
 
-Establishing a workspace administrator user is a recommended configuration providing limited access to the Admin Console to manage the publication of information, but are not intended to be trusted as a GeoServer Administrator with responsibility for the global settings and system integration controls.
+Establishing a [workspace administrator](../security/workspaceadmin/index.md) user is a recommended configuration providing limited access to the Admin Console and REST API to manage the publication of information, but are not intended to be trusted as a GeoServer Administrator with responsibility for the global settings and system integration controls.
 
 1.  Create a role to be used for workspace administration.
 2.  Provide this role to the Users (or Groups) requiring workspace admin access.
 3.  Provide this role [data security](../security/webadmin/data.md) admin access `a` to:
     - [workspace](../data/webadmin/workspaces.md#workspace_security) administration
     - [layer](../data/webadmin/layers.md#layer_security) administration
-4.  Recommendation: The combination of workspace admin permission and GROUP_ADMIN access provides a effective combination for an individual responsible for a workspace. This provides the ability to both manage and control access to the data products in a workspace.
+4.  Recommendation: The combination of workspace admin permission and GROUP_ADMIN access provides an effective combination for an individual responsible for a workspace. This provides the ability to both manage and control access to the data products in a workspace.
 5.  Recommendation: Provide each workspace admin with [sandbox](../security/sandbox.md) restricting file system access for data storage.
+
+For a hands-on guide, see the [Workspace Administration tutorial](../security/tutorials/workspaceadmin/index.md).
 
 ## GeoServer Administrator Guidance {: #production_config_geoserver_admin }
 

--- a/doc/en/user/rest/api/services.md
+++ b/doc/en/user/rest/api/services.md
@@ -24,6 +24,12 @@ Controls Web Coverage Service settings for a given workspace.
 | PUT | Create or modify WCS settings for workspace `ws` | 200 | XML,JSON |  |
 | DELETE | Delete WCS settings for workspace `ws` | 200 |  |  |
 
+### Exceptions
+
+| Exception                                              | Status code |
+|--------------------------------------------------------|-------------|
+| GET, PUT or DELETE for a workspace that does not exist | 404         |
+
 ## `/services/wfs/settings[.<format>]`
 
 Controls Web Feature Service settings.
@@ -45,6 +51,12 @@ Controls Web Feature Service settings for a given workspace.
 | POST |  | 405 |  |  |
 | PUT | Modify WFS settings for workspace `ws` | 200 | XML,JSON |  |
 | DELETE | Delete WFS settings for workspace `ws` | 200 |  |  |
+
+### Exceptions
+
+| Exception                                              | Status code |
+|--------------------------------------------------------|-------------|
+| GET, PUT or DELETE for a workspace that does not exist | 404         |
 
 ## `/services/wms/settings[.<format>]`
 
@@ -68,6 +80,12 @@ Controls Web Map Service settings for a given workspace.
 | PUT | Modify WMS settings for workspace `ws` | 200 | XML,JSON |  |
 | DELETE | Delete WMS settings for workspace `ws` | 200 |  |  |
 
+### Exceptions
+
+| Exception                                              | Status code |
+|--------------------------------------------------------|-------------|
+| GET, PUT or DELETE for a workspace that does not exist | 404         |
+
 ## `/services/wmts/settings[.<format>]`
 
 Controls Web Map Tile Service settings.
@@ -89,6 +107,12 @@ Controls Web Map Tile Service settings for a given workspace.
 | POST |  | 405 |  |  |
 | PUT | Modify WMTS settings for workspace `ws` | 200 | XML,JSON |  |
 | DELETE | Delete WMTS settings for workspace `ws` | 200 |  |  |
+
+### Exceptions
+
+| Exception                                              | Status code |
+|--------------------------------------------------------|-------------|
+| GET, PUT or DELETE for a workspace that does not exist | 404         |
 
 <!-- admonition follows -->
 

--- a/doc/en/user/security/index.md
+++ b/doc/en/user/security/index.md
@@ -15,6 +15,7 @@ The first page discusses configuration options in the web administration interfa
 - [Layer security](layer.md)
 - [Filesystem sandboxing](sandbox.md)
 - [REST Security](rest.md)
+- [Workspace Administration](workspaceadmin/index.md)
 - [URL Checks](urlchecks.md)
 - [Content Security Policy](csp.md)
 - [Disabling security](disable.md)

--- a/doc/en/user/security/layer.md
+++ b/doc/en/user/security/layer.md
@@ -153,7 +153,7 @@ The mapping of roles to permissions is as follows:
 
 ### Providing restricted administrative access
 
-The following provides administrative access on a single workspace to a specific role, in additional to the full administrator role:
+The following provides [workspace administration](workspaceadmin/index.md) access on a single workspace to a specific role, in addition to the full administrator role:
 
     *.*.a=ROLE_ADMINISTRATOR
     topp.*.a=ROLE_TOPP_ADMIN,ROLE_ADMINISTRATOR

--- a/doc/en/user/security/rest.md
+++ b/doc/en/user/security/rest.md
@@ -4,6 +4,10 @@ In addition to providing the ability to secure OWS style services, GeoServer als
 
 As with layer and service security, RESTful security configuration is based on `security_roles`. The mapping of request URI to role is defined in a file named `rest.properties`, located in the `security` directory of the GeoServer data directory.
 
+!!! note
+
+    For information on workspace administrator access to the REST API, please see [Workspace Administration](workspaceadmin/index.md).
+
 ## Syntax
 
 The following syntax defines access control rules for RESTful services (parameters in brackets [] are optional):

--- a/doc/en/user/security/sandbox.md
+++ b/doc/en/user/security/sandbox.md
@@ -35,4 +35,4 @@ When the regular sandbox is set:
 - The GeoServer administrator will still be able to access the full file system, as well as change the sandbox configuration if they so desire.
 - The GeoServer workspace administrators will be sandboxed into `<sandbox>/<workspace>`, where `<workspace>` is the name of any workspace they can access.
 
-The regular sandbox is best suited in multi-tenant environments where the main GeoServer administrator also has access to the server operating system, while each tenant is modelled as a workspace administrator and should be able to manage its own data, but not access the data of other tenants.
+The regular sandbox is best suited in multi-tenant environments where the main GeoServer administrator also has access to the server operating system, while each tenant is modelled as a [workspace administrator](workspaceadmin/index.md) and should be able to manage its own data, but not access the data of other tenants.

--- a/doc/en/user/security/tutorials/index.md
+++ b/doc/en/user/security/tutorials/index.md
@@ -8,3 +8,4 @@
 - [HTTP header proxy authentication](httpheaderproxy/index.md)
 - [Credentials from headers](credentialsfromheaders/index.md)
 - [CAS authentication](cas/index.md)
+- [Workspace administration with the REST API](workspaceadmin/index.md)

--- a/doc/en/user/security/tutorials/workspaceadmin/index.md
+++ b/doc/en/user/security/tutorials/workspaceadmin/index.md
@@ -1,0 +1,251 @@
+# Tutorial: Workspace Administration with the REST API
+
+This tutorial walks through setting up a workspace administrator and exploring their REST API access using the default GeoServer data directory.
+
+It is recommended to read the [Workspace Administration](../../workspaceadmin/index.md) section before proceeding.
+
+## Prerequisites
+
+- A running GeoServer instance with the default sample data (including the `ne` workspace with Natural Earth layers)
+- `curl` or a similar HTTP client
+- Admin access to GeoServer (default: `admin` / `geoserver`)
+
+## Step 1: Create a role
+
+Log in as administrator and navigate to **Security > Users, Groups, and Roles**. Select the **Roles** tab and click **Add new role**.
+
+Create a role named `ROLE_NE_ADMIN`. This role will grant workspace administration privileges.
+
+## Step 2: Create a user
+
+Switch to the **Users/Groups** tab and click **Add new user**.
+
+- Username: `neadmin`
+- Password: `geo123`
+- Assign the `ROLE_NE_ADMIN` role
+
+## Step 3: Grant workspace admin access
+
+Navigate to **Security > Data** and click **Add a new rule**.
+
+- Workspace: `ne`
+- Layer: `*`
+- Access mode: `Admin`
+- Grant to: `ROLE_NE_ADMIN`
+
+This rule tells GeoServer that users with `ROLE_NE_ADMIN` are workspace administrators for the `ne` workspace. GeoServer will use this to restrict management access to only the `ne` workspace in both the web interface and the REST API.
+
+## Step 4: Log in as the workspace admin
+
+Log out and log back in as `neadmin`. The web interface shows a restricted view:
+
+- Only the `ne` workspace appears in workspace listings
+- Only layers, stores, and styles from the `ne` workspace are visible
+- Global configuration pages are not accessible
+
+## Step 5: Explore the REST API
+
+Open a terminal and use `curl` to explore the REST API as the workspace admin. Use the `Accept` header for content negotiation rather than file extensions.
+
+### REST API index
+
+Start by requesting the REST API root. The index only shows endpoints the workspace admin is allowed to access — notice that admin-only endpoints like `settings`, `security/roles`, and `about` are absent:
+
+    curl -u neadmin:geo123 "http://localhost:8080/geoserver/rest"
+
+```html
+<html>
+<head><title> GeoServer Configuration API </title></head>
+<body>
+<h2>GeoServer Configuration API</h2>
+<ul>
+<li><a href=".../rest/crs">crs</a></li>
+<li><a href=".../rest/fonts">fonts</a></li>
+<li><a href=".../rest/index">index</a></li>
+<li><a href=".../rest/layers">layers</a></li>
+<li><a href=".../rest/namespaces">namespaces</a></li>
+<li><a href=".../rest/resource">resource</a></li>
+<li><a href=".../rest/security/self/password">security/self/password</a></li>
+<li><a href=".../rest/services/wcs/settings">services/wcs/settings</a></li>
+<li><a href=".../rest/services/wfs/settings">services/wfs/settings</a></li>
+<li><a href=".../rest/services/wms/settings">services/wms/settings</a></li>
+<li><a href=".../rest/services/wmts/settings">services/wmts/settings</a></li>
+<li><a href=".../rest/styles">styles</a></li>
+<li><a href=".../rest/templates">templates</a></li>
+<li><a href=".../rest/workspaces">workspaces</a></li>
+</ul>
+</body>
+</html>
+```
+
+### List workspaces
+
+The workspace admin sees only the workspaces they can administer:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces"
+
+```json
+{
+  "workspaces": {
+    "workspace": [
+      {
+        "name": "ne",
+        "href": "http://localhost:8080/geoserver/rest/workspaces/ne.json"
+      }
+    ]
+  }
+}
+```
+
+Compare with the full administrator who sees all 8 workspaces:
+
+    curl -u admin:geoserver -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces"
+
+### View workspace details
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces/ne"
+
+```json
+{
+  "workspace": {
+    "name": "ne",
+    "isolated": false,
+    "dataStores": "http://localhost:8080/geoserver/rest/workspaces/ne/datastores.json",
+    "coverageStores": "http://localhost:8080/geoserver/rest/workspaces/ne/coveragestores.json",
+    "wmsStores": "http://localhost:8080/geoserver/rest/workspaces/ne/wmsstores.json",
+    "wmtsStores": "http://localhost:8080/geoserver/rest/workspaces/ne/wmtsstores.json"
+  }
+}
+```
+
+### Other workspaces are hidden
+
+Workspaces the user doesn't administer are not accessible — the server returns 404 as if they don't exist:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces/cite"
+
+```
+HTTP/1.1 404 Not Found
+```
+
+### List layers
+
+The global `/rest/layers` endpoint returns only layers from workspaces the user administers — even though it's the global endpoint, the response is filtered:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/layers"
+
+```json
+{
+  "layers": {
+    "layer": [
+      {"name": "ne:boundary_lines"},
+      {"name": "ne:coastlines"},
+      {"name": "ne:countries"},
+      {"name": "ne:disputed_areas"},
+      {"name": "ne:populated_places"}
+    ]
+  }
+}
+```
+
+Only `ne` layers are returned. A full administrator would see layers from all workspaces.
+
+Layers can also be listed through the workspace-specific endpoint:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces/ne/layers"
+
+### List styles
+
+The global `/rest/styles` endpoint returns all global styles (read-only). These are available so workspace administrators can reference them in their layers:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/styles"
+
+```json
+{
+  "styles": {
+    "style": [
+      {"name": "burg"},
+      {"name": "capitals"},
+      {"name": "generic"},
+      {"name": "line"},
+      {"name": "point"},
+      ...
+    ]
+  }
+}
+```
+
+Workspace-specific styles are listed through the workspace endpoint:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces/ne/styles"
+
+```json
+{
+  "styles": {
+    "style": [
+      {"name": "boundary_lines"},
+      {"name": "coastline"},
+      {"name": "countries"},
+      {"name": "populated_places"}
+    ]
+  }
+}
+```
+
+### Global styles are read-only
+
+While workspace administrators can read global styles, they cannot create, modify, or delete them:
+
+    curl -u neadmin:geo123 -X POST -H "Content-Type: application/json" \
+      -d '{"style":{"name":"test","filename":"test.sld"}}' \
+      "http://localhost:8080/geoserver/rest/styles"
+
+```
+403 Forbidden
+```
+
+### Update workspace properties
+
+Workspace administrators can update workspace properties (e.g. isolated mode) but cannot rename the workspace:
+
+    curl -u neadmin:geo123 -X PUT -H "Content-Type: application/json" \
+      -d '{"workspace":{"name":"ne"}}' \
+      "http://localhost:8080/geoserver/rest/workspaces/ne"
+
+```
+200 OK
+```
+
+Attempting to rename the workspace is denied:
+
+    curl -u neadmin:geo123 -X PUT -H "Content-Type: application/json" \
+      -d '{"workspace":{"name":"renamed"}}' \
+      "http://localhost:8080/geoserver/rest/workspaces/ne"
+
+```
+403 Forbidden
+```
+
+### Admin-only endpoints are denied
+
+Global configuration endpoints are restricted to full administrators and return `403 Forbidden`:
+
+    curl -u neadmin:geo123 "http://localhost:8080/geoserver/rest/settings"
+
+```
+HTTP/1.1 403 Forbidden
+```
+
+## What's next
+
+- [Workspace Administration](../../workspaceadmin/index.md) -- conceptual overview
+- [REST workspace admin security](../../workspaceadmin/rest.md) -- access rules reference
+- [Filesystem sandboxing](../../sandbox.md) -- restricting file system access

--- a/doc/en/user/security/tutorials/workspaceadmin/index.md
+++ b/doc/en/user/security/tutorials/workspaceadmin/index.md
@@ -1,0 +1,251 @@
+# Tutorial: Workspace Administration with the REST API
+
+This tutorial walks through setting up a workspace administrator and exploring their REST API access using the default GeoServer data directory.
+
+It is recommended to read the [Workspace Administration](../../workspaceadmin/index.md) section before proceeding.
+
+## Prerequisites
+
+- A running GeoServer instance with the default sample data (including the `ne` workspace with Natural Earth layers)
+- `curl` or a similar HTTP client
+- Admin access to GeoServer (default: `admin` / `geoserver`)
+
+## Step 1: Create a role
+
+Log in as administrator and navigate to **Security > Users, Groups, and Roles**. Select the **Roles** tab and click **Add new role**.
+
+Create a role named `ROLE_NE_ADMIN`. This role will grant workspace administration privileges.
+
+## Step 2: Create a user
+
+Switch to the **Users/Groups** tab and click **Add new user**.
+
+- Username: `neadmin`
+- Password: `geo123`
+- Assign the `ROLE_NE_ADMIN` role
+
+## Step 3: Grant workspace admin access
+
+Navigate to **Security > Data** and click **Add a new rule**.
+
+- Workspace: `ne`
+- Layer: `*`
+- Access mode: `Admin`
+- Grant to: `ROLE_NE_ADMIN`
+
+This rule tells GeoServer that users with `ROLE_NE_ADMIN` are workspace administrators for the `ne` workspace. GeoServer will use this to restrict management access to only the `ne` workspace in both the web interface and the REST API.
+
+## Step 4: Log in as the workspace admin
+
+Log out and log back in as `neadmin`. The web interface shows a restricted view:
+
+- Only the `ne` workspace appears in workspace listings
+- Only layers, stores, and styles from the `ne` workspace are visible
+- Global configuration pages are not accessible
+
+## Step 5: Explore the REST API
+
+Open a terminal and use `curl` to explore the REST API as the workspace admin. Use the `Accept` header for content negotiation rather than file extensions.
+
+### REST API index
+
+Start by requesting the REST API root. The index only shows endpoints the workspace admin is allowed to access; notice that admin-only endpoints like `settings`, `security/roles`, and `about` are absent:
+
+    curl -u neadmin:geo123 "http://localhost:8080/geoserver/rest"
+
+```html
+<html>
+<head><title> GeoServer Configuration API </title></head>
+<body>
+<h2>GeoServer Configuration API</h2>
+<ul>
+<li><a href=".../rest/crs">crs</a></li>
+<li><a href=".../rest/fonts">fonts</a></li>
+<li><a href=".../rest/index">index</a></li>
+<li><a href=".../rest/layers">layers</a></li>
+<li><a href=".../rest/namespaces">namespaces</a></li>
+<li><a href=".../rest/resource">resource</a></li>
+<li><a href=".../rest/security/self/password">security/self/password</a></li>
+<li><a href=".../rest/services/wcs/settings">services/wcs/settings</a></li>
+<li><a href=".../rest/services/wfs/settings">services/wfs/settings</a></li>
+<li><a href=".../rest/services/wms/settings">services/wms/settings</a></li>
+<li><a href=".../rest/services/wmts/settings">services/wmts/settings</a></li>
+<li><a href=".../rest/styles">styles</a></li>
+<li><a href=".../rest/templates">templates</a></li>
+<li><a href=".../rest/workspaces">workspaces</a></li>
+</ul>
+</body>
+</html>
+```
+
+### List workspaces
+
+The workspace admin sees only the workspaces they can administer:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces"
+
+```json
+{
+  "workspaces": {
+    "workspace": [
+      {
+        "name": "ne",
+        "href": "http://localhost:8080/geoserver/rest/workspaces/ne.json"
+      }
+    ]
+  }
+}
+```
+
+Compare with the full administrator who sees all 8 workspaces:
+
+    curl -u admin:geoserver -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces"
+
+### View workspace details
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces/ne"
+
+```json
+{
+  "workspace": {
+    "name": "ne",
+    "isolated": false,
+    "dataStores": "http://localhost:8080/geoserver/rest/workspaces/ne/datastores.json",
+    "coverageStores": "http://localhost:8080/geoserver/rest/workspaces/ne/coveragestores.json",
+    "wmsStores": "http://localhost:8080/geoserver/rest/workspaces/ne/wmsstores.json",
+    "wmtsStores": "http://localhost:8080/geoserver/rest/workspaces/ne/wmtsstores.json"
+  }
+}
+```
+
+### Other workspaces are hidden
+
+Workspaces the user doesn't administer are not accessible; the server returns 404 as if they don't exist:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces/cite"
+
+```
+HTTP/1.1 404 Not Found
+```
+
+### List layers
+
+The global `/rest/layers` endpoint returns only layers from workspaces the user administers. Even though it's the global endpoint, the response is filtered:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/layers"
+
+```json
+{
+  "layers": {
+    "layer": [
+      {"name": "ne:boundary_lines"},
+      {"name": "ne:coastlines"},
+      {"name": "ne:countries"},
+      {"name": "ne:disputed_areas"},
+      {"name": "ne:populated_places"}
+    ]
+  }
+}
+```
+
+Only `ne` layers are returned. A full administrator would see layers from all workspaces.
+
+Layers can also be listed through the workspace-specific endpoint:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces/ne/layers"
+
+### List styles
+
+The global `/rest/styles` endpoint returns all global styles (read-only). These are available so workspace administrators can reference them in their layers:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/styles"
+
+```json
+{
+  "styles": {
+    "style": [
+      {"name": "burg"},
+      {"name": "capitals"},
+      {"name": "generic"},
+      {"name": "line"},
+      {"name": "point"},
+      ...
+    ]
+  }
+}
+```
+
+Workspace-specific styles are listed through the workspace endpoint:
+
+    curl -u neadmin:geo123 -H "Accept: application/json" \
+      "http://localhost:8080/geoserver/rest/workspaces/ne/styles"
+
+```json
+{
+  "styles": {
+    "style": [
+      {"name": "boundary_lines"},
+      {"name": "coastline"},
+      {"name": "countries"},
+      {"name": "populated_places"}
+    ]
+  }
+}
+```
+
+### Global styles are read-only
+
+While workspace administrators can read global styles, they cannot create, modify, or delete them:
+
+    curl -u neadmin:geo123 -X POST -H "Content-Type: application/json" \
+      -d '{"style":{"name":"test","filename":"test.sld"}}' \
+      "http://localhost:8080/geoserver/rest/styles"
+
+```
+403 Forbidden
+```
+
+### Update workspace properties
+
+Workspace administrators can update workspace properties (e.g. isolated mode) but cannot rename the workspace:
+
+    curl -u neadmin:geo123 -X PUT -H "Content-Type: application/json" \
+      -d '{"workspace":{"name":"ne"}}' \
+      "http://localhost:8080/geoserver/rest/workspaces/ne"
+
+```
+200 OK
+```
+
+Attempting to rename the workspace is denied:
+
+    curl -u neadmin:geo123 -X PUT -H "Content-Type: application/json" \
+      -d '{"workspace":{"name":"renamed"}}' \
+      "http://localhost:8080/geoserver/rest/workspaces/ne"
+
+```
+403 Forbidden
+```
+
+### Admin-only endpoints are denied
+
+Global configuration endpoints are restricted to full administrators and return `403 Forbidden`:
+
+    curl -u neadmin:geo123 "http://localhost:8080/geoserver/rest/settings"
+
+```
+HTTP/1.1 403 Forbidden
+```
+
+## What's next
+
+- [Workspace Administration](../../workspaceadmin/index.md) -- conceptual overview
+- [REST workspace admin security](../../workspaceadmin/rest.md) -- access rules reference
+- [Filesystem sandboxing](../../sandbox.md) -- restricting file system access

--- a/doc/en/user/security/webadmin/data.md
+++ b/doc/en/user/security/webadmin/data.md
@@ -40,7 +40,7 @@ This mode configures how GeoServer will advertise secured layers and behave when
 
 ## File sandbox
 
-The sandbox allows a GeoServer full administrator to limit file system access to workspace administrators. In particular, both GUI and REST API will sandbox workspace administrators to `<sandbox>/<workspace>`, and prevent them from accessing files outside of it.
+The sandbox allows a GeoServer full administrator to limit file system access to workspace administrators. In particular, both GUI and REST API will sandbox workspace administrators to `<sandbox>/<workspace>`, and prevent them from accessing files outside of it. For more information about workspace administrators, please see [Workspace Administration](../workspaceadmin/index.md).
 
 ![](images/fs_sandbox.png)
 

--- a/doc/en/user/security/workspaceadmin/index.md
+++ b/doc/en/user/security/workspaceadmin/index.md
@@ -1,0 +1,83 @@
+# Workspace Administration {: #security_workspace_admin }
+
+A workspace administrator is a user with limited administrative privileges scoped to one or more specific workspaces. Workspace administrators can manage data stores, layers, styles, layer groups, templates, and service configuration within their assigned workspaces, but cannot modify global settings, access other workspaces, or change system configuration.
+
+This model supports multi-tenant environments where different teams or organizations manage their own data independently, without requiring full GeoServer administrator access.
+
+## How workspace administration works
+
+Workspace administration is controlled by three configuration layers that work together:
+
+### Data security rules (`layers.properties`)
+
+The foundation of workspace administration. These rules define **who** is a workspace administrator by granting the admin access mode (`a`) on a workspace to a role.
+
+For example, to make `ROLE_NE_ADMIN` a workspace admin for the `ne` workspace:
+
+    ne.*.a=ROLE_NE_ADMIN
+
+This can also be configured through the web interface under **Security > Data**. See [Layer security](../layer.md) for the full syntax and [Data security settings](../webadmin/data.md) for the web interface.
+
+GeoServer's catalog security layer uses these rules to determine which workspaces a user can *manage*. In the admin interfaces (web UI and REST API), a workspace administrator will only see workspaces, layers, stores, and styles within their assigned workspaces — other workspaces are hidden entirely from management views.
+
+!!! note
+
+    Admin access is independent of service access. A workspace administrator for `ne` can only
+    manage the `ne` workspace, but may still be able to *view* layers from other workspaces via
+    OWS services (WMS, WFS, etc.) depending on the read/write rules (`r`, `w`) in `layers.properties`.
+    Conversely, a user may have read access to all layers but no admin access to any workspace.
+
+### Global REST security rules (`rest.properties`)
+
+The [REST security](../rest.md) configuration maps URL patterns and HTTP methods to **roles**. By default, all REST API endpoints are restricted to users with `ROLE_ADMINISTRATOR`:
+
+    /**;GET,HEAD=ROLE_ADMINISTRATOR
+    /**;POST,DELETE,PUT=ROLE_ADMINISTRATOR
+
+While `rest.properties` could be edited to grant any user role access to specific endpoints, it has no concept of workspace scoping — any role granted access gets it for all workspaces equally. It is also not aware of which users are workspace administrators.
+
+### Workspace admin REST access rules (`rest.workspaceadmin.properties`)
+
+This file complements `rest.properties` by defining **which REST API endpoints** workspace administrators can reach, without requiring changes to `rest.properties`. It uses Ant-style URL patterns to open specific endpoints for any user that is a workspace administrator (as determined by `layers.properties`).
+
+Both files are evaluated together during request authorization. A workspace admin request is granted if it matches a `rest.workspaceadmin.properties` rule, even if `rest.properties` would otherwise restrict it to `ROLE_ADMINISTRATOR`.
+
+Critically, this file only controls URL-level access — it does **not** determine which workspaces or resources are visible. GeoServer handles that based on the admin access rules from `layers.properties`.
+
+In other words: `rest.workspaceadmin.properties` opens the door to endpoints, `layers.properties` determines what's behind the door.
+
+The file is created automatically from a built-in template on first startup. Custom rules can be added to extend or restrict the default permissions. See [REST workspace admin security](rest.md) for the full reference.
+
+## Web interface
+
+When a workspace administrator logs into the GeoServer web interface, they see a restricted version of the admin console:
+
+- Only their administrable workspaces appear in workspace listings
+- Layer, store, and style listings are filtered to their workspaces
+- Global configuration pages (Settings, Security, etc.) are not accessible
+- Workspace-specific settings and service configuration can be managed
+
+## REST API
+
+Workspace administrators can access the REST API with the same scope as the web interface. The default access rules provide:
+
+- **Read-only** access to workspace and namespace listings, global styles, global templates, fonts, and the REST API index
+- **Read/write** access to all resources within their workspaces (datastores, layers, styles, layer groups, templates)
+- **Read/write** access to per-workspace service settings (WMS, WFS, etc.)
+- **No access** to admin-only endpoints (global settings, security configuration, etc.)
+
+Requests to endpoints outside the configured patterns fall through to `rest.properties`, which typically restricts access to full administrators only.
+
+See [REST workspace admin security](rest.md) for the full access rules reference.
+
+## Filesystem sandboxing
+
+Workspace administrators can be further restricted with [filesystem sandboxing](../sandbox.md), which limits file system access to `<sandbox>/<workspace>`. This ensures workspace administrators can only access files within their assigned workspace directories, both through the web interface and the REST API resource browser.
+
+## See also
+
+- [REST workspace admin security](rest.md) -- access rules reference
+- [Layer security](../layer.md) -- admin access mode
+- [Filesystem sandboxing](../sandbox.md) -- file system restrictions
+- [Workspace admin guidance](../../production/config.md#production_config_workspace_admin) -- production recommendations
+- [Tutorial: Workspace administration with the REST API](../tutorials/workspaceadmin/index.md) -- hands-on setup guide

--- a/doc/en/user/security/workspaceadmin/index.md
+++ b/doc/en/user/security/workspaceadmin/index.md
@@ -1,0 +1,83 @@
+# Workspace Administration {: #security_workspace_admin }
+
+A workspace administrator is a user with limited administrative privileges scoped to one or more specific workspaces. Workspace administrators can manage data stores, layers, styles, layer groups, templates, and service configuration within their assigned workspaces, but cannot modify global settings, access other workspaces, or change system configuration.
+
+This model supports multi-tenant environments where different teams or organizations manage their own data independently, without requiring full GeoServer administrator access.
+
+## How workspace administration works
+
+Workspace administration is controlled by three configuration layers that work together:
+
+### Data security rules (`layers.properties`)
+
+The foundation of workspace administration. These rules define **who** is a workspace administrator by granting the admin access mode (`a`) on a workspace to a role.
+
+For example, to make `ROLE_NE_ADMIN` a workspace admin for the `ne` workspace:
+
+    ne.*.a=ROLE_NE_ADMIN
+
+This can also be configured through the web interface under **Security > Data**. See [Layer security](../layer.md) for the full syntax and [Data security settings](../webadmin/data.md) for the web interface.
+
+GeoServer's catalog security layer uses these rules to determine which workspaces a user can *manage*. In the admin interfaces (web UI and REST API), a workspace administrator will only see workspaces, layers, stores, and styles within their assigned workspaces; other workspaces are hidden entirely from management views.
+
+!!! note
+
+    Admin access is independent of service access. A workspace administrator for `ne` can only
+    manage the `ne` workspace, but may still be able to *view* layers from other workspaces via
+    OWS services (WMS, WFS, etc.) depending on the read/write rules (`r`, `w`) in `layers.properties`.
+    Conversely, a user may have read access to all layers but no admin access to any workspace.
+
+### Global REST security rules (`rest.properties`)
+
+The [REST security](../rest.md) configuration maps URL patterns and HTTP methods to **roles**. By default, all REST API endpoints are restricted to users with `ROLE_ADMINISTRATOR`:
+
+    /**;GET,HEAD=ROLE_ADMINISTRATOR
+    /**;POST,DELETE,PUT=ROLE_ADMINISTRATOR
+
+While `rest.properties` could be edited to grant any user role access to specific endpoints, it has no concept of workspace scoping: any role granted access gets it for all workspaces equally. It is also not aware of which users are workspace administrators.
+
+### Workspace admin REST access rules (`rest.workspaceadmin.properties`)
+
+This file complements `rest.properties` by defining **which REST API endpoints** workspace administrators can reach, without requiring changes to `rest.properties`. It uses Ant-style URL patterns to open specific endpoints for any user that is a workspace administrator (as determined by `layers.properties`).
+
+Both files are evaluated together during request authorization. A workspace admin request is granted if it matches a `rest.workspaceadmin.properties` rule, even if `rest.properties` would otherwise restrict it to `ROLE_ADMINISTRATOR`.
+
+This file only controls URL-level access: it does not determine which workspaces or resources are visible. GeoServer handles that based on the admin access rules from `layers.properties`.
+
+In other words: `rest.workspaceadmin.properties` opens the door to endpoints, `layers.properties` determines what's behind the door.
+
+The file is created automatically from a built-in template on first startup. Custom rules can be added to extend or restrict the default permissions. See [REST workspace admin security](rest.md) for the full reference.
+
+## Web interface
+
+When a workspace administrator logs into the GeoServer web interface, they see a restricted version of the admin console:
+
+- Only their administrable workspaces appear in workspace listings
+- Layer, store, and style listings are filtered to their workspaces
+- Global configuration pages (Settings, Security, etc.) are not accessible
+- Workspace-specific settings and service configuration can be managed
+
+## REST API
+
+Workspace administrators can access the REST API with the same scope as the web interface. The default access rules provide:
+
+- **Read-only** access to workspace and namespace listings, global styles, global templates, fonts, and the REST API index
+- **Read/write** access to all resources within their workspaces (datastores, layers, styles, layer groups, templates)
+- **Read/write** access to per-workspace service settings (WMS, WFS, etc.)
+- **No access** to admin-only endpoints (global settings, security configuration, etc.)
+
+Requests to endpoints outside the configured patterns fall through to `rest.properties`, which typically restricts access to full administrators only.
+
+See [REST workspace admin security](rest.md) for the full access rules reference.
+
+## Filesystem sandboxing
+
+Workspace administrators can be further restricted with [filesystem sandboxing](../sandbox.md), which limits file system access to `<sandbox>/<workspace>`. This ensures workspace administrators can only access files within their assigned workspace directories, both through the web interface and the REST API resource browser.
+
+## See also
+
+- [REST workspace admin security](rest.md) -- access rules reference
+- [Layer security](../layer.md) -- admin access mode
+- [Filesystem sandboxing](../sandbox.md) -- file system restrictions
+- [Workspace admin guidance](../../production/config.md#production_config_workspace_admin) -- production recommendations
+- [Tutorial: Workspace administration with the REST API](../tutorials/workspaceadmin/index.md) -- hands-on setup guide

--- a/doc/en/user/security/workspaceadmin/rest.md
+++ b/doc/en/user/security/workspaceadmin/rest.md
@@ -1,0 +1,133 @@
+# REST Workspace Admin Security {: #security_rest_workspace_admin }
+
+The `rest.workspaceadmin.properties` file controls which REST API endpoints workspace administrators can access. These rules determine URL-level access only — they do not control which workspaces or resources are visible. That is determined by the data security rules in `layers.properties` (see [Workspace Administration](index.md) for the full picture).
+
+## How It Works
+
+1. Access rules are defined using Ant-style URL patterns in `rest.workspaceadmin.properties`
+2. Different HTTP methods (GET, POST, PUT, DELETE) can be controlled separately
+3. Endpoints that don't match any pattern fall back to `rest.properties` (typically admin-only)
+4. Default rules are provided and can be extended with custom rules
+5. GeoServer independently filters which workspaces and resources are visible to each user based on data security rules
+
+## Default Access Rules
+
+The default workspace administrator access rules are defined in a template that is used to initialize the `rest.workspaceadmin.properties` file. By default, workspace administrators are granted the following access through the REST API:
+
+**Workspace and Catalog Endpoints:**
+
+- `/rest/workspaces.{ext}=r` - Read-only access to the workspaces listing (JSON/XML)
+- `/rest/workspaces=r` - Read-only access to the workspaces listing
+- `/rest/workspaces/{workspace}.{ext}=r,PUT` - Read and update access to specific workspace (JSON/XML), but cannot rename the workspace
+- `/rest/workspaces/{workspace}=r,PUT` - Read and update access to specific workspace, but cannot rename the workspace
+- `/rest/workspaces/{workspace}/**=rw` - Full access to all resources under the workspace
+- `/rest/namespaces.{ext}=r` - Read-only access to namespaces listing (JSON/XML)
+- `/rest/namespaces=r` - Read-only access to namespaces listing
+- `/rest/namespaces/{namespace}.{ext}=r,PUT` - Read and update access to specific namespace (JSON/XML), but cannot rename the namespace
+- `/rest/namespaces/{namespace}=r,PUT` - Read and update access to specific namespace, but cannot rename the namespace
+- `/rest/namespaces/{namespace}/**=rw` - Full access to all resources under the namespace
+- `/rest/layers/**=rw` - Full access to layers (filtered by secure catalog to only show layers in managed workspaces)
+- `/rest/styles.{ext}=r` - Read-only access to global styles listing (JSON/XML)
+- `/rest/styles/**=r` - Read-only access to all global styles (for use in layers within the workspace)
+- `/rest/templates.{ext}=r` - Read-only access to global templates listing (JSON/XML)
+- `/rest/templates/**=r` - Read-only access to all global templates (for reference when creating workspace-specific templates)
+
+!!! note
+
+    Workspace-specific resources are accessed through the workspace endpoint, for example:
+    `/rest/workspaces/{workspace}/styles/**`, `/rest/workspaces/{workspace}/templates/**`,
+    and `/rest/workspaces/{workspace}/layergroups/**`. Workspace administrators have full access (read/write)
+    to styles, templates, and layer groups within their assigned workspaces, but only read access to global
+    styles and templates. Workspace administrators have no access to global layer groups. Layers and layer groups
+    in workspace-administered workspaces can reference global styles.
+
+**Resource Access:**
+
+- `/rest/resource/workspaces=r` - Read-only access to workspace resources listing
+- `/rest/resource/workspaces/{workspace}/**=rw` - Full access to resources within workspace
+- `/rest/resource/**=r` - Read-only access to other resources
+
+**User Account Management:**
+
+- `/rest/security/self/**=rw` - Full access to self-service account management
+
+**General Service Endpoints:**
+
+- `/rest/fonts.{ext}=r` - Read-only access to fonts listing (JSON/XML)
+- `/rest/fonts/**=r` - Read-only access to fonts
+- `/rest=r` - Read-only access to REST API root
+- `/rest/=r` - Read-only access to REST API root (alternate)
+- `/rest.{ext}=r` - Read-only access to REST API root (JSON/XML)
+- `/rest/index=r` - Read-only access to REST API index
+- `/rest/index.{ext}=r` - Read-only access to REST API index (JSON/XML)
+
+## Configuration
+
+The workspace administrator REST access rules are defined in the `rest.workspaceadmin.properties` file located in the `security` directory of the GeoServer data directory. When GeoServer is first started or the file doesn't exist, it's automatically created from a template containing the default workspace administrator access rules.
+
+Custom rules can be added to this file to extend or modify the default permissions using the syntax:
+
+    /url/pattern=METHOD1,METHOD2,...
+
+Where methods can be specific HTTP methods (GET, POST, PUT, DELETE) or shorthand values:
+
+- `r` = Read operations (GET, HEAD, OPTIONS, TRACE)
+- `w` = Write operations (POST, PUT, PATCH, DELETE)
+- `rw` = All operations (read + write)
+
+For example, to allow workspace administrators to access styling information across all workspaces (read-only):
+
+    /rest/styles/**=r
+
+## Filesystem Sandboxing
+
+Workspace administrators are also subject to filesystem sandboxing when accessing resources through the REST API. This ensures that they can only access files within their assigned workspace directories.
+
+When a filesystem sandbox is configured as described in [Filesystem sandboxing](../sandbox.md), workspace administrators will be restricted to the subdirectory matching their workspace name within the sandbox.
+
+## Examples
+
+The following examples demonstrate typical REST API operations available to workspace administrators:
+
+**Accessing workspace information:**
+
+    GET /rest/workspaces/myworkspace
+
+**Adding a new datastore to their workspace:**
+
+    POST /rest/workspaces/myworkspace/datastores
+
+**Modifying layer settings within their workspace:**
+
+    PUT /rest/workspaces/myworkspace/layers/mylayer
+
+**Creating a workspace-specific style:**
+
+    POST /rest/workspaces/myworkspace/styles
+
+**Reading a global style (read-only access):**
+
+    GET /rest/styles/default_point
+
+**Accessing workspace resources:**
+
+    GET /rest/resource/workspaces/myworkspace/styles/mystyle.sld
+
+## Security Considerations
+
+1. Workspace administrators cannot access resources outside of their assigned workspaces
+2. Workspace administrators cannot rename workspaces they administer (can update other properties)
+3. Workspace administrators cannot change the default workspace or namespace settings
+4. Workspace administrators have read-only access to global styles (but can create/modify workspace-specific styles)
+5. REST endpoints not matching any patterns fall back to global REST security rules (typically administrators-only)
+6. URL pattern matching is case-sensitive by default
+7. Nested paths under workspace resources are automatically secured
+8. Appropriate HTTP status codes (401/403) are returned for unauthorized access attempts
+
+When troubleshooting access issues, check:
+
+1. The user has the ROLE_WORKSPACE_ADMIN role assigned
+2. The user has the correct workspace(s) assigned
+3. The requested resource falls under the permitted URL patterns
+4. The HTTP method being used is allowed for that resource pattern
+5. For PUT operations on workspaces or namespaces, ensure the name field is not being modified

--- a/doc/en/user/security/workspaceadmin/rest.md
+++ b/doc/en/user/security/workspaceadmin/rest.md
@@ -1,0 +1,107 @@
+# REST workspace admin security {: #security_rest_workspace_admin }
+
+The `rest.workspaceadmin.properties` file controls which REST API endpoints workspace administrators can access. These rules determine URL-level access only: they do not control which workspaces or resources are visible, which is determined by the data security rules in `layers.properties` (see [Workspace Administration](index.md) for the full picture).
+
+The file lives in the `security` directory of the GeoServer data directory, and is created from a built-in template on first startup.
+
+## Syntax
+
+Each rule maps an Ant-style URL pattern to the HTTP methods workspace administrators may use on it:
+
+    /url/pattern=METHOD1,METHOD2,...
+
+Methods can be explicit HTTP method names (GET, POST, PUT, ...) or one of the shorthands:
+
+- `r` = Read operations (GET, HEAD, OPTIONS, TRACE)
+- `w` = Write operations (POST, PUT, PATCH, DELETE)
+- `rw` = All operations (read + write)
+
+Rules are evaluated in order and the first match wins, so place more specific patterns before more general ones. Requests that match no rule fall back to [rest.properties](../rest.md), which by default restricts access to full administrators.
+
+## Default access rules
+
+The default rules give workspace administrators read-write access to the contents of their workspaces, and read-only access to the global resources needed to work with them:
+
+```properties
+# Workspace and catalog endpoints. GeoServer filters the actual contents
+# based on the user's manageable workspaces; these rules only open the endpoints.
+/rest/workspaces.{ext}=r
+/rest/workspaces=r
+
+# read and update; a workspace rename is rejected
+/rest/workspaces/{workspace}.{ext}=r,PUT
+/rest/workspaces/{workspace}=r,PUT
+
+# full access to sub-resources (datastores, coveragestores, styles, layergroups, etc.)
+/rest/workspaces/{workspace}/**=rw
+
+# namespaces mirror the workspace rules
+/rest/namespaces.{ext}=r
+/rest/namespaces=r
+/rest/namespaces/{namespace}.{ext}=r,PUT
+/rest/namespaces/{namespace}=r,PUT
+/rest/namespaces/{namespace}/**=rw
+
+# layers, filtered to manageable workspaces
+/rest/layers/**=rw
+
+# read-only global styles and templates
+# (workspace ones are under /rest/workspaces/{workspace}/**)
+/rest/styles.{ext}=r
+/rest/styles/**=r
+/rest/templates.{ext}=r
+/rest/templates/**=r
+
+# resource browser, contents filtered to manageable workspaces
+/rest/resource/workspaces=r
+/rest/resource/workspaces/{workspace}/**=rw
+/rest/resource/styles=r
+/rest/resource/styles/**=r
+/rest/resource/**=r
+
+# self-service account management
+/rest/security/self/**=rw
+
+# per-workspace OWS service settings
+# (global settings, /rest/services/*/settings, fall through to rest.properties)
+/rest/services/*/workspaces/{workspace}/**=rw
+
+# read-only API root, index, fonts and CRS lookups
+/rest/fonts.{ext}=r
+/rest/fonts/**=r
+/rest/crs=r
+/rest/crs/**=r
+/rest=r
+/rest/=r
+/rest.{ext}=r
+/rest/index=r
+/rest/index.{ext}=r
+```
+
+With these rules, workspace administrators:
+
+- can update workspaces and namespaces they administer, but cannot rename them
+- cannot change the default workspace or namespace
+- have read-only access to global styles and templates, and no access to global layer groups
+- can manage per-workspace service settings (WMS, WFS, etc.), but not the global ones
+
+## Customization
+
+Edit `security/rest.workspaceadmin.properties` in the data directory to extend or restrict the default permissions. For example, to also give workspace administrators read access to the GeoServer logging configuration:
+
+    /rest/logging=GET
+
+## Filesystem sandboxing
+
+When a [filesystem sandbox](../sandbox.md) is configured, workspace administrators accessing `/rest/resource` are restricted to the subdirectory matching their workspace name within the sandbox.
+
+## Troubleshooting
+
+When a workspace administrator gets an unexpected `403` or `404` response, check that:
+
+1. The user's role is granted admin access (`a`) to the workspace by the data security rules in `layers.properties`
+2. The request URL matches one of the patterns, with an allowed HTTP method
+3. The resource belongs to a workspace the user administers; resources in other workspaces are hidden and return `404`
+4. For PUT operations on a workspace or namespace, the name is not being modified
+
+For a hands-on walkthrough, see the [Workspace Administration tutorial](../tutorials/workspaceadmin/index.md).

--- a/doc/en/user/tutorials/index.md
+++ b/doc/en/user/tutorials/index.md
@@ -61,6 +61,15 @@ Catalogue tutorials:
 
 </div>
 
+Security tutorials:
+
+<div class="grid cards" markdown>
+
+- [Workspace administration with the REST API](../security/tutorials/workspaceadmin/index.md)
+- [Authentication tutorials](../security/tutorials/index.md) (LDAP, CAS, X.509, and more)
+
+</div>
+
 Application server tutorials:
 
 <div class="grid cards" markdown>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -563,6 +563,9 @@ nav:
       - en/user/security/layer.md
       - en/user/security/sandbox.md
       - en/user/security/rest.md
+      - Workspace Administration:
+        - en/user/security/workspaceadmin/index.md
+        - en/user/security/workspaceadmin/rest.md
       - en/user/security/urlchecks.md
       - en/user/security/csp.md
       - en/user/security/disable.md
@@ -576,6 +579,7 @@ nav:
         - Configuring HTTP Header Proxy Authentication: en/user/security/tutorials/httpheaderproxy/index.md
         - Configuring Apache HTTPD Session Integration: en/user/security/tutorials/credentialsfromheaders/index.md
         - Authentication with CAS: en/user/security/tutorials/cas/index.md
+        - Workspace Administration: en/user/security/tutorials/workspaceadmin/index.md
     - GeoWebCache:
       - en/user/geowebcache/index.md
       - GeoWebCache settings:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -575,6 +575,9 @@ nav:
       - en/user/security/layer.md
       - en/user/security/sandbox.md
       - en/user/security/rest.md
+      - Workspace Administration:
+        - en/user/security/workspaceadmin/index.md
+        - en/user/security/workspaceadmin/rest.md
       - en/user/security/urlchecks.md
       - en/user/security/csp.md
       - en/user/security/disable.md
@@ -588,6 +591,7 @@ nav:
         - Configuring HTTP Header Proxy Authentication: en/user/security/tutorials/httpheaderproxy/index.md
         - Configuring Apache HTTPD Session Integration: en/user/security/tutorials/credentialsfromheaders/index.md
         - Authentication with CAS: en/user/security/tutorials/cas/index.md
+        - Workspace Administration: en/user/security/tutorials/workspaceadmin/index.md
     - GeoWebCache:
       - en/user/geowebcache/index.md
       - GeoWebCache settings:

--- a/src/main/src/main/java/applicationSecurityContext.xml
+++ b/src/main/src/main/java/applicationSecurityContext.xml
@@ -18,8 +18,26 @@
       Remember that rules are matched in order, so please put the most specific rules at the beginning of the list.
       In order to have these applied, add restFilterDefintionMap to the end of the filter list in the filterChainProxy above
   -->
-  <bean id="restFilterDefinitionMap" class="org.geoserver.security.RESTfulDefinitionSource">
+  <bean id="defaultRestFilterDefinitionMap" class="org.geoserver.security.RESTfulDefinitionSource">
       <constructor-arg ref="restRulesDao"/>
+  </bean>
+  <!--
+     HTTP Method security rules for workspace administrators, handling the dynamic nature of it
+  -->
+  <bean id="workspaceAdminRestDefinitionSource" class="org.geoserver.security.workspaceadmin.WorkspaceAdminRestfulDefinitionSource">
+      <constructor-arg ref="workspaceAdminAuthorization"/>
+  </bean>
+
+  <!--
+     HTTP Method security proxy for FilterInvocationSecurityMetadataSource implementations handling REST security
+  -->
+  <bean id="restFilterDefinitionMap" class="org.geoserver.security.RESTfulDefinitionSourceProxy">
+      <constructor-arg>
+        <list>
+            <ref bean="defaultRestFilterDefinitionMap"/>
+            <ref bean="workspaceAdminRestDefinitionSource"/>
+        </list>
+      </constructor-arg>
   </bean>
 
   <bean id="geoserverMetadataSource" class="org.geoserver.security.filter.GeoServerSecurityMetadataSource" />
@@ -197,5 +215,14 @@
     <constructor-arg ref="geoServer"/>
     <constructor-arg ref="dataDirectory"/>
     <constructor-arg ref="xstreamPersisterFactory"/>
+  </bean>
+
+  <!-- The dao used to deal with rest security for workspace administrators -->
+  <bean id="workspaceAdminRESTAccessRuleDAO" class="org.geoserver.security.workspaceadmin.WorkspaceAdminRESTAccessRuleDAO">
+  </bean>
+  
+  <!-- The workspace administrators centralized logic -->
+  <bean id="workspaceAdminAuthorization" class="org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer">
+      <constructor-arg ref="workspaceAdminRESTAccessRuleDAO"/>
   </bean>
 </beans>

--- a/src/main/src/main/java/applicationSecurityContext.xml
+++ b/src/main/src/main/java/applicationSecurityContext.xml
@@ -12,8 +12,26 @@
       Remember that rules are matched in order, so please put the most specific rules at the beginning of the list.
       In order to have these applied, add restFilterDefintionMap to the end of the filter list in the filterChainProxy above
   -->
-  <bean id="restFilterDefinitionMap" class="org.geoserver.security.RESTfulDefinitionSource">
+  <bean id="defaultRestFilterDefinitionMap" class="org.geoserver.security.RESTfulDefinitionSource">
       <constructor-arg ref="restRulesDao"/>
+  </bean>
+  <!--
+     HTTP Method security rules for workspace administrators, loaded from security/rest.workspaceadmin.properties
+  -->
+  <bean id="workspaceAdminRestDefinitionSource" class="org.geoserver.security.workspaceadmin.WorkspaceAdminRestfulDefinitionSource">
+      <constructor-arg ref="workspaceAdminAuthorization"/>
+  </bean>
+
+  <!--
+     Combines the default REST security rules with the workspace administrator ones
+  -->
+  <bean id="restFilterDefinitionMap" class="org.geoserver.security.RESTfulDefinitionSourceProxy">
+      <constructor-arg>
+        <list>
+            <ref bean="defaultRestFilterDefinitionMap"/>
+            <ref bean="workspaceAdminRestDefinitionSource"/>
+        </list>
+      </constructor-arg>
   </bean>
 
   <bean id="geoserverMetadataSource" class="org.geoserver.security.filter.GeoServerSecurityMetadataSource" />
@@ -209,5 +227,14 @@
     <constructor-arg ref="geoServer"/>
     <constructor-arg ref="dataDirectory"/>
     <constructor-arg ref="xstreamPersisterFactory"/>
+  </bean>
+
+  <!-- Loads the REST security rules for workspace administrators -->
+  <bean id="workspaceAdminRESTAccessRuleDAO" class="org.geoserver.security.workspaceadmin.WorkspaceAdminRESTAccessRuleDAO">
+  </bean>
+
+  <!-- Centralized workspace administrator authorization logic -->
+  <bean id="workspaceAdminAuthorization" class="org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer">
+      <constructor-arg ref="workspaceAdminRESTAccessRuleDAO"/>
   </bean>
 </beans>

--- a/src/main/src/main/java/org/geoserver/security/RESTfulDefinitionSource.java
+++ b/src/main/src/main/java/org/geoserver/security/RESTfulDefinitionSource.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.security.impl.RESTAccessRuleDAO;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminRestfulDefinitionSource;
 import org.geotools.util.logging.Logging;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.access.SecurityConfig;
@@ -24,7 +25,10 @@ import org.springframework.security.web.access.intercept.FilterInvocationSecurit
 import org.springframework.security.web.util.UrlUtils;
 import org.springframework.util.StringUtils;
 
-/** @author Chris Berry http://opensource.atlassian.com/projects/spring/browse/SEC-531 */
+/**
+ * @author Chris Berry http://opensource.atlassian.com/projects/spring/browse/SEC-531
+ * @see WorkspaceAdminRestfulDefinitionSource
+ */
 @SuppressWarnings({"deprecation", "removal"})
 public class RESTfulDefinitionSource implements FilterInvocationSecurityMetadataSource {
 

--- a/src/main/src/main/java/org/geoserver/security/RESTfulDefinitionSourceProxy.java
+++ b/src/main/src/main/java/org/geoserver/security/RESTfulDefinitionSourceProxy.java
@@ -1,0 +1,84 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminRestfulDefinitionSource;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
+
+/**
+ * A proxy implementation of {@link FilterInvocationSecurityMetadataSource} that delegates to a list of other
+ * FilterInvocationSecurityMetadataSource instances.
+ *
+ * <p>This allows combining multiple security metadata sources, such as the standard {@link RESTfulDefinitionSource} and
+ * the {@link WorkspaceAdminRestfulDefinitionSource}, to handle different authorization scenarios.
+ */
+@SuppressWarnings({"deprecation", "removal"})
+public class RESTfulDefinitionSourceProxy implements FilterInvocationSecurityMetadataSource {
+
+    private List<FilterInvocationSecurityMetadataSource> delegates;
+
+    /**
+     * Creates a new proxy with the given list of delegate metadata sources.
+     *
+     * @param delegates the list of metadata sources to delegate to
+     */
+    public RESTfulDefinitionSourceProxy(List<FilterInvocationSecurityMetadataSource> delegates) {
+        this.delegates = delegates;
+    }
+
+    /**
+     * Returns true if any of the delegate metadata sources support the given class.
+     *
+     * @param clazz the class to check for support
+     * @return true if any delegate supports the class, false otherwise
+     */
+    @Override
+    public boolean supports(Class<?> clazz) {
+        for (FilterInvocationSecurityMetadataSource delegate : delegates) {
+            if (delegate.supports(clazz)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the combined security attributes from all delegate metadata sources. Optimizes for the common case of a
+     * single delegate.
+     *
+     * @param object the object to get attributes for
+     * @return a collection of security config attributes from all delegates
+     * @throws IllegalArgumentException if the object is not supported
+     */
+    @Override
+    public Collection<ConfigAttribute> getAttributes(Object object) throws IllegalArgumentException {
+        if (1 == delegates.size()) return delegates.get(0).getAttributes(object);
+        return delegates.stream()
+                .map(d -> d.getAttributes(object))
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the combined config attributes from all delegate metadata sources. Optimizes for the common case of a
+     * single delegate.
+     *
+     * @return a collection of all config attributes from all delegates
+     */
+    @Override
+    public Collection<ConfigAttribute> getAllConfigAttributes() {
+        if (1 == delegates.size()) return delegates.get(0).getAllConfigAttributes();
+        return delegates.stream()
+                .map(d -> d.getAllConfigAttributes())
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/RESTfulDefinitionSourceProxy.java
+++ b/src/main/src/main/java/org/geoserver/security/RESTfulDefinitionSourceProxy.java
@@ -1,0 +1,61 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminRestfulDefinitionSource;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
+
+/**
+ * A proxy implementation of {@link FilterInvocationSecurityMetadataSource} that delegates to a list of other
+ * FilterInvocationSecurityMetadataSource instances.
+ *
+ * <p>This allows combining multiple security metadata sources, such as the standard {@link RESTfulDefinitionSource} and
+ * the {@link WorkspaceAdminRestfulDefinitionSource}, to handle different authorization scenarios.
+ */
+@SuppressWarnings({"deprecation", "removal"})
+public class RESTfulDefinitionSourceProxy implements FilterInvocationSecurityMetadataSource {
+
+    private List<FilterInvocationSecurityMetadataSource> delegates;
+
+    public RESTfulDefinitionSourceProxy(List<FilterInvocationSecurityMetadataSource> delegates) {
+        this.delegates = delegates;
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        for (FilterInvocationSecurityMetadataSource delegate : delegates) {
+            if (delegate.supports(clazz)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Returns the combined security attributes from all delegates. */
+    @Override
+    public Collection<ConfigAttribute> getAttributes(Object object) throws IllegalArgumentException {
+        if (1 == delegates.size()) return delegates.get(0).getAttributes(object);
+        return delegates.stream()
+                .map(d -> d.getAttributes(object))
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    /** Returns the combined config attributes from all delegates. */
+    @Override
+    public Collection<ConfigAttribute> getAllConfigAttributes() {
+        if (1 == delegates.size()) return delegates.get(0).getAllConfigAttributes();
+        return delegates.stream()
+                .map(d -> d.getAllConfigAttributes())
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/filter/GeoServerSecurityInterceptorFilter.java
+++ b/src/main/src/main/java/org/geoserver/security/filter/GeoServerSecurityInterceptorFilter.java
@@ -12,10 +12,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.geoserver.security.config.SecurityInterceptorFilterConfig;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizationManager;
 import org.jspecify.annotations.Nullable;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.access.SecurityMetadataSource;
@@ -37,9 +39,9 @@ import org.springframework.security.web.access.intercept.AuthorizationFilter;
 @SuppressWarnings({"deprecation", "removal"})
 public class GeoServerSecurityInterceptorFilter extends GeoServerCompositeFilter {
 
-    private static final AuthorizationDecision ACCESS_GRANTED = new AuthorizationDecision(true);
-    private static final AuthorizationDecision ACCESS_DENIED = new AuthorizationDecision(false);
-    private static final AuthorizationDecision ACCESS_ABSTAIN = null;
+    public static final AuthorizationDecision ACCESS_GRANTED = new AuthorizationDecision(true);
+    public static final AuthorizationDecision ACCESS_DENIED = new AuthorizationDecision(false);
+    public static final AuthorizationDecision ACCESS_ABSTAIN = null;
 
     /**
      * AuthorizationManager implementation considers the authentication requirements of the respective request, in
@@ -78,8 +80,7 @@ public class GeoServerSecurityInterceptorFilter extends GeoServerCompositeFilter
                             || IS_AUTHENTICATED_ANONYMOUSLY.equals(attribute.getAttribute()));
         }
 
-        private AuthorizationDecision vote(
-                Authentication authentication, Object object, Collection<ConfigAttribute> attributes) {
+        private AuthorizationDecision vote(Authentication authentication, Collection<ConfigAttribute> attributes) {
             AuthorizationDecision result = ACCESS_ABSTAIN;
             for (ConfigAttribute attribute : attributes) {
                 if (this.supports(attribute)) {
@@ -112,7 +113,7 @@ public class GeoServerSecurityInterceptorFilter extends GeoServerCompositeFilter
                 Supplier<? extends @Nullable Authentication> authentication, HttpServletRequest request) {
             Collection<ConfigAttribute> attributes =
                     Optional.ofNullable(metadata.getAttributes(request)).orElse(Collections.emptySet());
-            return vote(authentication.get(), request, attributes);
+            return vote(authentication.get(), attributes);
         }
     }
 
@@ -131,8 +132,7 @@ public class GeoServerSecurityInterceptorFilter extends GeoServerCompositeFilter
             this.metadata = metadata;
         }
 
-        private AuthorizationDecision vote(
-                Authentication authentication, Object object, Collection<ConfigAttribute> attributes) {
+        private AuthorizationDecision vote(Authentication authentication, Collection<ConfigAttribute> attributes) {
             if (authentication == null) {
                 return ACCESS_DENIED;
             }
@@ -157,50 +157,58 @@ public class GeoServerSecurityInterceptorFilter extends GeoServerCompositeFilter
                 Supplier<? extends @Nullable Authentication> authentication, HttpServletRequest request) {
             Collection<ConfigAttribute> attributes =
                     Optional.ofNullable(metadata.getAttributes(request)).orElse(Collections.emptySet());
-            return vote(authentication.get(), request, attributes);
+            return vote(authentication.get(), attributes);
         }
     }
 
     /**
-     * Compound {@link AuthorizationManager} implementation forwards the check to delegates. <br>
-     * Based on org.springframework.security.access.vote.AffirmativeBased, which is deprecated with Spring Security 5.8.
+     * Compound {@link AuthorizationManager} implementation forwards the check to delegates.
+     *
+     * <p>Simply polls all configured {@link AuthorizationManager} delegates and grants access if any voted
+     * affirmatively. Denies access only if there was a deny vote AND no affirmative votes.
+     *
+     * <p>If every {@link AuthorizationManager} delegate abstained from voting, the decision will be based on the
+     * {@code allowIfAllAbstainDecisions} argument.
+     *
+     * @implNote Based on {@code org.springframework.security.access.vote.AffirmativeBased}, which is deprecated with
+     *     Spring Security 5.8.
      */
     private static final class AffirmativeAuthorizationManager implements AuthorizationManager<HttpServletRequest> {
 
-        private AuthorizationManager<HttpServletRequest> delegate1;
-        private AuthorizationManager<HttpServletRequest> delegate2;
+        private List<AuthorizationManager<HttpServletRequest>> delegates;
         private boolean allowIfAllAbstainDecisions;
 
         /**
-         * @param delegate1
-         * @param delegate2
+         * @param delegates
          * @param allowIfAllAbstainDecisions
          */
         public AffirmativeAuthorizationManager(
-                AuthorizationManager<HttpServletRequest> delegate1,
-                AuthorizationManager<HttpServletRequest> delegate2,
-                boolean allowIfAllAbstainDecisions) {
+                List<AuthorizationManager<HttpServletRequest>> delegates, boolean allowIfAllAbstainDecisions) {
             super();
-            this.delegate1 = delegate1;
-            this.delegate2 = delegate2;
+            this.delegates = delegates;
             this.allowIfAllAbstainDecisions = allowIfAllAbstainDecisions;
         }
 
         @Override
         public @Nullable AuthorizationResult authorize(
                 Supplier<? extends @Nullable Authentication> authentication, HttpServletRequest object) {
-            AuthorizationResult d1 = delegate1.authorize(authentication, object);
-            AuthorizationResult d2 = delegate2.authorize(authentication, object);
-            if (d1 == null && d2 == null) {
-                return allowIfAllAbstainDecisions ? ACCESS_GRANTED : ACCESS_DENIED;
+            int deny = 0;
+            for (AuthorizationManager<HttpServletRequest> delegate : delegates) {
+                @Nullable AuthorizationResult result = delegate.authorize(authentication, object);
+                boolean abstain = result == ACCESS_ABSTAIN;
+                if (!abstain) {
+                    if (result.isGranted()) {
+                        return ACCESS_GRANTED;
+                    } else {
+                        ++deny;
+                    }
+                }
             }
-            if (d1 != null && d1.isGranted()) {
-                return ACCESS_GRANTED;
+            if (deny > 0) {
+                return ACCESS_DENIED;
             }
-            if (d2 != null && d2.isGranted()) {
-                return ACCESS_GRANTED;
-            }
-            return ACCESS_DENIED;
+            // To get this far, every delegate AuthorizationManager abstained
+            return allowIfAllAbstainDecisions ? ACCESS_GRANTED : ACCESS_DENIED;
         }
     }
 
@@ -211,12 +219,17 @@ public class GeoServerSecurityInterceptorFilter extends GeoServerCompositeFilter
         SecurityInterceptorFilterConfig siConfig = (SecurityInterceptorFilterConfig) config;
         boolean allowIfAllAbstainDecisions = siConfig.isAllowIfAllAbstainDecisions();
 
-        AuthenticatedAuthorizationManager aam = new AuthenticatedAuthorizationManager(source);
-        RoleAuthorizationManager ram = new RoleAuthorizationManager(source);
-        AffirmativeAuthorizationManager am = new AffirmativeAuthorizationManager(aam, ram, allowIfAllAbstainDecisions);
-        AuthorizationFilter filter = new AuthorizationFilter(am);
+        AuthenticatedAuthorizationManager authenticated = new AuthenticatedAuthorizationManager(source);
+        WorkspaceAdminAuthorizationManager wsAdmin = new WorkspaceAdminAuthorizationManager(source);
+        RoleAuthorizationManager roleBased = new RoleAuthorizationManager(source);
+        List<AuthorizationManager<HttpServletRequest>> delegates = List.of(authenticated, wsAdmin, roleBased);
 
-        getNestedFilters().add(filter);
+        AffirmativeAuthorizationManager affirmativeAuthManager =
+                new AffirmativeAuthorizationManager(delegates, allowIfAllAbstainDecisions);
+
+        AuthorizationFilter authorizationFilter = new AuthorizationFilter(affirmativeAuthManager);
+
+        getNestedFilters().add(authorizationFilter);
     }
 
     @Override

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizationManager.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizationManager.java
@@ -1,0 +1,156 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.geoserver.security.filter.GeoServerSecurityInterceptorFilter.ACCESS_ABSTAIN;
+import static org.geoserver.security.filter.GeoServerSecurityInterceptorFilter.ACCESS_GRANTED;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collection;
+import java.util.function.Supplier;
+import org.geoserver.security.filter.GeoServerSecurityInterceptorFilter;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.SecurityMetadataSource;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.util.UrlUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Authorization manager specifically for handling workspace administrator access permissions.
+ *
+ * <p>This class is used by the {@link GeoServerSecurityInterceptorFilter} as one of several potential authorization
+ * strategies when evaluating access to protected resources in GeoServer. It focuses specifically on the workspace
+ * administrator role and permissions.
+ *
+ * <p>The class works in tandem with the {@link WorkspaceAdminAuthorizer} to determine if a user has workspace
+ * administrator privileges and whether they should be granted access to a specific resource based on URL patterns
+ * defined in the {@link WorkspaceAdminRESTAccessRuleDAO}.
+ *
+ * <p>Authorization proceeds as follows:
+ *
+ * <ol>
+ *   <li>First checks if the {@link WorkspaceAdminAuthorizer} service is available
+ *   <li>Extracts the request URI and HTTP method
+ *   <li>Checks if there's a matching {@link WorkspaceAdminRestAccessRule} for the URI and method
+ *   <li>If a rule matches, confirms that the user is a workspace administrator
+ *   <li>Returns ACCESS_GRANTED if all conditions are met, otherwise ACCESS_ABSTAIN to allow other authorization
+ *       managers to evaluate the request
+ * </ol>
+ *
+ * <p>By returning ACCESS_ABSTAIN rather than ACCESS_DENIED when a user isn't a workspace administrator, this manager
+ * allows the request to be evaluated by other authorization managers in the filter chain, such as those handling
+ * role-based or authenticated access.
+ *
+ * @see WorkspaceAdminAuthorizer
+ * @see WorkspaceAdminRestAccessRule
+ * @see GeoServerSecurityInterceptorFilter
+ */
+@SuppressWarnings("deprecation")
+public final class WorkspaceAdminAuthorizationManager implements AuthorizationManager<HttpServletRequest> {
+
+    /**
+     * The security metadata source containing access rules for workspace administrators. This provides the
+     * configuration attributes (rules) to be checked against the request.
+     */
+    private SecurityMetadataSource metadata;
+
+    /**
+     * Creates a new authorization manager for workspace administrators.
+     *
+     * @param metadata the security metadata source containing access rules for workspace administrators
+     */
+    public WorkspaceAdminAuthorizationManager(SecurityMetadataSource metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Evaluates if the current request should be authorized based on workspace administrator privileges.
+     *
+     * <p>This method implements the core authorization logic for workspace administrators by:
+     *
+     * <ul>
+     *   <li>Obtaining the WorkspaceAdminAuthorizer service
+     *   <li>Determining if any workspace admin access rules match the requested URI and HTTP method
+     *   <li>Verifying that the user has workspace administrator privileges
+     * </ul>
+     *
+     * <p>The method will return:
+     *
+     * <ul>
+     *   <li>{@link GeoServerSecurityInterceptorFilter#ACCESS_ABSTAIN} if the WorkspaceAdminAuthorizer is not available,
+     *       if no matching rules are found, or if the user is not a workspace administrator
+     *   <li>{@link GeoServerSecurityInterceptorFilter#ACCESS_GRANTED} if a matching rule is found and the user is a
+     *       workspace administrator
+     * </ul>
+     *
+     * @param authentication a supplier for the authentication object representing the current user
+     * @param request the HTTP request being evaluated
+     * @return an authorization decision indicating whether access should be granted, denied, or abstained
+     */
+    @Override
+    @Nullable
+    public AuthorizationResult authorize(
+            Supplier<? extends @Nullable Authentication> authentication, HttpServletRequest request) {
+
+        final Authentication auth = authentication.get();
+
+        // if the authorizer service isn't available, abstain from making a decision
+        if (WorkspaceAdminAuthorizer.get().isEmpty()) {
+            return ACCESS_ABSTAIN;
+        }
+
+        WorkspaceAdminAuthorizer authorizer = WorkspaceAdminAuthorizer.get().orElseThrow();
+
+        // if the user is not a workspace administrator, just abstain
+        if (!authorizer.isWorkspaceAdmin(auth)) {
+            return ACCESS_ABSTAIN;
+        }
+
+        // extract the request URI and HTTP method
+        final String uri = buildRequestUrl(request);
+        final HttpMethod method = HttpMethod.valueOf(request.getMethod());
+
+        // get the security attributes (rules) that apply to this request
+        Collection<ConfigAttribute> attributes = metadata.getAttributes(request);
+
+        // check if any workspace admin rules match the request URI and method
+        boolean match = attributes.stream()
+                .filter(WorkspaceAdminRestAccessRule.class::isInstance)
+                .map(WorkspaceAdminRestAccessRule.class::cast)
+                .anyMatch(rule -> rule.matches(uri, method));
+
+        // grant access if a rule matches, otherwise abstain
+        return match ? ACCESS_GRANTED : ACCESS_ABSTAIN;
+    }
+
+    /**
+     * Replacement for {@link UrlUtils#buildRequestUrl()} because it adds a {@code ?} trailing character even if the
+     * querystring is empty
+     */
+    private String buildRequestUrl(HttpServletRequest r) {
+        String servletPath = r.getServletPath();
+        String requestURI = r.getRequestURI();
+        String contextPath = r.getContextPath();
+        String pathInfo = r.getPathInfo();
+        String queryString = r.getQueryString();
+        StringBuilder url = new StringBuilder();
+        if (servletPath != null) {
+            url.append(servletPath);
+            if (pathInfo != null) {
+                url.append(pathInfo);
+            }
+        } else {
+            url.append(requestURI.substring(contextPath.length()));
+        }
+        if (StringUtils.hasLength(queryString)) {
+            url.append("?").append(queryString);
+        }
+        return url.toString();
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizationManager.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizationManager.java
@@ -1,0 +1,98 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.geoserver.security.filter.GeoServerSecurityInterceptorFilter.ACCESS_ABSTAIN;
+import static org.geoserver.security.filter.GeoServerSecurityInterceptorFilter.ACCESS_GRANTED;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collection;
+import java.util.function.Supplier;
+import org.geoserver.security.filter.GeoServerSecurityInterceptorFilter;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.SecurityMetadataSource;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.util.UrlUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link AuthorizationManager} that grants access when the current user is a workspace administrator and the request
+ * matches one of the {@link WorkspaceAdminRestAccessRule workspace admin access rules}.
+ *
+ * <p>In every other case it abstains rather than denies, leaving the decision to the other authorization managers
+ * configured by {@link GeoServerSecurityInterceptorFilter}. This way it can only widen access for workspace
+ * administrators, never restrict anyone else's.
+ *
+ * @see WorkspaceAdminAuthorizer
+ */
+@SuppressWarnings("deprecation")
+public final class WorkspaceAdminAuthorizationManager implements AuthorizationManager<HttpServletRequest> {
+
+    private SecurityMetadataSource metadata;
+
+    public WorkspaceAdminAuthorizationManager(SecurityMetadataSource metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    @Nullable
+    public AuthorizationResult authorize(
+            Supplier<? extends @Nullable Authentication> authentication, HttpServletRequest request) {
+
+        final Authentication auth = authentication.get();
+
+        // abstain if there's no authorizer bean in the application context
+        if (WorkspaceAdminAuthorizer.get().isEmpty()) {
+            return ACCESS_ABSTAIN;
+        }
+
+        WorkspaceAdminAuthorizer authorizer = WorkspaceAdminAuthorizer.get().orElseThrow();
+
+        if (!authorizer.isWorkspaceAdmin(auth)) {
+            return ACCESS_ABSTAIN;
+        }
+
+        final String uri = buildRequestUrl(request);
+        final HttpMethod method = HttpMethod.valueOf(request.getMethod());
+
+        Collection<ConfigAttribute> attributes = metadata.getAttributes(request);
+
+        boolean match = attributes.stream()
+                .filter(WorkspaceAdminRestAccessRule.class::isInstance)
+                .map(WorkspaceAdminRestAccessRule.class::cast)
+                .anyMatch(rule -> rule.matches(uri, method));
+
+        return match ? ACCESS_GRANTED : ACCESS_ABSTAIN;
+    }
+
+    /**
+     * Replacement for {@link UrlUtils#buildRequestUrl()} because it adds a {@code ?} trailing character even if the
+     * querystring is empty
+     */
+    private String buildRequestUrl(HttpServletRequest r) {
+        String servletPath = r.getServletPath();
+        String requestURI = r.getRequestURI();
+        String contextPath = r.getContextPath();
+        String pathInfo = r.getPathInfo();
+        String queryString = r.getQueryString();
+        StringBuilder url = new StringBuilder();
+        if (servletPath != null) {
+            url.append(servletPath);
+            if (pathInfo != null) {
+                url.append(pathInfo);
+            }
+        } else {
+            url.append(requestURI.substring(contextPath.length()));
+        }
+        if (StringUtils.hasLength(queryString)) {
+            url.append("?").append(queryString);
+        }
+        return url.toString();
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizer.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizer.java
@@ -1,0 +1,272 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static java.util.Objects.requireNonNull;
+import static org.geoserver.platform.GeoServerExtensions.bean;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.RESTfulDefinitionSource;
+import org.geoserver.security.RESTfulDefinitionSourceProxy;
+import org.geoserver.security.ResourceAccessManager;
+import org.geoserver.security.SecureCatalogImpl;
+import org.geoserver.security.WorkspaceAccessLimits;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * Central authorization component for workspace administrators in GeoServer.
+ *
+ * <p>This class provides a unified authorization mechanism for determining whether a user with workspace administration
+ * privileges can access specific resources, both in the web UI and the REST API. It serves as the cornerstone of
+ * GeoServer's fine-grained access control system for workspace administrators.
+ *
+ * <p>The WorkspaceAdminAuthorizer:
+ *
+ * <ul>
+ *   <li>Determines if a user is a workspace administrator
+ *   <li>Identifies which workspaces a user can administer
+ *   <li>Evaluates access permissions for REST API endpoints and resources
+ *   <li>Manages performance through request-scoped caching of authorization decisions
+ * </ul>
+ *
+ * <p><strong>REST API Access Control</strong>
+ *
+ * <p>For REST API access, this class works with {@link WorkspaceAdminRestfulDefinitionSource} as a delegate to the
+ * {@link RESTfulDefinitionSourceProxy} to enforce URL pattern-based security rules for workspace administrators. It
+ * uses the access rule values:
+ *
+ * <ul>
+ *   <li>{@code r} = Read operations ({@code GET, HEAD, OPTIONS, TRACE})
+ *   <li>{@code w} = Write operations ({@code POST, PUT, PATCH, DELETE})
+ *   <li>{@code rw} = All operations ({@code r + w})
+ * </ul>
+ *
+ * <p><strong>Default Access Rules</strong>
+ *
+ * <p>By default, workspace administrators have these permissions:
+ *
+ * <pre>
+ * /rest/workspaces/{workspace}/**:*=rw       (Full control over their workspaces)
+ * /rest/namespaces/{workspace}/**:*=rw       (Full control over related namespaces)
+ * /rest/layers/{workspace}:*=rw              (Full control over workspace layers)
+ * /rest/resource/workspaces/{workspace}=rw   (Full control over workspace resources)
+ * /rest/resource/workspaces=r               (Read-only access to workspaces list)
+ * /rest=r                                   (Read-only access to REST API root)
+ * </pre>
+ *
+ * <p>This pattern-based system allows for flexible and fine-grained control over which REST endpoints and resources a
+ * workspace administrator can access.
+ *
+ * <p><strong>Implementation Details</strong>
+ *
+ * <p>The authorizer uses {@link GeoServerExtensions} to access the {@link Catalog} and {@link SecureCatalogImpl}. The
+ * catalog filters which workspaces an {@code Authentication} can see, while the secure catalog provides access to the
+ * {@link ResourceAccessManager} which determines administrator privileges for specific workspaces.
+ *
+ * @see RESTfulDefinitionSource
+ * @see WorkspaceAdminRESTAccessRuleDAO
+ * @see WorkspaceAdminRestfulDefinitionSource
+ * @see ResourceAccessManager#isWorkspaceAdmin(Authentication, Catalog)
+ */
+public class WorkspaceAdminAuthorizer {
+
+    /**
+     * Key to cache the result of {@link #isWorkspaceAdmin(Authentication)} on the request's {@link RequestAttributes}
+     * in {@link RequestAttributes#SCOPE_REQUEST request scope}
+     */
+    static final String WSADMIN_REQUEST_CONTEXT_KEY = "WORKSPACEADMIN_AUTHORIZER_VALUE";
+
+    private WorkspaceAdminRESTAccessRuleDAO dao;
+
+    public WorkspaceAdminAuthorizer(WorkspaceAdminRESTAccessRuleDAO dao) {
+        Objects.requireNonNull(dao, "AbstractAccessRuleDAO<WorkspaceAdminRestAccessRule> is null");
+        this.dao = dao;
+    }
+
+    public static Optional<WorkspaceAdminAuthorizer> get() {
+        return Optional.ofNullable(bean(WorkspaceAdminAuthorizer.class));
+    }
+
+    /**
+     * Determines if the given authentication can access the specified URI and HTTP method. Access is granted if the
+     * user is a GeoServer admin or if the user is a workspace admin and the URI/method matches one of the configured
+     * access rules.
+     *
+     * @param authentication the authentication to check
+     * @param requestUri the request URI to check
+     * @param method the HTTP method being used
+     * @return true if access should be granted, false otherwise
+     */
+    public boolean canAccess(Authentication authentication, String requestUri, HttpMethod method) {
+        return isAdmin() || (matches(requestUri, method) && isWorkspaceAdmin(authentication));
+    }
+
+    /**
+     * Returns an immutable list of all configured workspace admin access rules.
+     *
+     * @return list of all access rules
+     */
+    List<WorkspaceAdminRestAccessRule> getAccessRules() {
+        return List.copyOf(dao.getRules());
+    }
+
+    /**
+     * Finds the first rule that matches the given URL and HTTP method.
+     *
+     * @param url the URL to match
+     * @param method the HTTP method to match
+     * @return an Optional containing the first matching rule, or empty if no rules match
+     */
+    Optional<WorkspaceAdminRestAccessRule> findMatchingRule(String url, HttpMethod method) {
+        return dao.getRules().stream().filter(rule -> rule.matches(url, method)).findFirst();
+    }
+
+    /**
+     * Checks if the given URI and method match any configured access rule.
+     *
+     * @param uri the URI to check
+     * @param method the HTTP method to check
+     * @return true if a matching rule is found, false otherwise
+     */
+    private boolean matches(String uri, HttpMethod method) {
+        return findMatchingRule(uri, method).isPresent();
+    }
+
+    /**
+     * Determines if the current user has the admin role.
+     *
+     * @return true if the user has the admin role, false otherwise
+     */
+    private boolean isAdmin() {
+        GeoServerSecurityManager manager = requireNonNull(bean(GeoServerSecurityManager.class));
+        return manager.checkAuthenticationForAdminRole();
+    }
+
+    /**
+     * Determines if the given authentication represents a workspace administrator. The result is cached per request for
+     * performance.
+     *
+     * <p>This authorizer may be called several times per request, use a per-request cached value
+     *
+     * @param authentication the authentication to check
+     * @return true if the authentication represents a workspace administrator, false otherwise
+     */
+    public boolean isWorkspaceAdmin(Authentication authentication) {
+        // if not authenticated deny access
+        Boolean workspaceAdmin = false;
+        if (isFullyAuthenticated(authentication)) {
+            workspaceAdmin = getRequestScopeCachedValue().orElseGet(() -> checkIsWorkspaceAdmin(authentication));
+            setRequestScopeCachedValue(workspaceAdmin);
+        }
+        return workspaceAdmin;
+    }
+
+    private boolean checkIsWorkspaceAdmin(Authentication authentication) {
+        ResourceAccessManager accessManager = getAccessManager();
+        if (accessManager == null) {
+            return false;
+        }
+        Catalog catalog = getCatalog();
+        return accessManager.isWorkspaceAdmin(authentication, catalog);
+    }
+
+    /**
+     * Checks if the given authentication represents a fully authenticated user (authenticated and not anonymous).
+     *
+     * @param auth the authentication to check
+     * @return true if the authentication is valid and not anonymous, false otherwise
+     */
+    boolean isFullyAuthenticated(Authentication auth) {
+        return null != auth && auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken);
+    }
+
+    /**
+     * Caches the workspace admin status of a user in the current request scope, since
+     * {@link #isWorkspaceAdmin(Authentication)} can be called multiple times for a single request.
+     *
+     * @param workspaceAdmin true if the user is a workspace admin, false otherwise
+     */
+    void setRequestScopeCachedValue(boolean workspaceAdmin) {
+        RequestAttributes atts = RequestContextHolder.getRequestAttributes();
+        if (null != atts) {
+            atts.setAttribute(WSADMIN_REQUEST_CONTEXT_KEY, workspaceAdmin, SCOPE_REQUEST);
+        }
+    }
+
+    /**
+     * Retrieves the cached workspace admin status from the current request scope.
+     *
+     * @return the cached status if available, empty otherwise
+     */
+    private Optional<Boolean> getRequestScopeCachedValue() {
+        RequestAttributes atts = RequestContextHolder.getRequestAttributes();
+        if (atts == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable((Boolean) atts.getAttribute(WSADMIN_REQUEST_CONTEXT_KEY, SCOPE_REQUEST));
+    }
+
+    /**
+     * Gets the ResourceAccessManager from the SecureCatalog.
+     *
+     * @return the resource access manager
+     */
+    protected ResourceAccessManager getAccessManager() {
+        // the secure catalog builds and owns the ResourceAccessManager
+        return getSecureCatalog().getResourceAccessManager();
+    }
+
+    /**
+     * Gets the SecureCatalogImpl from the application context.
+     *
+     * @return the secure catalog implementation
+     * @throws NullPointerException if the secure catalog is not found
+     */
+    private SecureCatalogImpl getSecureCatalog() {
+        return requireNonNull(bean(SecureCatalogImpl.class));
+    }
+
+    /**
+     * Gets the catalog from the GeoServer instance.
+     *
+     * @return the catalog
+     * @throws NullPointerException if either GeoServer or the catalog is not found
+     */
+    private Catalog getCatalog() {
+        return requireNonNull(bean(GeoServer.class)).getCatalog();
+    }
+
+    /**
+     * Gets the workspace access limits for the given authentication and workspace.
+     *
+     * @param authentication the authentication to check
+     * @param workspaceName the name of the workspace
+     * @return the workspace access limits, or null if the workspace doesn't exist or the user has no access
+     */
+    @Nullable
+    public WorkspaceAccessLimits getWorkspaceAccessLimits(Authentication authentication, final String workspaceName) {
+        WorkspaceAccessLimits wsAccessLimits = null;
+        Catalog catalog = getCatalog();
+        WorkspaceInfo workspace = catalog.getWorkspaceByName(workspaceName);
+        if (workspace != null) {
+            ResourceAccessManager accessManager = getAccessManager();
+            wsAccessLimits = accessManager.getAccessLimits(authentication, workspace);
+        }
+        return wsAccessLimits;
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizer.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizer.java
@@ -1,0 +1,154 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static java.util.Objects.requireNonNull;
+import static org.geoserver.platform.GeoServerExtensions.bean;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.RESTfulDefinitionSource;
+import org.geoserver.security.ResourceAccessManager;
+import org.geoserver.security.SecureCatalogImpl;
+import org.geoserver.security.WorkspaceAccessLimits;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * Determines whether an authenticated user is a workspace administrator, and whether a request URI and HTTP method
+ * match the configured workspace admin REST access rules.
+ *
+ * <p>Shared by the web UI ({@code WorkspaceAdminComponentAuthorizer}) and the REST API
+ * ({@link WorkspaceAdminRestfulDefinitionSource}, {@link WorkspaceAdminAuthorizationManager}). The access rules are
+ * loaded by {@link WorkspaceAdminRESTAccessRuleDAO} from {@code security/rest.workspaceadmin.properties}.
+ *
+ * <p>The workspace admin check delegates to {@link ResourceAccessManager#isWorkspaceAdmin(Authentication, Catalog)} and
+ * caches the result in request scope, since it can be called several times while processing a single request.
+ *
+ * @see RESTfulDefinitionSource
+ * @see WorkspaceAdminRESTAccessRuleDAO
+ */
+public class WorkspaceAdminAuthorizer {
+
+    /**
+     * Key to cache the result of {@link #isWorkspaceAdmin(Authentication)} on the request's {@link RequestAttributes}
+     * in {@link RequestAttributes#SCOPE_REQUEST request scope}
+     */
+    static final String WSADMIN_REQUEST_CONTEXT_KEY = "WORKSPACEADMIN_AUTHORIZER_VALUE";
+
+    private WorkspaceAdminRESTAccessRuleDAO dao;
+
+    public WorkspaceAdminAuthorizer(WorkspaceAdminRESTAccessRuleDAO dao) {
+        Objects.requireNonNull(dao, "AbstractAccessRuleDAO<WorkspaceAdminRestAccessRule> is null");
+        this.dao = dao;
+    }
+
+    public static Optional<WorkspaceAdminAuthorizer> get() {
+        return Optional.ofNullable(bean(WorkspaceAdminAuthorizer.class));
+    }
+
+    /**
+     * Returns true if the user is a full administrator, or is a workspace administrator and the URI and method match
+     * one of the configured access rules.
+     */
+    public boolean canAccess(Authentication authentication, String requestUri, HttpMethod method) {
+        return isAdmin() || (matches(requestUri, method) && isWorkspaceAdmin(authentication));
+    }
+
+    List<WorkspaceAdminRestAccessRule> getAccessRules() {
+        return List.copyOf(dao.getRules());
+    }
+
+    Optional<WorkspaceAdminRestAccessRule> findMatchingRule(String url, HttpMethod method) {
+        return dao.getRules().stream().filter(rule -> rule.matches(url, method)).findFirst();
+    }
+
+    private boolean matches(String uri, HttpMethod method) {
+        return findMatchingRule(uri, method).isPresent();
+    }
+
+    private boolean isAdmin() {
+        GeoServerSecurityManager manager = requireNonNull(bean(GeoServerSecurityManager.class));
+        return manager.checkAuthenticationForAdminRole();
+    }
+
+    /**
+     * Determines if the given authentication represents a workspace administrator, caching the result in request scope
+     * since this can be called several times per request. Anonymous or unauthenticated users are never workspace
+     * administrators.
+     */
+    public boolean isWorkspaceAdmin(Authentication authentication) {
+        Boolean workspaceAdmin = false;
+        if (isFullyAuthenticated(authentication)) {
+            workspaceAdmin = getRequestScopeCachedValue().orElseGet(() -> checkIsWorkspaceAdmin(authentication));
+            setRequestScopeCachedValue(workspaceAdmin);
+        }
+        return workspaceAdmin;
+    }
+
+    private boolean checkIsWorkspaceAdmin(Authentication authentication) {
+        ResourceAccessManager accessManager = getAccessManager();
+        if (accessManager == null) {
+            return false;
+        }
+        Catalog catalog = getCatalog();
+        return accessManager.isWorkspaceAdmin(authentication, catalog);
+    }
+
+    boolean isFullyAuthenticated(Authentication auth) {
+        return null != auth && auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken);
+    }
+
+    void setRequestScopeCachedValue(boolean workspaceAdmin) {
+        RequestAttributes atts = RequestContextHolder.getRequestAttributes();
+        if (null != atts) {
+            atts.setAttribute(WSADMIN_REQUEST_CONTEXT_KEY, workspaceAdmin, SCOPE_REQUEST);
+        }
+    }
+
+    private Optional<Boolean> getRequestScopeCachedValue() {
+        RequestAttributes atts = RequestContextHolder.getRequestAttributes();
+        if (atts == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable((Boolean) atts.getAttribute(WSADMIN_REQUEST_CONTEXT_KEY, SCOPE_REQUEST));
+    }
+
+    protected ResourceAccessManager getAccessManager() {
+        // the secure catalog builds and owns the ResourceAccessManager
+        return getSecureCatalog().getResourceAccessManager();
+    }
+
+    private SecureCatalogImpl getSecureCatalog() {
+        return requireNonNull(bean(SecureCatalogImpl.class));
+    }
+
+    private Catalog getCatalog() {
+        return requireNonNull(bean(GeoServer.class)).getCatalog();
+    }
+
+    /** Returns the access limits for the given workspace, or null if the workspace does not exist. */
+    @Nullable
+    public WorkspaceAccessLimits getWorkspaceAccessLimits(Authentication authentication, final String workspaceName) {
+        WorkspaceAccessLimits wsAccessLimits = null;
+        Catalog catalog = getCatalog();
+        WorkspaceInfo workspace = catalog.getWorkspaceByName(workspaceName);
+        if (workspace != null) {
+            ResourceAccessManager accessManager = getAccessManager();
+            wsAccessLimits = accessManager.getAccessLimits(authentication, workspace);
+        }
+        return wsAccessLimits;
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRESTAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRESTAccessRuleDAO.java
@@ -1,0 +1,213 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.security.workspaceadmin;
+
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
+import static org.springframework.http.HttpMethod.OPTIONS;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.TRACE;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.security.impl.AbstractAccessRuleDAO;
+import org.geoserver.util.LinkedProperties;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.StringUtils;
+
+/**
+ * Data access object for workspace administrator REST API security rules.
+ *
+ * <p>This class is responsible for loading, managing, and providing access to the security rules that control which
+ * REST API endpoints workspace administrators can access. It extends {@link AbstractAccessRuleDAO} to inherit common
+ * functionality for rule management.
+ *
+ * <p>The rules are loaded from the "rest.workspaceadmin.properties" file in the GeoServer data directory's security
+ * folder. If the file doesn't exist, it's initialized from the classpath template
+ * "rest.workspaceadmin.properties.template" which contains the default workspace administrator access rules.
+ *
+ * <p>REST endpoints that don't match any pattern in the rest.workspaceadmin.properties file fall back to the global
+ * REST security configuration (rest.properties), which typically restricts access to administrators only. The default
+ * template includes patterns for workspace-specific resources that workspace administrators need to manage their
+ * workspaces while restricting access to other areas of the API.
+ *
+ * <p>Rules are defined in properties files with the format:
+ *
+ * <pre>
+ * /url/pattern=METHOD1,METHOD2,...
+ * </pre>
+ *
+ * <p>Where methods can use these shorthand values:
+ *
+ * <ul>
+ *   <li>{@code r} = Read operations ({@code GET, HEAD, OPTIONS, TRACE})
+ *   <li>{@code w} = Write operations ({@code POST, PUT, PATCH, DELETE})
+ *   <li>{@code rw} = All operations ({@code r + w})
+ * </ul>
+ *
+ * <p>This class maintains rules in a sorted collection based on priority, allowing the most specific rules to be
+ * evaluated first.
+ *
+ * @see WorkspaceAdminRestAccessRule
+ * @see WorkspaceAdminRestfulDefinitionSource
+ * @see WorkspaceAdminAuthorizer
+ */
+public class WorkspaceAdminRESTAccessRuleDAO extends AbstractAccessRuleDAO<WorkspaceAdminRestAccessRule>
+        implements InitializingBean {
+
+    private static final List<HttpMethod> READ_METHODS = List.of(GET, HEAD, OPTIONS, TRACE);
+    private static final List<HttpMethod> WRITE_METHODS = List.of(POST, PUT, PATCH, DELETE);
+    private static final List<HttpMethod> READ_WRITE_METHODS = List.copyOf(
+            Stream.concat(READ_METHODS.stream(), WRITE_METHODS.stream()).collect(Collectors.toList()));
+    /**
+     * The file under {@literal security/} to load rules from. AbstractAccessRuleDAO will initialize it from the
+     * classpath's rest.workspaceadmin.properties.template if the file doesn't exist.
+     */
+    private static final String WORKSPACEADMIN_REST_PROPERTIES = "rest.workspaceadmin.properties";
+
+    /**
+     * Creates a new DAO for workspace administrator REST access rules.
+     *
+     * @param dd the GeoServer data directory to read configuration from
+     * @throws IOException if there is an error accessing the data directory
+     */
+    public WorkspaceAdminRESTAccessRuleDAO(GeoServerDataDirectory dd) throws IOException {
+        super(dd, WORKSPACEADMIN_REST_PROPERTIES);
+    }
+
+    /**
+     * Force loading the rules and initializing the {@code security/rest.workspaceadmin.properties} file with the
+     * default rules if it doesn't exist
+     */
+    @Override
+    public void afterPropertiesSet() {
+        checkPropertyFile(false);
+    }
+
+    /**
+     * Converts the current rules to a Properties object for persistence.
+     *
+     * <p>Each rule is stored as a property with the Ant pattern as the key and a comma-separated list of method names
+     * as the value.
+     *
+     * @return a Properties object containing the current rules
+     */
+    @Override
+    protected Properties toProperties() {
+        // LinkedProperties used to maintain order
+        LinkedProperties props = new LinkedProperties();
+        for (WorkspaceAdminRestAccessRule rule : rules) {
+            props.setProperty(rule.getAntPattern(), rule.methods());
+        }
+        return props;
+    }
+
+    /**
+     * Loads rules from the provided properties.
+     *
+     * <p>This method:
+     *
+     * <ol>
+     *   <li>Loads the user-configured rules from the properties
+     *   <li>Merges them, with configured rules taking precedence
+     *   <li>Clears the existing rules and adds the merged set
+     * </ol>
+     *
+     * @param props the properties to load rules from
+     */
+    @Override
+    protected void loadRules(Properties props) {
+        rules = new ConcurrentSkipListSet<>(loadInternal(props));
+    }
+
+    /**
+     * Creates rules from the provided properties with sequential priorities.
+     *
+     * <p>Each property entry is converted to a rule with:
+     *
+     * <ul>
+     *   <li>The key as the Ant pattern
+     *   <li>The value as a comma-separated list of HTTP methods or shorthand values
+     *   <li>A sequential priority to maintain the declared order of the rules
+     * </ul>
+     *
+     * @param props the properties to convert to rules
+     * @return a list of rules created from the properties
+     */
+    private List<WorkspaceAdminRestAccessRule> loadInternal(Properties props) {
+        AtomicInteger priority = new AtomicInteger(0);
+        return props.entrySet().stream()
+                .map(e -> {
+                    String antPattern = (String) e.getKey();
+                    Set<HttpMethod> methods = parseMethods((String) e.getValue());
+                    int p = priority.getAndIncrement();
+                    return new WorkspaceAdminRestAccessRule(p, antPattern, methods);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Parses a comma-separated string of HTTP methods or shorthand values.
+     *
+     * <p>This method:
+     *
+     * <ol>
+     *   <li>Splits the input string by commas
+     *   <li>Trims and uppercases each part
+     *   <li>Filters out empty parts
+     *   <li>Maps shorthand values (R, W, RW) to actual HTTP methods
+     *   <li>Collects the results into a set
+     * </ol>
+     *
+     * @param values the comma-separated string of methods
+     * @return a set of HTTP methods
+     */
+    Set<HttpMethod> parseMethods(String values) {
+        return Stream.of(values.split(","))
+                .map(String::trim)
+                .map(String::toUpperCase)
+                .filter(StringUtils::hasText)
+                .map(this::mapMethods)
+                .flatMap(List::stream)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Maps a method string to a list of HTTP methods.
+     *
+     * <p>Handles shorthand values:
+     *
+     * <ul>
+     *   <li>R = GET, HEAD, OPTIONS, TRACE (read operations)
+     *   <li>W = POST, PUT, PATCH, DELETE (write operations)
+     *   <li>RW = R + W (all operations)
+     * </ul>
+     *
+     * <p>For any other value, it assumes the string is a valid HTTP method name (like "GET" or "POST") and returns it
+     * directly.
+     *
+     * @param value the method string to map
+     * @return a list of HTTP methods
+     */
+    private List<HttpMethod> mapMethods(String value) {
+        if ("R".equalsIgnoreCase(value)) return READ_METHODS;
+        if ("W".equalsIgnoreCase(value)) return WRITE_METHODS;
+        if ("RW".equalsIgnoreCase(value)) return READ_WRITE_METHODS;
+
+        return List.of(HttpMethod.valueOf(value));
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRESTAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRESTAccessRuleDAO.java
@@ -1,0 +1,112 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.security.workspaceadmin;
+
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
+import static org.springframework.http.HttpMethod.OPTIONS;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.TRACE;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.security.impl.AbstractAccessRuleDAO;
+import org.geoserver.util.LinkedProperties;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.StringUtils;
+
+/**
+ * Loads and manages the REST API access rules for workspace administrators.
+ *
+ * <p>Rules are read from {@code security/rest.workspaceadmin.properties} in the data directory, initialized from the
+ * classpath template {@code rest.workspaceadmin.properties.template} when the file doesn't exist. Each entry has the
+ * form {@code /url/pattern=METHOD1,METHOD2,...}, where a method is an HTTP method name or one of the shorthands
+ * {@code r} (GET, HEAD, OPTIONS, TRACE), {@code w} (POST, PUT, PATCH, DELETE), or {@code rw} (both).
+ *
+ * <p>Rules are evaluated in declaration order. Requests matching no rule fall back to the global REST security
+ * configuration ({@code rest.properties}), which typically restricts access to full administrators.
+ *
+ * @see WorkspaceAdminRestAccessRule
+ * @see WorkspaceAdminAuthorizer
+ */
+public class WorkspaceAdminRESTAccessRuleDAO extends AbstractAccessRuleDAO<WorkspaceAdminRestAccessRule>
+        implements InitializingBean {
+
+    private static final List<HttpMethod> READ_METHODS = List.of(GET, HEAD, OPTIONS, TRACE);
+    private static final List<HttpMethod> WRITE_METHODS = List.of(POST, PUT, PATCH, DELETE);
+    private static final List<HttpMethod> READ_WRITE_METHODS = List.copyOf(
+            Stream.concat(READ_METHODS.stream(), WRITE_METHODS.stream()).collect(Collectors.toList()));
+    /** The file under {@literal security/} to load rules from, initialized from the classpath template if missing. */
+    private static final String WORKSPACEADMIN_REST_PROPERTIES = "rest.workspaceadmin.properties";
+
+    public WorkspaceAdminRESTAccessRuleDAO(GeoServerDataDirectory dd) throws IOException {
+        super(dd, WORKSPACEADMIN_REST_PROPERTIES);
+    }
+
+    /** Forces loading the rules at startup, creating the properties file from the template if it doesn't exist. */
+    @Override
+    public void afterPropertiesSet() {
+        checkPropertyFile(false);
+    }
+
+    @Override
+    protected Properties toProperties() {
+        // LinkedProperties used to maintain order
+        LinkedProperties props = new LinkedProperties();
+        for (WorkspaceAdminRestAccessRule rule : rules) {
+            props.setProperty(rule.getAntPattern(), rule.methods());
+        }
+        return props;
+    }
+
+    @Override
+    protected void loadRules(Properties props) {
+        rules = new ConcurrentSkipListSet<>(loadInternal(props));
+    }
+
+    /** Assigns sequential priorities to the rules to preserve their declaration order. */
+    private List<WorkspaceAdminRestAccessRule> loadInternal(Properties props) {
+        AtomicInteger priority = new AtomicInteger(0);
+        return props.entrySet().stream()
+                .map(e -> {
+                    String antPattern = (String) e.getKey();
+                    Set<HttpMethod> methods = parseMethods((String) e.getValue());
+                    int p = priority.getAndIncrement();
+                    return new WorkspaceAdminRestAccessRule(p, antPattern, methods);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /** Parses a comma-separated list of HTTP method names or the {@code r}/{@code w}/{@code rw} shorthands. */
+    Set<HttpMethod> parseMethods(String values) {
+        return Stream.of(values.split(","))
+                .map(String::trim)
+                .map(String::toUpperCase)
+                .filter(StringUtils::hasText)
+                .map(this::mapMethods)
+                .flatMap(List::stream)
+                .collect(Collectors.toSet());
+    }
+
+    private List<HttpMethod> mapMethods(String value) {
+        if ("R".equalsIgnoreCase(value)) return READ_METHODS;
+        if ("W".equalsIgnoreCase(value)) return WRITE_METHODS;
+        if ("RW".equalsIgnoreCase(value)) return READ_WRITE_METHODS;
+
+        return List.of(HttpMethod.valueOf(value));
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestAccessRule.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestAccessRule.java
@@ -1,0 +1,211 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.util.AntPathMatcher;
+
+/**
+ * Represents a REST API access rule for workspace administrators.
+ *
+ * <p>This class defines URL patterns and HTTP methods that workspace administrators are allowed to access. Each rule
+ * consists of:
+ *
+ * <ul>
+ *   <li>An Ant-style URL pattern (e.g., "/rest/workspaces/{workspace}/**")
+ *   <li>A set of permitted HTTP methods (e.g., GET, POST, PUT, etc.)
+ *   <li>A priority value used for rule ordering
+ * </ul>
+ *
+ * <p>Rules are defined in the security/rest.workspaceadmin.properties file and loaded by the
+ * {@link WorkspaceAdminRESTAccessRuleDAO}. The file is initially populated from a template with default rules that
+ * allow workspace administrators to manage resources within their assigned workspaces.
+ *
+ * <p>Rules have the format:
+ *
+ * <pre>
+ * /url/pattern=METHOD1,METHOD2,...
+ * </pre>
+ *
+ * <p>Where methods can use shorthand values:
+ *
+ * <ul>
+ *   <li>r = Read operations (GET, HEAD, OPTIONS, TRACE)
+ *   <li>w = Write operations (POST, PUT, PATCH, DELETE)
+ *   <li>rw = All operations (read + write)
+ * </ul>
+ *
+ * <p>When evaluating access, rules with lower priority values (higher priority) are evaluated before rules with higher
+ * values.
+ *
+ * <p>The class implements {@link ConfigAttribute} to integrate with Spring Security's authorization framework and
+ * {@link Comparable} to allow sorting rules by priority.
+ *
+ * <p>Examples of rule patterns:
+ *
+ * <pre>
+ * /rest/workspaces/{workspace}/**   - All URLs under a specific workspace
+ * /rest/namespaces/{workspace}/**    - All namespace URLs for a specific workspace
+ * /rest/layers/{workspace}:*         - Layer resources for a specific workspace
+ * /rest/resource/workspaces          - The workspaces resource collection
+ * </pre>
+ *
+ * @see WorkspaceAdminRESTAccessRuleDAO
+ * @see WorkspaceAdminAuthorizationManager
+ * @see WorkspaceAdminRestfulDefinitionSource
+ */
+@SuppressWarnings({"serial", "deprecation"})
+public class WorkspaceAdminRestAccessRule implements ConfigAttribute, Comparable<WorkspaceAdminRestAccessRule> {
+
+    /** The path matcher used to compare request URLs against the rule's Ant pattern. */
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+    /**
+     * The Ant-style pattern defining which URLs this rule applies to. May contain wildcards and path variables like
+     * {workspace}.
+     */
+    private String antPattern;
+
+    /** The set of HTTP methods (GET, POST, PUT, etc.) allowed by this rule. */
+    private Set<HttpMethod> methods;
+
+    /**
+     * The priority of this rule, used for ordering when multiple rules might apply. Lower values indicate higher
+     * priority.
+     */
+    private int priority;
+
+    /**
+     * Creates a new REST access rule for workspace administrators.
+     *
+     * @param priority the rule priority (lower values are evaluated first)
+     * @param antPattern the Ant-style URL pattern this rule applies to
+     * @param methods the set of HTTP methods allowed by this rule
+     */
+    public WorkspaceAdminRestAccessRule(int priority, String antPattern, Set<HttpMethod> methods) {
+        this.priority = priority;
+        this.antPattern = antPattern;
+        this.methods = Set.copyOf(methods);
+    }
+
+    /**
+     * Returns the Ant-style URL pattern for this rule.
+     *
+     * @return the URL pattern
+     */
+    public String getAntPattern() {
+        return antPattern;
+    }
+
+    /**
+     * Returns the set of HTTP methods allowed by this rule.
+     *
+     * @return the allowed HTTP methods
+     */
+    public Set<HttpMethod> getMethods() {
+        return methods;
+    }
+
+    /**
+     * Determines if this rule matches the given URI and HTTP method.
+     *
+     * <p>A match occurs when:
+     *
+     * <ol>
+     *   <li>The HTTP method is contained in this rule's allowed methods
+     *   <li>The URI matches this rule's Ant pattern according to Spring's AntPathMatcher
+     * </ol>
+     *
+     * @param uri the URI to check against this rule's pattern
+     * @param method the HTTP method to check against this rule's allowed methods
+     * @return true if both the URI and method match this rule, false otherwise
+     */
+    public boolean matches(String uri, HttpMethod method) {
+        int i;
+        if ((i = uri.indexOf('?')) > -1) {
+            uri = uri.substring(0, i);
+        }
+        return methods.contains(method) && PATH_MATCHER.match(antPattern, uri);
+    }
+
+    /**
+     * Returns a string representation of this rule as required by the ConfigAttribute interface.
+     *
+     * <p>The format is "antPattern=METHOD1,METHOD2,..." where the methods are sorted alphabetically.
+     *
+     * @return a string representation of this rule
+     */
+    @Override
+    public String getAttribute() {
+        return String.format("%s=%s", antPattern, methods());
+    }
+
+    /**
+     * Returns a comma-separated string of HTTP method names in alphabetical order.
+     *
+     * @return a string representation of the allowed HTTP methods
+     */
+    public String methods() {
+        return methods.stream().map(HttpMethod::name).sorted().collect(Collectors.joining(","));
+    }
+
+    /**
+     * Compares this rule to another based on priority.
+     *
+     * <p>Rules with lower priority values are "less than" rules with higher values, meaning they will appear earlier in
+     * sorted collections.
+     *
+     * @param o the rule to compare to
+     * @return negative if this rule has higher priority, positive if lower, 0 if equal
+     */
+    @Override
+    public int compareTo(WorkspaceAdminRestAccessRule o) {
+        return Integer.compare(priority, o.priority);
+    }
+
+    /**
+     * Generates a hash code based on the antPattern and methods.
+     *
+     * <p>Note that priority is deliberately excluded from the hash code calculation as it affects ordering but not the
+     * rule's semantic identity.
+     *
+     * @return a hash code for this rule
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(antPattern, methods);
+    }
+
+    /**
+     * Determines if this rule is equal to another object.
+     *
+     * <p>Rules are considered equal if they have the same antPattern and methods. The priority is deliberately excluded
+     * from equality checks as it affects ordering but not the rule's semantic identity.
+     *
+     * @param obj the object to compare to
+     * @return true if the objects are equal, false otherwise
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof WorkspaceAdminRestAccessRule other) {
+            return Objects.equals(antPattern, other.antPattern) && Objects.equals(methods, other.methods);
+        }
+        return false;
+    }
+
+    /**
+     * Returns a string representation of this rule, equivalent to getAttribute().
+     *
+     * @return a string representation of this rule
+     */
+    @Override
+    public String toString() {
+        return getAttribute();
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestAccessRule.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestAccessRule.java
@@ -1,0 +1,98 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.util.AntPathMatcher;
+
+/**
+ * A single REST access rule for workspace administrators: an Ant-style URL pattern, the set of HTTP methods it allows,
+ * and a priority determining evaluation order (lower values first).
+ *
+ * <p>Rules are loaded by {@link WorkspaceAdminRESTAccessRuleDAO} from {@code security/rest.workspaceadmin.properties}.
+ * Implements {@link ConfigAttribute} to integrate with Spring Security's authorization framework.
+ */
+@SuppressWarnings({"serial", "deprecation"})
+public class WorkspaceAdminRestAccessRule implements ConfigAttribute, Comparable<WorkspaceAdminRestAccessRule> {
+
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+    private String antPattern;
+
+    private Set<HttpMethod> methods;
+
+    private int priority;
+
+    public WorkspaceAdminRestAccessRule(int priority, String antPattern, Set<HttpMethod> methods) {
+        this.priority = priority;
+        this.antPattern = antPattern;
+        this.methods = Set.copyOf(methods);
+    }
+
+    public String getAntPattern() {
+        return antPattern;
+    }
+
+    public Set<HttpMethod> getMethods() {
+        return methods;
+    }
+
+    /** Returns true if the method is allowed and the URI, ignoring any query string, matches the Ant pattern. */
+    public boolean matches(String uri, HttpMethod method) {
+        int i;
+        if ((i = uri.indexOf('?')) > -1) {
+            uri = uri.substring(0, i);
+        }
+        return methods.contains(method) && PATH_MATCHER.match(antPattern, uri);
+    }
+
+    /** Returns this rule as {@code antPattern=METHOD1,METHOD2,...} with the methods sorted alphabetically. */
+    @Override
+    public String getAttribute() {
+        return String.format("%s=%s", antPattern, methods());
+    }
+
+    /** Returns the allowed HTTP method names, comma-separated and sorted alphabetically. */
+    public String methods() {
+        return methods.stream().map(HttpMethod::name).sorted().collect(Collectors.joining(","));
+    }
+
+    /** Orders by priority, breaking ties by pattern and methods so sorted sets never drop a distinct rule. */
+    @Override
+    public int compareTo(WorkspaceAdminRestAccessRule o) {
+        int c = Integer.compare(priority, o.priority);
+        if (c == 0) {
+            c = antPattern.compareTo(o.antPattern);
+        }
+        if (c == 0) {
+            c = methods().compareTo(o.methods());
+        }
+        return c;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(priority, antPattern, methods);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof WorkspaceAdminRestAccessRule other) {
+            return priority == other.priority
+                    && Objects.equals(antPattern, other.antPattern)
+                    && Objects.equals(methods, other.methods);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return getAttribute();
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestfulDefinitionSource.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestfulDefinitionSource.java
@@ -1,0 +1,184 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.geoserver.security.RESTfulDefinitionSource;
+import org.geoserver.security.RESTfulDefinitionSourceProxy;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
+import org.springframework.security.web.util.UrlUtils;
+
+/**
+ * Spring Security metadata source that provides access rules for workspace administrators.
+ *
+ * <p>This class implements {@link FilterInvocationSecurityMetadataSource} and is used as a delegate by the
+ * {@link RESTfulDefinitionSourceProxy} to determine which REST API resources workspace administrators are allowed to
+ * access. It works closely with the {@link WorkspaceAdminAuthorizer} to match HTTP requests against defined access
+ * rules.
+ *
+ * <p>When a request comes in, this class:
+ *
+ * <ol>
+ *   <li>Extracts the request URI and HTTP method
+ *   <li>Delegates to the WorkspaceAdminAuthorizer to find a matching rule
+ *   <li>Returns the rule as a ConfigAttribute if found, or an empty list if no rule matches
+ * </ol>
+ *
+ * <p>The actual authorization decision is made by the {@link WorkspaceAdminAuthorizationManager}, which uses this class
+ * to get the applicable rules and then checks if the user has workspace administrator privileges.
+ *
+ * <h3>Rule Format</h3>
+ *
+ * <p>Rules are defined in properties files with the format:
+ *
+ * <pre>
+ * /url/pattern=METHOD1,METHOD2,...
+ * </pre>
+ *
+ * <p>Where methods can use these shorthand values:
+ *
+ * <ul>
+ *   <li>{@code r} = Read operations ({@code GET, HEAD, OPTIONS, TRACE})
+ *   <li>{@code w} = Write operations ({@code POST, PUT, PATCH, DELETE})
+ *   <li>{@code rw} = All operations ({@code r + w})
+ * </ul>
+ *
+ * <p>The default rules in rest.workspaceadmin.properties allow workspace administrators to manage resources within
+ * their assigned workspaces, while endpoints not matching any pattern fall back to the global REST security
+ * configuration, which typically restricts access to administrators only.
+ *
+ * <h3>Default Rules</h3>
+ *
+ * <p>By default, workspace administrators have access to:
+ *
+ * <pre>
+ * # Workspace and catalog endpoints
+ * /rest/workspaces.{ext}=r
+ * /rest/workspaces=r
+ * /rest/workspaces/{workspace}.{ext}=r,PUT  # Can update but not rename workspace
+ * /rest/workspaces/{workspace}=r,PUT  # Can update but not rename workspace
+ * /rest/workspaces/{workspace}/**=rw
+ * /rest/namespaces.{ext}=r
+ * /rest/namespaces=r
+ * /rest/namespaces/{namespace}.{ext}=r,PUT  # Can update but not rename namespace
+ * /rest/namespaces/{namespace}=r,PUT  # Can update but not rename namespace
+ * /rest/namespaces/{namespace}/**=rw
+ * /rest/layers/**=rw  # Filtered by secure catalog to only show layers in managed workspaces
+ * /rest/styles.{ext}=r  # Read-only access to global styles listing
+ * /rest/styles/**=r  # Read-only access to global styles
+ *
+ * # Resource access
+ * /rest/resource/workspaces=r
+ * /rest/resource/workspaces/{workspace}/**=rw
+ * /rest/resource/**=r
+ *
+ * # User account management
+ * /rest/security/self/**=rw
+ *
+ * # General service endpoints
+ * /rest/fonts.{ext}=r
+ * /rest/fonts/**=r
+ * /rest=r
+ * /rest/=r
+ * /rest.{ext}=r
+ * /rest/index=r
+ * /rest/index.{ext}=r
+ * </pre>
+ *
+ * <p>Note that workspace administrators cannot:
+ *
+ * <ul>
+ *   <li>Rename workspaces or namespaces they administer (can only modify other properties)
+ *   <li>Change the default workspace or namespace settings
+ *   <li>Modify global styles (read-only access)
+ * </ul>
+ *
+ * <p>The URL patterns use Spring's AntPathMatcher syntax, with the {workspace} variable being matched against
+ * workspaces the administrator has access to.
+ *
+ * @see RESTfulDefinitionSource
+ * @see RESTfulDefinitionSourceProxy
+ * @see WorkspaceAdminRESTAccessRuleDAO
+ * @see WorkspaceAdminAuthorizationManager
+ * @see WorkspaceAdminAuthorizer
+ */
+@SuppressWarnings("deprecation")
+public class WorkspaceAdminRestfulDefinitionSource implements FilterInvocationSecurityMetadataSource {
+
+    /**
+     * The workspace administrator authorizer that maintains the access rules and provides rule matching functionality.
+     */
+    private WorkspaceAdminAuthorizer authorizer;
+
+    /**
+     * Creates a new definition source for workspace administrator REST API access.
+     *
+     * @param authorizer the authorizer that will provide and match access rules
+     */
+    public WorkspaceAdminRestfulDefinitionSource(WorkspaceAdminAuthorizer authorizer) {
+        this.authorizer = authorizer;
+    }
+
+    /**
+     * Checks if this definition source supports the given class.
+     *
+     * <p>This implementation only supports HTTP servlet requests.
+     *
+     * @param clazz the class to check
+     * @return true if the class is assignable from HttpServletRequest, false otherwise
+     */
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return HttpServletRequest.class.isAssignableFrom(clazz);
+    }
+
+    /**
+     * Returns the security attributes (access rules) that apply to the given object.
+     *
+     * <p>This method:
+     *
+     * <ol>
+     *   <li>Extracts the URI and HTTP method from the request
+     *   <li>Delegates to the {@link WorkspaceAdminAuthorizer} to find a matching rule
+     *   <li>Returns the rule as a ConfigAttribute if found, or an empty list if no match
+     * </ol>
+     *
+     * @param object the object to get attributes for (must be an HttpServletRequest)
+     * @return a collection containing the matching rule, or an empty collection if no rule matches
+     * @throws IllegalArgumentException if the object is not an HttpServletRequest
+     */
+    @Override
+    public Collection<ConfigAttribute> getAttributes(Object object) throws IllegalArgumentException {
+        HttpServletRequest request = (HttpServletRequest) object;
+        String uri = UrlUtils.buildRequestUrl(request);
+        HttpMethod method = HttpMethod.valueOf(request.getMethod());
+
+        return authorizer
+                .findMatchingRule(uri, method)
+                .map(ConfigAttribute.class::cast)
+                .map(List::of)
+                .orElse(List.of());
+    }
+
+    /**
+     * Returns all configuration attributes (access rules) defined for workspace administrators.
+     *
+     * <p>This method returns all access rules from the {@link WorkspaceAdminAuthorizer}, converting them to
+     * ConfigAttribute instances.
+     *
+     * @return a collection of all workspace administrator access rules
+     */
+    @Override
+    public List<ConfigAttribute> getAllConfigAttributes() {
+        return authorizer.getAccessRules().stream()
+                .map(ConfigAttribute.class::cast)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestfulDefinitionSource.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestfulDefinitionSource.java
@@ -1,0 +1,62 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.geoserver.security.RESTfulDefinitionSource;
+import org.geoserver.security.RESTfulDefinitionSourceProxy;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
+import org.springframework.security.web.util.UrlUtils;
+
+/**
+ * Security metadata source that returns the {@link WorkspaceAdminRestAccessRule} matching a request's URI and HTTP
+ * method, or nothing when no rule matches.
+ *
+ * <p>Registered as a delegate of {@link RESTfulDefinitionSourceProxy} alongside the standard
+ * {@link RESTfulDefinitionSource}. The authorization decision itself is made by
+ * {@link WorkspaceAdminAuthorizationManager}, which also checks that the user is a workspace administrator.
+ *
+ * @see WorkspaceAdminRESTAccessRuleDAO
+ */
+@SuppressWarnings("deprecation")
+public class WorkspaceAdminRestfulDefinitionSource implements FilterInvocationSecurityMetadataSource {
+
+    private WorkspaceAdminAuthorizer authorizer;
+
+    public WorkspaceAdminRestfulDefinitionSource(WorkspaceAdminAuthorizer authorizer) {
+        this.authorizer = authorizer;
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return HttpServletRequest.class.isAssignableFrom(clazz);
+    }
+
+    /** Returns the first access rule matching the request, or an empty collection if none matches. */
+    @Override
+    public Collection<ConfigAttribute> getAttributes(Object object) throws IllegalArgumentException {
+        HttpServletRequest request = (HttpServletRequest) object;
+        String uri = UrlUtils.buildRequestUrl(request);
+        HttpMethod method = HttpMethod.valueOf(request.getMethod());
+
+        return authorizer
+                .findMatchingRule(uri, method)
+                .map(ConfigAttribute.class::cast)
+                .map(List::of)
+                .orElse(List.of());
+    }
+
+    @Override
+    public List<ConfigAttribute> getAllConfigAttributes() {
+        return authorizer.getAccessRules().stream()
+                .map(ConfigAttribute.class::cast)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/package-info.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/package-info.java
@@ -1,0 +1,85 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+/**
+ * Provides components for workspace administration security in GeoServer.
+ *
+ * <p>This package contains classes that implement a fine-grained security framework for managing workspace
+ * administrator access rights across both the web UI and REST API. Workspace administrators in GeoServer have limited
+ * administrative privileges, focused only on the workspaces they've been granted access to, in contrast to global
+ * administrators who have unrestricted access to all GeoServer functionality.
+ *
+ * <h2>Key Components</h2>
+ *
+ * <h3>Core Authorization</h3>
+ *
+ * <ul>
+ *   <li>{@link org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer} - Central component that determines
+ *       whether a user is a workspace administrator and which workspaces they can access.
+ *   <li>{@link org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizationManager} - Spring Security integration
+ *       for evaluating workspace admin permissions during HTTP request processing.
+ * </ul>
+ *
+ * <h3>REST API Security</h3>
+ *
+ * <ul>
+ *   <li>{@link org.geoserver.security.workspaceadmin.WorkspaceAdminRestfulDefinitionSource} - Provides URL
+ *       pattern-based security rules for REST API endpoints.
+ *   <li>{@link org.geoserver.security.workspaceadmin.WorkspaceAdminRestAccessRule} - Represents individual REST API
+ *       access rules for workspace administrators.
+ *   <li>{@link org.geoserver.security.workspaceadmin.WorkspaceAdminRESTAccessRuleDAO} - Manages the loading and access
+ *       to workspace admin REST API security rules from the security/rest.workspaceadmin.properties file.
+ * </ul>
+ *
+ * <h2>Security Model</h2>
+ *
+ * <p>The workspace administrator security model is based on several key principles:
+ *
+ * <ol>
+ *   <li><strong>Workspace Scoping</strong> - Administrators are restricted to managing only resources within workspaces
+ *       they've been granted access to.
+ *   <li><strong>Consistent Authorization</strong> - The same authorization logic applies to both the web UI and REST
+ *       API interfaces.
+ *   <li><strong>URL Pattern Matching</strong> - REST API access is controlled through Ant-style pattern matching for
+ *       HTTP requests. Endpoints that don't match any pattern fall back to the global REST security configuration,
+ *       which typically restricts access to administrators only.
+ *   <li><strong>Read/Write Differentiation</strong> - Rules differentiate between read operations (GET, HEAD, OPTIONS,
+ *       TRACE) and write operations (POST, PUT, PATCH, DELETE).
+ *   <li><strong>Extensible Rules</strong> - Access rules are loaded from the security/rest.workspaceadmin.properties
+ *       file and can be extended or customized. When the file doesn't exist, it's initialized from a template.
+ * </ol>
+ *
+ * <h2>Integration Points</h2>
+ *
+ * <p>This package integrates with several other parts of GeoServer:
+ *
+ * <ul>
+ *   <li>Spring Security Framework - For HTTP request authorization
+ *   <li>GeoServer Web UI - For workspace-limited administrative interfaces
+ *   <li>GeoServer REST API - For programmatic access to administrative functions
+ *   <li>GeoServer Catalog - To determine workspace-level permissions
+ *   <li>ResourceAccessManager - For extracting workspace administration privileges
+ * </ul>
+ *
+ * <h2>Usage Examples</h2>
+ *
+ * <p>To check if a user is a workspace administrator:
+ *
+ * <pre>
+ * WorkspaceAdminAuthorizer authorizer = GeoServerExtensions.bean(WorkspaceAdminAuthorizer.class);
+ * boolean isWorkspaceAdmin = authorizer.isWorkspaceAdmin(authentication);
+ * </pre>
+ *
+ * <p>To determine if a workspace administrator can access a specific REST endpoint:
+ *
+ * <pre>
+ * boolean canAccess = authorizer.canAccess(authentication, "/rest/workspaces/myworkspace", HttpMethod.GET);
+ * </pre>
+ *
+ * @see org.geoserver.security.ResourceAccessManager
+ * @see org.geoserver.security.GeoServerSecurityManager
+ * @see org.springframework.security.authorization.AuthorizationManager
+ */
+package org.geoserver.security.workspaceadmin;

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/package-info.java
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/package-info.java
@@ -1,0 +1,21 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+/**
+ * Workspace administrator access control for the REST API.
+ *
+ * <p>Workspace administrators are users that, without being full administrators, can manage the contents of one or more
+ * workspaces, as determined by {@link org.geoserver.security.ResourceAccessManager#isWorkspaceAdmin}. This package
+ * grants them through the REST API the same privileges they already have in the web UI.
+ *
+ * <p>{@link org.geoserver.security.workspaceadmin.WorkspaceAdminRESTAccessRuleDAO} loads Ant-style URL pattern access
+ * rules from {@code security/rest.workspaceadmin.properties}, created from a bundled template on first use.
+ * {@link org.geoserver.security.workspaceadmin.WorkspaceAdminRestfulDefinitionSource} matches requests against those
+ * rules, and {@link org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizationManager} grants access when a rule
+ * matches and {@link org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer} confirms the user is a workspace
+ * administrator, abstaining otherwise. Requests matching no rule fall back to the global REST security configuration
+ * ({@code rest.properties}), which typically restricts access to full administrators.
+ */
+package org.geoserver.security.workspaceadmin;

--- a/src/main/src/main/java/org/geoserver/security/workspaceadmin/rest.workspaceadmin.properties.template
+++ b/src/main/src/main/java/org/geoserver/security/workspaceadmin/rest.workspaceadmin.properties.template
@@ -1,0 +1,107 @@
+# (c) 2024 Open Source Geospatial Foundation - all rights reserved
+# This code is licensed under the GPL 2.0 license, available at the root
+# application directory.
+#
+# Workspace Admin REST API Access Rules
+# --------------------------------------
+# These rules control which REST API endpoints workspace administrators can access,
+# and with which HTTP methods. They do NOT control which workspaces a user can
+# administer -- that is determined by the ResourceAccessManager / security subsystem.
+#
+# This file is copied to security/rest.workspaceadmin.properties in the GeoServer
+# data directory when that file does not exist. Edit the copy in the data directory
+# to customize.
+#
+# IMPORTANT: Rule order matters. Rules are evaluated in order during the Spring Security
+# filter chain, and the first matching rule determines the access decision. Place more
+# specific patterns before more general ones (e.g. /rest/workspaces/{workspace} before
+# /rest/workspaces/{workspace}/**).
+#
+# REST endpoints that don't match any pattern in this file fall back to the global
+# REST security configuration (rest.properties), which typically restricts access
+# to full administrators only. Only add patterns for end-points that workspace
+# administrators should be allowed to access.
+#
+# Format:
+#   /url/pattern=METHOD1,METHOD2,...
+#
+# Shorthand method values:
+#   r  = Read operations (GET, HEAD, OPTIONS, TRACE)
+#   w  = Write operations (POST, PUT, PATCH, DELETE)
+#   rw = All operations (r + w)
+# Or use explicit HTTP methods: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, TRACE
+#
+
+# Workspace and catalog endpoints
+# -------------------------------
+# SecureCatalog filters the actual workspace/layer contents based on the user's
+# manageable workspaces. These rules only open the REST end-points.
+
+# Read-only access to the workspaces collection listing
+/rest/workspaces.{ext}=r
+/rest/workspaces=r
+
+# Read + PUT on individual workspaces (allows updating properties, but not renaming)
+/rest/workspaces/{workspace}.{ext}=r,PUT
+/rest/workspaces/{workspace}=r,PUT
+
+# Full access to sub-resources (datastores, coveragestores, styles, layergroups, etc.)
+/rest/workspaces/{workspace}/**=rw
+
+# Namespaces mirror the workspace rules
+/rest/namespaces.{ext}=r
+/rest/namespaces=r
+
+/rest/namespaces/{namespace}.{ext}=r,PUT
+/rest/namespaces/{namespace}=r,PUT
+
+/rest/namespaces/{namespace}/**=rw
+
+# Layers -- SecureCatalog restricts visibility to manageable workspaces
+/rest/layers/**=rw
+
+# No rule for global layer groups -- workspace-specific layer groups are covered
+# by /rest/workspaces/{workspace}/** above
+
+# Read-only access to global styles (workspace styles are under /rest/workspaces/{workspace}/**)
+/rest/styles.{ext}=r
+/rest/styles/**=r
+
+# Read-only access to global templates (workspace templates are under /rest/workspaces/{workspace}/**)
+/rest/templates.{ext}=r
+/rest/templates/**=r
+
+# Resource access
+# ---------------
+# SecureResourceStore filters contents to manageable workspaces
+/rest/resource/workspaces=r
+/rest/resource/workspaces/{workspace}/**=rw
+# can read global styles
+/rest/resource/styles=r
+/rest/resource/styles/**=r
+/rest/resource/**=r
+
+# User account management
+# -----------------------
+/rest/security/self/**=rw
+
+# OWS service settings (WMS, WFS, WCS, etc.)
+# -------------------------------------------
+# Per-workspace service configuration only -- global service settings (/rest/services/*/settings)
+# fall through to rest.properties (admin-only)
+/rest/services/*/workspaces/{workspace}/**=rw
+
+# General service endpoints
+# -------------------------
+# API root, index, fonts, and CRS lookups -- read-only for discoverability
+/rest/fonts.{ext}=r
+/rest/fonts/**=r
+
+/rest/crs=r
+/rest/crs/**=r
+
+/rest=r
+/rest/=r
+/rest.{ext}=r
+/rest/index=r
+/rest/index.{ext}=r

--- a/src/main/src/test/java/org/geoserver/security/RESTfulDefinitionSourceProxyTest.java
+++ b/src/main/src/test/java/org/geoserver/security/RESTfulDefinitionSourceProxyTest.java
@@ -1,0 +1,157 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.SecurityConfig;
+import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
+
+/** Unit tests for {@link RESTfulDefinitionSourceProxy}. */
+@SuppressWarnings("deprecation")
+public class RESTfulDefinitionSourceProxyTest {
+
+    private RESTfulDefinitionSourceProxy proxy;
+    private FilterInvocationSecurityMetadataSource delegate1;
+    private FilterInvocationSecurityMetadataSource delegate2;
+    private HttpServletRequest request;
+
+    @Before
+    public void setUp() {
+        delegate1 = mock(FilterInvocationSecurityMetadataSource.class);
+        delegate2 = mock(FilterInvocationSecurityMetadataSource.class);
+        request = mock(HttpServletRequest.class);
+
+        // Create proxy with two delegates
+        proxy = new RESTfulDefinitionSourceProxy(Arrays.asList(delegate1, delegate2));
+    }
+
+    @Test
+    public void testSupportsSingleDelegate() {
+        // When at least one delegate supports the class, proxy should support it
+        when(delegate1.supports(HttpServletRequest.class)).thenReturn(true);
+        when(delegate2.supports(HttpServletRequest.class)).thenReturn(false);
+
+        assertTrue(proxy.supports(HttpServletRequest.class));
+
+        // When no delegate supports the class, proxy should not support it
+        when(delegate1.supports(String.class)).thenReturn(false);
+        when(delegate2.supports(String.class)).thenReturn(false);
+
+        assertFalse(proxy.supports(String.class));
+    }
+
+    @Test
+    public void testSupportsMultipleDelegates() {
+        // When both delegates support the class, proxy should support it
+        when(delegate1.supports(HttpServletRequest.class)).thenReturn(true);
+        when(delegate2.supports(HttpServletRequest.class)).thenReturn(true);
+
+        assertTrue(proxy.supports(HttpServletRequest.class));
+    }
+
+    @Test
+    public void testGetAttributesSingleDelegate() {
+        // Create proxy with a single delegate
+        proxy = new RESTfulDefinitionSourceProxy(Collections.singletonList(delegate1));
+
+        // Setup delegate to return some attributes
+        ConfigAttribute attr1 = new SecurityConfig("ROLE_ADMIN");
+        ConfigAttribute attr2 = new SecurityConfig("ROLE_USER");
+        when(delegate1.getAttributes(request)).thenReturn(Arrays.asList(attr1, attr2));
+
+        // Proxy should return the same attributes
+        Collection<ConfigAttribute> attributes = proxy.getAttributes(request);
+        assertEquals(2, attributes.size());
+        assertTrue(attributes.contains(attr1));
+        assertTrue(attributes.contains(attr2));
+
+        // Verify delegate was called
+        verify(delegate1, times(1)).getAttributes(request);
+    }
+
+    @Test
+    public void testGetAttributesMultipleDelegates() {
+        // Setup delegates to return different attributes
+        ConfigAttribute attr1 = new SecurityConfig("ROLE_ADMIN");
+        ConfigAttribute attr2 = new SecurityConfig("ROLE_USER");
+        ConfigAttribute attr3 = new SecurityConfig("ROLE_WORKSPACE_ADMIN");
+
+        when(delegate1.getAttributes(request)).thenReturn(Arrays.asList(attr1, attr2));
+        when(delegate2.getAttributes(request)).thenReturn(Collections.singletonList(attr3));
+
+        // Proxy should merge attributes from both delegates
+        Collection<ConfigAttribute> attributes = proxy.getAttributes(request);
+        assertEquals(3, attributes.size());
+        assertTrue(attributes.contains(attr1));
+        assertTrue(attributes.contains(attr2));
+        assertTrue(attributes.contains(attr3));
+
+        // Verify both delegates were called
+        verify(delegate1, times(1)).getAttributes(request);
+        verify(delegate2, times(1)).getAttributes(request);
+    }
+
+    @Test
+    public void testGetAttributesNullResponse() {
+        // Setup one delegate to return null (this can happen in real implementations)
+        when(delegate1.getAttributes(request)).thenReturn(null);
+        ConfigAttribute attr = new SecurityConfig("ROLE_USER");
+        when(delegate2.getAttributes(request)).thenReturn(Collections.singletonList(attr));
+
+        // Proxy should handle null response and still return attributes from other delegate
+        Collection<ConfigAttribute> attributes = proxy.getAttributes(request);
+        assertEquals(1, attributes.size());
+        assertTrue(attributes.contains(attr));
+    }
+
+    @Test
+    public void testGetAllConfigAttributes() {
+        // Setup delegates to return different attributes
+        ConfigAttribute attr1 = new SecurityConfig("ROLE_ADMIN");
+        ConfigAttribute attr2 = new SecurityConfig("ROLE_USER");
+        ConfigAttribute attr3 = new SecurityConfig("ROLE_WORKSPACE_ADMIN");
+
+        when(delegate1.getAllConfigAttributes()).thenReturn(Arrays.asList(attr1, attr2));
+        when(delegate2.getAllConfigAttributes()).thenReturn(Collections.singletonList(attr3));
+
+        // Proxy should merge all config attributes from both delegates
+        Collection<ConfigAttribute> attributes = proxy.getAllConfigAttributes();
+        assertEquals(3, attributes.size());
+        assertTrue(attributes.contains(attr1));
+        assertTrue(attributes.contains(attr2));
+        assertTrue(attributes.contains(attr3));
+    }
+
+    @Test
+    public void testGetAllConfigAttributesWithSingleDelegate() {
+        // Create proxy with a single delegate
+        proxy = new RESTfulDefinitionSourceProxy(Collections.singletonList(delegate1));
+
+        // Setup delegate to return some attributes
+        ConfigAttribute attr1 = new SecurityConfig("ROLE_ADMIN");
+        ConfigAttribute attr2 = new SecurityConfig("ROLE_USER");
+        when(delegate1.getAllConfigAttributes()).thenReturn(Arrays.asList(attr1, attr2));
+
+        // Proxy should return the same attributes
+        Collection<ConfigAttribute> attributes = proxy.getAllConfigAttributes();
+        assertEquals(2, attributes.size());
+        assertTrue(attributes.contains(attr1));
+        assertTrue(attributes.contains(attr2));
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/RESTfulDefinitionSourceProxyTest.java
+++ b/src/main/src/test/java/org/geoserver/security/RESTfulDefinitionSourceProxyTest.java
@@ -1,0 +1,146 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.SecurityConfig;
+import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
+
+/** Unit tests for {@link RESTfulDefinitionSourceProxy}. */
+@SuppressWarnings("deprecation")
+public class RESTfulDefinitionSourceProxyTest {
+
+    private RESTfulDefinitionSourceProxy proxy;
+    private FilterInvocationSecurityMetadataSource delegate1;
+    private FilterInvocationSecurityMetadataSource delegate2;
+    private HttpServletRequest request;
+
+    @Before
+    public void setUp() {
+        delegate1 = mock(FilterInvocationSecurityMetadataSource.class);
+        delegate2 = mock(FilterInvocationSecurityMetadataSource.class);
+        request = mock(HttpServletRequest.class);
+
+        proxy = new RESTfulDefinitionSourceProxy(Arrays.asList(delegate1, delegate2));
+    }
+
+    @Test
+    public void testSupportsSingleDelegate() {
+        // When at least one delegate supports the class, proxy should support it
+        when(delegate1.supports(HttpServletRequest.class)).thenReturn(true);
+        when(delegate2.supports(HttpServletRequest.class)).thenReturn(false);
+
+        assertTrue(proxy.supports(HttpServletRequest.class));
+
+        // When no delegate supports the class, proxy should not support it
+        when(delegate1.supports(String.class)).thenReturn(false);
+        when(delegate2.supports(String.class)).thenReturn(false);
+
+        assertFalse(proxy.supports(String.class));
+    }
+
+    @Test
+    public void testSupportsMultipleDelegates() {
+        // When both delegates support the class, proxy should support it
+        when(delegate1.supports(HttpServletRequest.class)).thenReturn(true);
+        when(delegate2.supports(HttpServletRequest.class)).thenReturn(true);
+
+        assertTrue(proxy.supports(HttpServletRequest.class));
+    }
+
+    @Test
+    public void testGetAttributesSingleDelegate() {
+        proxy = new RESTfulDefinitionSourceProxy(Collections.singletonList(delegate1));
+
+        ConfigAttribute attr1 = new SecurityConfig("ROLE_ADMIN");
+        ConfigAttribute attr2 = new SecurityConfig("ROLE_USER");
+        when(delegate1.getAttributes(request)).thenReturn(Arrays.asList(attr1, attr2));
+
+        Collection<ConfigAttribute> attributes = proxy.getAttributes(request);
+        assertEquals(2, attributes.size());
+        assertTrue(attributes.contains(attr1));
+        assertTrue(attributes.contains(attr2));
+
+        verify(delegate1, times(1)).getAttributes(request);
+    }
+
+    @Test
+    public void testGetAttributesMultipleDelegates() {
+        ConfigAttribute attr1 = new SecurityConfig("ROLE_ADMIN");
+        ConfigAttribute attr2 = new SecurityConfig("ROLE_USER");
+        ConfigAttribute attr3 = new SecurityConfig("ROLE_WORKSPACE_ADMIN");
+
+        when(delegate1.getAttributes(request)).thenReturn(Arrays.asList(attr1, attr2));
+        when(delegate2.getAttributes(request)).thenReturn(Collections.singletonList(attr3));
+
+        // Proxy should merge attributes from both delegates
+        Collection<ConfigAttribute> attributes = proxy.getAttributes(request);
+        assertEquals(3, attributes.size());
+        assertTrue(attributes.contains(attr1));
+        assertTrue(attributes.contains(attr2));
+        assertTrue(attributes.contains(attr3));
+
+        verify(delegate1, times(1)).getAttributes(request);
+        verify(delegate2, times(1)).getAttributes(request);
+    }
+
+    @Test
+    public void testGetAttributesNullResponse() {
+        // Setup one delegate to return null (this can happen in real implementations)
+        when(delegate1.getAttributes(request)).thenReturn(null);
+        ConfigAttribute attr = new SecurityConfig("ROLE_USER");
+        when(delegate2.getAttributes(request)).thenReturn(Collections.singletonList(attr));
+
+        // Proxy should handle null response and still return attributes from other delegate
+        Collection<ConfigAttribute> attributes = proxy.getAttributes(request);
+        assertEquals(1, attributes.size());
+        assertTrue(attributes.contains(attr));
+    }
+
+    @Test
+    public void testGetAllConfigAttributes() {
+        ConfigAttribute attr1 = new SecurityConfig("ROLE_ADMIN");
+        ConfigAttribute attr2 = new SecurityConfig("ROLE_USER");
+        ConfigAttribute attr3 = new SecurityConfig("ROLE_WORKSPACE_ADMIN");
+
+        when(delegate1.getAllConfigAttributes()).thenReturn(Arrays.asList(attr1, attr2));
+        when(delegate2.getAllConfigAttributes()).thenReturn(Collections.singletonList(attr3));
+
+        // Proxy should merge all config attributes from both delegates
+        Collection<ConfigAttribute> attributes = proxy.getAllConfigAttributes();
+        assertEquals(3, attributes.size());
+        assertTrue(attributes.contains(attr1));
+        assertTrue(attributes.contains(attr2));
+        assertTrue(attributes.contains(attr3));
+    }
+
+    @Test
+    public void testGetAllConfigAttributesWithSingleDelegate() {
+        proxy = new RESTfulDefinitionSourceProxy(Collections.singletonList(delegate1));
+
+        ConfigAttribute attr1 = new SecurityConfig("ROLE_ADMIN");
+        ConfigAttribute attr2 = new SecurityConfig("ROLE_USER");
+        when(delegate1.getAllConfigAttributes()).thenReturn(Arrays.asList(attr1, attr2));
+
+        Collection<ConfigAttribute> attributes = proxy.getAllConfigAttributes();
+        assertEquals(2, attributes.size());
+        assertTrue(attributes.contains(attr1));
+        assertTrue(attributes.contains(attr2));
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizationManagerTest.java
+++ b/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizationManagerTest.java
@@ -1,0 +1,124 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.geoserver.security.filter.GeoServerSecurityInterceptorFilter.ACCESS_ABSTAIN;
+import static org.geoserver.security.filter.GeoServerSecurityInterceptorFilter.ACCESS_GRANTED;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.jspecify.annotations.Nullable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.access.SecurityMetadataSource;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.core.Authentication;
+
+/** Unit tests for {@link WorkspaceAdminAuthorizationManager}. */
+@SuppressWarnings("deprecation")
+public class WorkspaceAdminAuthorizationManagerTest {
+
+    private SecurityMetadataSource metadataSource;
+    private WorkspaceAdminAuthorizer authorizer;
+    private Authentication authentication;
+    private HttpServletRequest request;
+    private Supplier<Authentication> authSupplier;
+
+    private WorkspaceAdminAuthorizationManager authManager;
+
+    @Before
+    public void setUp() {
+        metadataSource = mock(SecurityMetadataSource.class);
+        authentication = mock(Authentication.class);
+        authSupplier = () -> authentication;
+        authorizer = mock(WorkspaceAdminAuthorizer.class);
+
+        // Setup WorkspaceAdminAuthorizer.get() to return our mock
+        GeoServerExtensionsHelper.singleton("workspaceAdminAuthorization", authorizer, WorkspaceAdminAuthorizer.class);
+
+        authManager = new WorkspaceAdminAuthorizationManager(metadataSource);
+
+        request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getContextPath()).thenReturn("/geoserver");
+    }
+
+    @After
+    public void tearDown() {
+        GeoServerExtensionsHelper.init(null);
+    }
+
+    @Test
+    public void testCheckWhenAuthorizerNotAvailable() {
+        // Test when WorkspaceAdminAuthorizer is not available
+        GeoServerExtensionsHelper.clear();
+
+        // Should abstain when authorizer not available
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_ABSTAIN, decision);
+    }
+
+    @Test
+    public void testCheckAbstainsWhenNotFullyAuthenticated() {
+        // Test when user is not fully authenticated (not a workspace admin)
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(false);
+
+        // Should abstain, letting other authorization managers handle it
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_ABSTAIN, decision);
+    }
+
+    @Test
+    public void testCheckWhenNoMatchingRules() {
+        when(request.getRequestURI()).thenReturn("/geoserver/rest/logging");
+
+        // No matching rules
+        when(metadataSource.getAttributes(request)).thenReturn(Collections.emptyList());
+
+        // Should abstain when no matching rules
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_ABSTAIN, decision);
+    }
+
+    @Test
+    public void testCheckWhenMatchingRuleButNotWorkspaceAdmin() {
+        // Create a matching rule
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/topp", Set.of(GET));
+        when(metadataSource.getAttributes(request)).thenReturn(List.of(rule));
+        when(request.getRequestURI()).thenReturn("/geoserver/rest/workspaces/topp");
+
+        // But user is not a workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(false);
+
+        // Should abstain when matching rule but not workspace admin
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_ABSTAIN, decision);
+    }
+
+    @Test
+    public void testCheckWhenMatchingRuleAndWorkspaceAdmin() {
+        // Create a matching rule
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/topp", Set.of(GET));
+        when(metadataSource.getAttributes(request)).thenReturn(List.of(rule));
+
+        when(request.getRequestURI()).thenReturn("/geoserver/rest/workspaces/topp");
+
+        // User is a workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // Should grant access when matching rule and workspace admin
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_GRANTED, decision);
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizationManagerTest.java
+++ b/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizationManagerTest.java
@@ -1,0 +1,113 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.geoserver.security.filter.GeoServerSecurityInterceptorFilter.ACCESS_ABSTAIN;
+import static org.geoserver.security.filter.GeoServerSecurityInterceptorFilter.ACCESS_GRANTED;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.jspecify.annotations.Nullable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.access.SecurityMetadataSource;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.core.Authentication;
+
+/** Unit tests for {@link WorkspaceAdminAuthorizationManager}. */
+@SuppressWarnings("deprecation")
+public class WorkspaceAdminAuthorizationManagerTest {
+
+    private SecurityMetadataSource metadataSource;
+    private WorkspaceAdminAuthorizer authorizer;
+    private Authentication authentication;
+    private HttpServletRequest request;
+    private Supplier<Authentication> authSupplier;
+
+    private WorkspaceAdminAuthorizationManager authManager;
+
+    @Before
+    public void setUp() {
+        metadataSource = mock(SecurityMetadataSource.class);
+        authentication = mock(Authentication.class);
+        authSupplier = () -> authentication;
+        authorizer = mock(WorkspaceAdminAuthorizer.class);
+
+        // Setup WorkspaceAdminAuthorizer.get() to return our mock
+        GeoServerExtensionsHelper.singleton("workspaceAdminAuthorization", authorizer, WorkspaceAdminAuthorizer.class);
+
+        authManager = new WorkspaceAdminAuthorizationManager(metadataSource);
+
+        request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getContextPath()).thenReturn("/geoserver");
+    }
+
+    @After
+    public void tearDown() {
+        GeoServerExtensionsHelper.init(null);
+    }
+
+    @Test
+    public void testCheckWhenAuthorizerNotAvailable() {
+        // remove the authorizer bean, the manager should abstain without it
+        GeoServerExtensionsHelper.clear();
+
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_ABSTAIN, decision);
+    }
+
+    @Test
+    public void testCheckAbstainsWhenNotFullyAuthenticated() {
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(false);
+
+        // abstains, letting other authorization managers handle it
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_ABSTAIN, decision);
+    }
+
+    @Test
+    public void testCheckWhenNoMatchingRules() {
+        when(request.getRequestURI()).thenReturn("/geoserver/rest/logging");
+
+        when(metadataSource.getAttributes(request)).thenReturn(Collections.emptyList());
+
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_ABSTAIN, decision);
+    }
+
+    @Test
+    public void testCheckWhenMatchingRuleButNotWorkspaceAdmin() {
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/topp", Set.of(GET));
+        when(metadataSource.getAttributes(request)).thenReturn(List.of(rule));
+        when(request.getRequestURI()).thenReturn("/geoserver/rest/workspaces/topp");
+
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(false);
+
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_ABSTAIN, decision);
+    }
+
+    @Test
+    public void testCheckWhenMatchingRuleAndWorkspaceAdmin() {
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/topp", Set.of(GET));
+        when(metadataSource.getAttributes(request)).thenReturn(List.of(rule));
+        when(request.getRequestURI()).thenReturn("/geoserver/rest/workspaces/topp");
+
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        @Nullable AuthorizationResult decision = authManager.authorize(authSupplier, request);
+        assertEquals(ACCESS_GRANTED, decision);
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizerTest.java
+++ b/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminAuthorizerTest.java
@@ -1,0 +1,337 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.ResourceAccessManager;
+import org.geoserver.security.SecureCatalogImpl;
+import org.geoserver.security.WorkspaceAccessLimits;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/** Unit tests for {@link WorkspaceAdminAuthorizer}. */
+public class WorkspaceAdminAuthorizerTest {
+
+    private WorkspaceAdminRESTAccessRuleDAO dao;
+    private GeoServerSecurityManager securityManager;
+    private SecureCatalogImpl secureCatalog;
+    private ResourceAccessManager accessManager;
+    private Catalog catalog;
+    private GeoServer geoServer;
+
+    private WorkspaceAdminAuthorizer authorizer;
+
+    @Before
+    public void setUp() {
+        dao = mock(WorkspaceAdminRESTAccessRuleDAO.class);
+        securityManager = mock(GeoServerSecurityManager.class);
+        secureCatalog = mock(SecureCatalogImpl.class);
+        accessManager = mock(ResourceAccessManager.class);
+        catalog = mock(Catalog.class);
+        geoServer = mock(GeoServer.class);
+
+        when(secureCatalog.getResourceAccessManager()).thenReturn(accessManager);
+        when(geoServer.getCatalog()).thenReturn(catalog);
+
+        GeoServerExtensionsHelper.singleton("secureCatalog", secureCatalog, SecureCatalogImpl.class);
+        GeoServerExtensionsHelper.singleton(
+                "geoServerSecurityManager", securityManager, GeoServerSecurityManager.class);
+        GeoServerExtensionsHelper.singleton("geoServer", geoServer, GeoServer.class);
+
+        authorizer = new WorkspaceAdminAuthorizer(dao);
+    }
+
+    @After
+    public void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+        GeoServerExtensionsHelper.init(null);
+    }
+
+    @Test
+    public void isFullyAuthenticated_nullAuth() {
+        assertFalse(authorizer.isFullyAuthenticated(null));
+    }
+
+    @Test
+    public void isFullyAuthenticated_notAuthenticated() {
+        Authentication auth = mock(Authentication.class);
+        when(auth.isAuthenticated()).thenReturn(false);
+        assertFalse(authorizer.isFullyAuthenticated(auth));
+    }
+
+    @Test
+    public void isFullyAuthenticated_anonymous() {
+        AnonymousAuthenticationToken auth = mock(AnonymousAuthenticationToken.class);
+        when(auth.isAuthenticated()).thenReturn(true);
+        assertFalse(authorizer.isFullyAuthenticated(auth));
+    }
+
+    @Test
+    public void isFullyAuthenticated_fullyAuthenticated() {
+        Authentication auth = new TestingAuthenticationToken("user", "password", "ROLE_USER");
+        auth.setAuthenticated(true);
+        assertTrue(authorizer.isFullyAuthenticated(auth));
+    }
+
+    @Test
+    public void getAccessRules() {
+        WorkspaceAdminRestAccessRule rule1 = new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/**", Set.of(GET));
+        WorkspaceAdminRestAccessRule rule2 =
+                new WorkspaceAdminRestAccessRule(2, "/rest/namespaces/**", Set.of(GET, POST));
+        when(dao.getRules()).thenReturn(List.of(rule1, rule2));
+
+        List<WorkspaceAdminRestAccessRule> rules = authorizer.getAccessRules();
+        assertEquals(2, rules.size());
+        assertTrue(rules.contains(rule1));
+        assertTrue(rules.contains(rule2));
+    }
+
+    @Test
+    public void findMatchingRule_match() {
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/**", Set.of(GET));
+        when(dao.getRules()).thenReturn(List.of(rule));
+
+        Optional<WorkspaceAdminRestAccessRule> result = authorizer.findMatchingRule("/rest/workspaces/topp", GET);
+        assertTrue(result.isPresent());
+        assertEquals(rule, result.get());
+    }
+
+    @Test
+    public void findMatchingRule_noMatch() {
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/**", Set.of(GET));
+        when(dao.getRules()).thenReturn(List.of(rule));
+
+        // POST doesn't match GET-only rule
+        Optional<WorkspaceAdminRestAccessRule> result = authorizer.findMatchingRule("/rest/workspaces/topp", POST);
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void isWorkspaceAdmin_notFullyAuthenticated() {
+        // null auth should return false
+        assertFalse(authorizer.isWorkspaceAdmin(null));
+    }
+
+    @Test
+    public void isWorkspaceAdmin_anonymous() {
+        AnonymousAuthenticationToken auth = mock(AnonymousAuthenticationToken.class);
+        when(auth.isAuthenticated()).thenReturn(true);
+        assertFalse(authorizer.isWorkspaceAdmin(auth));
+    }
+
+    @Test
+    public void isWorkspaceAdmin_delegatesToResourceAccessManager() {
+        Authentication auth = new TestingAuthenticationToken("wsadmin", "password", "ROLE_USER");
+        auth.setAuthenticated(true);
+
+        when(accessManager.isWorkspaceAdmin(same(auth), any(Catalog.class))).thenReturn(true);
+
+        assertTrue(authorizer.isWorkspaceAdmin(auth));
+        verify(accessManager).isWorkspaceAdmin(same(auth), any(Catalog.class));
+    }
+
+    @Test
+    public void isWorkspaceAdmin_notWorkspaceAdmin() {
+        Authentication auth = new TestingAuthenticationToken("user", "password", "ROLE_USER");
+        auth.setAuthenticated(true);
+
+        when(accessManager.isWorkspaceAdmin(same(auth), any(Catalog.class))).thenReturn(false);
+
+        assertFalse(authorizer.isWorkspaceAdmin(auth));
+    }
+
+    @Test
+    public void isWorkspaceAdmin_cachesResultInRequestScope() {
+        Authentication auth = new TestingAuthenticationToken("wsadmin", "password", "ROLE_USER");
+        auth.setAuthenticated(true);
+
+        // set up request attributes for caching
+        RequestContextHolder.setRequestAttributes(new SimpleRequestAttributes());
+
+        when(accessManager.isWorkspaceAdmin(same(auth), any(Catalog.class))).thenReturn(true);
+
+        // call twice
+        assertTrue(authorizer.isWorkspaceAdmin(auth));
+        assertTrue(authorizer.isWorkspaceAdmin(auth));
+
+        // should only have called the access manager once due to caching
+        verify(accessManager, times(1)).isWorkspaceAdmin(same(auth), any(Catalog.class));
+    }
+
+    @Test
+    public void canAccess_adminAlwaysGranted() {
+        Authentication auth = new TestingAuthenticationToken("admin", "password", "ROLE_ADMINISTRATOR");
+        auth.setAuthenticated(true);
+
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(true);
+
+        // admin should have access regardless of rules
+        assertTrue(authorizer.canAccess(auth, "/rest/anything", GET));
+    }
+
+    @Test
+    public void canAccess_workspaceAdminWithMatchingRule() {
+        Authentication auth = new TestingAuthenticationToken("wsadmin", "password", "ROLE_USER");
+        auth.setAuthenticated(true);
+
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        WorkspaceAdminRestAccessRule rule =
+                new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/**", Set.of(GET, PUT));
+        when(dao.getRules()).thenReturn(List.of(rule));
+        when(accessManager.isWorkspaceAdmin(eq(auth), any(Catalog.class))).thenReturn(true);
+
+        assertTrue(authorizer.canAccess(auth, "/rest/workspaces/topp", GET));
+        assertTrue(authorizer.canAccess(auth, "/rest/workspaces/topp", PUT));
+    }
+
+    @Test
+    public void canAccess_workspaceAdminNoMatchingRule() {
+        Authentication auth = new TestingAuthenticationToken("wsadmin", "password", "ROLE_USER");
+        auth.setAuthenticated(true);
+
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/**", Set.of(GET));
+        when(dao.getRules()).thenReturn(List.of(rule));
+        when(accessManager.isWorkspaceAdmin(eq(auth), any(Catalog.class))).thenReturn(true);
+
+        // DELETE doesn't match GET-only rule
+        assertFalse(authorizer.canAccess(auth, "/rest/workspaces/topp", DELETE));
+    }
+
+    @Test
+    public void canAccess_notWorkspaceAdmin() {
+        Authentication auth = new TestingAuthenticationToken("user", "password", "ROLE_USER");
+        auth.setAuthenticated(true);
+
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/**", Set.of(GET));
+        when(dao.getRules()).thenReturn(List.of(rule));
+        when(accessManager.isWorkspaceAdmin(eq(auth), any(Catalog.class))).thenReturn(false);
+
+        // rule matches but user is not a workspace admin
+        assertFalse(authorizer.canAccess(auth, "/rest/workspaces/topp", GET));
+    }
+
+    @Test
+    public void getWorkspaceAccessLimits_workspaceExists() {
+        Authentication auth = new TestingAuthenticationToken("wsadmin", "password", "ROLE_USER");
+        WorkspaceInfo workspace = mock(WorkspaceInfo.class);
+        WorkspaceAccessLimits limits = mock(WorkspaceAccessLimits.class);
+
+        when(catalog.getWorkspaceByName("topp")).thenReturn(workspace);
+        when(accessManager.getAccessLimits(auth, workspace)).thenReturn(limits);
+
+        WorkspaceAccessLimits result = authorizer.getWorkspaceAccessLimits(auth, "topp");
+        assertNotNull(result);
+        assertEquals(limits, result);
+    }
+
+    @Test
+    public void getWorkspaceAccessLimits_workspaceNotFound() {
+        Authentication auth = new TestingAuthenticationToken("wsadmin", "password", "ROLE_USER");
+
+        when(catalog.getWorkspaceByName("nonexistent")).thenReturn(null);
+
+        WorkspaceAccessLimits result = authorizer.getWorkspaceAccessLimits(auth, "nonexistent");
+        assertNull(result);
+    }
+
+    @Test
+    public void get_returnsAuthorizerWhenAvailable() {
+        GeoServerExtensionsHelper.singleton("workspaceAdminAuthorization", authorizer, WorkspaceAdminAuthorizer.class);
+        Optional<WorkspaceAdminAuthorizer> result = WorkspaceAdminAuthorizer.get();
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    public void get_returnsEmptyWhenNotAvailable() {
+        GeoServerExtensionsHelper.clear();
+        Optional<WorkspaceAdminAuthorizer> result = WorkspaceAdminAuthorizer.get();
+        assertFalse(result.isPresent());
+    }
+
+    /**
+     * Minimal {@link RequestAttributes} implementation backed by a map, sufficient for testing the request-scope
+     * caching in {@link WorkspaceAdminAuthorizer}.
+     */
+    private static class SimpleRequestAttributes implements RequestAttributes {
+        private final Map<String, Object> attributes = new HashMap<>();
+
+        @Override
+        public Object getAttribute(String name, int scope) {
+            return attributes.get(name);
+        }
+
+        @Override
+        public void setAttribute(String name, Object value, int scope) {
+            attributes.put(name, value);
+        }
+
+        @Override
+        public void removeAttribute(String name, int scope) {
+            attributes.remove(name);
+        }
+
+        @Override
+        public String[] getAttributeNames(int scope) {
+            return attributes.keySet().toArray(new String[0]);
+        }
+
+        @Override
+        public void registerDestructionCallback(String name, Runnable callback, int scope) {
+            // no-op
+        }
+
+        @Override
+        public Object resolveReference(String key) {
+            return null;
+        }
+
+        @Override
+        public String getSessionId() {
+            return "test-session";
+        }
+
+        @Override
+        public Object getSessionMutex() {
+            return this;
+        }
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRESTAccessRuleDAOTest.java
+++ b/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRESTAccessRuleDAOTest.java
@@ -1,0 +1,134 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
+import static org.springframework.http.HttpMethod.OPTIONS;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.TRACE;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.util.LinkedProperties;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.http.HttpMethod;
+
+/** Unit tests for {@link WorkspaceAdminRESTAccessRuleDAO}. */
+public class WorkspaceAdminRESTAccessRuleDAOTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private WorkspaceAdminRESTAccessRuleDAO dao;
+
+    @Before
+    public void setUp() throws IOException {
+        File dataDirFile = tempFolder.newFolder("dataDir");
+        GeoServerDataDirectory dataDir = new GeoServerDataDirectory(dataDirFile);
+        Resource securityDir = dataDir.get("security");
+        securityDir.dir().mkdir();
+        dao = new WorkspaceAdminRESTAccessRuleDAO(dataDir);
+    }
+
+    @Test
+    public void testCreateAndInitialize() throws IOException {
+        Properties properties = new Properties();
+        try (InputStream in = getClass().getResourceAsStream("rest.workspaceadmin.properties.template")) {
+            properties.load(in);
+        }
+        assertFalse(properties.isEmpty());
+
+        // The rules should be loaded from the template file
+        List<WorkspaceAdminRestAccessRule> rules = dao.getRules();
+        assertFalse(rules.isEmpty());
+
+        Map<String, WorkspaceAdminRestAccessRule> rulesMap = rules.stream()
+                .collect(Collectors.toMap(WorkspaceAdminRestAccessRule::getAntPattern, Function.identity()));
+        for (String pattern : properties.stringPropertyNames()) {
+            assertTrue(rulesMap.containsKey(pattern));
+            String value = properties.getProperty(pattern);
+            WorkspaceAdminRestAccessRule rule = rulesMap.get(pattern);
+
+            Set<HttpMethod> expected = dao.parseMethods(value);
+            assertFalse(expected.isEmpty());
+            Set<HttpMethod> actual = rule.getMethods();
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Test
+    public void testLoadRules() {
+        // Create a custom properties file
+        Properties props = new LinkedProperties();
+        props.setProperty("/custom/path", "GET,POST,PUT");
+        props.setProperty("/custom/path/with/wildcard/**", "rw");
+
+        final String defaultRule = "/rest/workspaces/{workspace}/**";
+        assertTrue(dao.getRules().stream()
+                .map(WorkspaceAdminRestAccessRule::getAntPattern)
+                .anyMatch(defaultRule::equals));
+        // Call loadRules with custom properties
+        dao.loadRules(props);
+
+        // Verify custom rules are loaded
+        boolean foundCustomRule = false;
+        boolean foundWildcardRule = false;
+        boolean foundDefaultRule = false;
+
+        for (WorkspaceAdminRestAccessRule rule : dao.getRules()) {
+            if ("/custom/path".equals(rule.getAntPattern())) {
+                foundCustomRule = true;
+                assertEquals(Set.of(GET, POST, PUT), rule.getMethods());
+            } else if ("/custom/path/with/wildcard/**".equals(rule.getAntPattern())) {
+                foundWildcardRule = true;
+                assertEquals(Set.of(PATCH, HEAD, OPTIONS, POST, PUT, TRACE, DELETE, GET), rule.getMethods());
+            } else if (defaultRule.equals(rule.getAntPattern())) {
+                foundDefaultRule = true;
+            }
+        }
+
+        assertTrue("Custom rule not found", foundCustomRule);
+        assertTrue("Wildcard rule not found", foundWildcardRule);
+        assertFalse("Default rules should be replaced", foundDefaultRule);
+    }
+
+    @Test
+    public void testToProperties() {
+        dao.afterPropertiesSet();
+        // Add a custom rule
+        WorkspaceAdminRestAccessRule customRule =
+                new WorkspaceAdminRestAccessRule(100, "/rest/custom/test", Set.of(GET, POST));
+        dao.addRule(customRule);
+
+        // Convert to properties
+        Properties props = dao.toProperties();
+
+        // Check that properties contain all rules
+        assertTrue(props.containsKey("/rest/custom/test"));
+        assertEquals("GET,POST", props.getProperty("/rest/custom/test"));
+
+        // Check for default rules too
+        assertTrue(props.containsKey("/rest/workspaces/{workspace}/**"));
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestAccessRuleTest.java
+++ b/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestAccessRuleTest.java
@@ -1,0 +1,116 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
+import static org.springframework.http.HttpMethod.OPTIONS;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.TRACE;
+
+import java.util.Set;
+import org.junit.Test;
+
+/** Unit tests for {@link WorkspaceAdminRestAccessRule}. */
+public class WorkspaceAdminRestAccessRuleTest {
+
+    @Test
+    public void testConstructor() {
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(5, "/test/path", Set.of(GET, POST));
+        assertEquals("/test/path", rule.getAntPattern());
+        assertEquals(Set.of(GET, POST), rule.getMethods());
+        assertEquals("GET,POST", rule.methods());
+        assertEquals("/test/path=GET,POST", rule.getAttribute());
+    }
+
+    @Test
+    public void testMatches() {
+        WorkspaceAdminRestAccessRule rule =
+                new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/{workspace}/**", Set.of(GET, POST, PUT, DELETE));
+
+        // Positive tests
+        assertTrue(rule.matches("/rest/workspaces/topp", GET));
+        assertTrue(rule.matches("/rest/workspaces/topp/datastores", POST));
+        assertTrue(rule.matches("/rest/workspaces/topp/datastores/nyc", PUT));
+        assertTrue(rule.matches("/rest/workspaces/topp/datastores/nyc/featuretypes/buildings", DELETE));
+
+        // Negative tests - wrong HTTP method
+        assertFalse(rule.matches("/rest/workspaces/topp", PATCH));
+
+        // Negative tests - pattern doesn't match
+        assertFalse(rule.matches("/rest/namespaces/topp", GET));
+        assertFalse(rule.matches("/rest/layers/topp:roads", GET));
+    }
+
+    @Test
+    public void testMatchesWithWildcards() {
+        WorkspaceAdminRestAccessRule rule =
+                new WorkspaceAdminRestAccessRule(1, "/rest/*/workspaces/{workspace}/*", Set.of(GET, PUT));
+
+        // Positive tests
+        assertTrue(rule.matches("/rest/abc/workspaces/topp/xyz", GET));
+
+        // Negative tests - too many path segments
+        assertFalse(rule.matches("/rest/abc/workspaces/topp/xyz/123", PUT));
+
+        // Negative tests - too few path segments
+        assertFalse(rule.matches("/rest/abc/workspaces/topp", GET));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testEqualsAndHashCode() {
+        WorkspaceAdminRestAccessRule rule1 = new WorkspaceAdminRestAccessRule(1, "/path", Set.of(GET, POST));
+        WorkspaceAdminRestAccessRule rule2 = new WorkspaceAdminRestAccessRule(1, "/path", Set.of(GET, POST));
+        WorkspaceAdminRestAccessRule rule3 = new WorkspaceAdminRestAccessRule(2, "/path", Set.of(GET, POST));
+        WorkspaceAdminRestAccessRule rule4 = new WorkspaceAdminRestAccessRule(1, "/different", Set.of(GET, POST));
+        WorkspaceAdminRestAccessRule rule5 = new WorkspaceAdminRestAccessRule(1, "/path", Set.of(GET, DELETE));
+
+        // Same pattern and methods should be equal, even with different priorities
+        assertEquals(rule1, rule2);
+        assertEquals(rule1.hashCode(), rule2.hashCode());
+        assertEquals(rule1, rule3);
+        assertEquals(rule1.hashCode(), rule3.hashCode());
+
+        // Different pattern should not be equal
+        assertNotEquals(rule1, rule4);
+        assertNotEquals(rule1.hashCode(), rule4.hashCode());
+
+        assertNotEquals(rule1, rule5);
+        assertNotEquals(rule1.hashCode(), rule5.hashCode());
+    }
+
+    @Test
+    public void testCompareTo() {
+        WorkspaceAdminRestAccessRule rule1 = new WorkspaceAdminRestAccessRule(1, "/path", Set.of(GET));
+        WorkspaceAdminRestAccessRule rule2 = new WorkspaceAdminRestAccessRule(2, "/path", Set.of(GET));
+        WorkspaceAdminRestAccessRule rule3 = new WorkspaceAdminRestAccessRule(3, "/path", Set.of(GET));
+
+        // Lower priority value should come before higher priority value
+        assertTrue(rule1.compareTo(rule2) < 0);
+        assertTrue(rule2.compareTo(rule3) < 0);
+        assertTrue(rule1.compareTo(rule3) < 0);
+
+        // Same priority should be equal
+        WorkspaceAdminRestAccessRule ruleSame = new WorkspaceAdminRestAccessRule(1, "/different", Set.of(POST));
+        assertEquals(0, rule1.compareTo(ruleSame));
+    }
+
+    @Test
+    public void testToString() {
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(
+                5, "/test/path", Set.of(GET, HEAD, OPTIONS, TRACE, POST, PUT, PATCH, DELETE));
+
+        // toString should return the attribute representation, with methods sorted alphabetically
+        assertEquals("/test/path=DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE", rule.toString());
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestAccessRuleTest.java
+++ b/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestAccessRuleTest.java
@@ -1,0 +1,133 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
+import static org.springframework.http.HttpMethod.OPTIONS;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.TRACE;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import org.junit.Test;
+
+/** Unit tests for {@link WorkspaceAdminRestAccessRule}. */
+public class WorkspaceAdminRestAccessRuleTest {
+
+    @Test
+    public void testConstructor() {
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(5, "/test/path", Set.of(GET, POST));
+        assertEquals("/test/path", rule.getAntPattern());
+        assertEquals(Set.of(GET, POST), rule.getMethods());
+        assertEquals("GET,POST", rule.methods());
+        assertEquals("/test/path=GET,POST", rule.getAttribute());
+    }
+
+    @Test
+    public void testMatches() {
+        WorkspaceAdminRestAccessRule rule =
+                new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/{workspace}/**", Set.of(GET, POST, PUT, DELETE));
+
+        // Positive tests
+        assertTrue(rule.matches("/rest/workspaces/topp", GET));
+        assertTrue(rule.matches("/rest/workspaces/topp/datastores", POST));
+        assertTrue(rule.matches("/rest/workspaces/topp/datastores/nyc", PUT));
+        assertTrue(rule.matches("/rest/workspaces/topp/datastores/nyc/featuretypes/buildings", DELETE));
+
+        // Negative tests - wrong HTTP method
+        assertFalse(rule.matches("/rest/workspaces/topp", PATCH));
+
+        // Negative tests - pattern doesn't match
+        assertFalse(rule.matches("/rest/namespaces/topp", GET));
+        assertFalse(rule.matches("/rest/layers/topp:roads", GET));
+    }
+
+    @Test
+    public void testMatchesWithWildcards() {
+        WorkspaceAdminRestAccessRule rule =
+                new WorkspaceAdminRestAccessRule(1, "/rest/*/workspaces/{workspace}/*", Set.of(GET, PUT));
+
+        // Positive tests
+        assertTrue(rule.matches("/rest/abc/workspaces/topp/xyz", GET));
+
+        // Negative tests - too many path segments
+        assertFalse(rule.matches("/rest/abc/workspaces/topp/xyz/123", PUT));
+
+        // Negative tests - too few path segments
+        assertFalse(rule.matches("/rest/abc/workspaces/topp", GET));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testEqualsAndHashCode() {
+        WorkspaceAdminRestAccessRule rule1 = new WorkspaceAdminRestAccessRule(1, "/path", Set.of(GET, POST));
+        WorkspaceAdminRestAccessRule rule2 = new WorkspaceAdminRestAccessRule(1, "/path", Set.of(GET, POST));
+        WorkspaceAdminRestAccessRule rule3 = new WorkspaceAdminRestAccessRule(2, "/path", Set.of(GET, POST));
+        WorkspaceAdminRestAccessRule rule4 = new WorkspaceAdminRestAccessRule(1, "/different", Set.of(GET, POST));
+        WorkspaceAdminRestAccessRule rule5 = new WorkspaceAdminRestAccessRule(1, "/path", Set.of(GET, DELETE));
+
+        // Equal only when priority, pattern, and methods all match, consistently with compareTo
+        assertEquals(rule1, rule2);
+        assertEquals(rule1.hashCode(), rule2.hashCode());
+
+        assertNotEquals(rule1, rule3);
+        assertNotEquals(rule1.hashCode(), rule3.hashCode());
+
+        assertNotEquals(rule1, rule4);
+        assertNotEquals(rule1.hashCode(), rule4.hashCode());
+
+        assertNotEquals(rule1, rule5);
+        assertNotEquals(rule1.hashCode(), rule5.hashCode());
+    }
+
+    @Test
+    public void testCompareTo() {
+        WorkspaceAdminRestAccessRule rule1 = new WorkspaceAdminRestAccessRule(1, "/path", Set.of(GET));
+        WorkspaceAdminRestAccessRule rule2 = new WorkspaceAdminRestAccessRule(2, "/path", Set.of(GET));
+        WorkspaceAdminRestAccessRule rule3 = new WorkspaceAdminRestAccessRule(3, "/path", Set.of(GET));
+
+        // Lower priority value should come before higher priority value
+        assertTrue(rule1.compareTo(rule2) < 0);
+        assertTrue(rule2.compareTo(rule3) < 0);
+        assertTrue(rule1.compareTo(rule3) < 0);
+
+        // Same priority, pattern, and methods compare as equal
+        WorkspaceAdminRestAccessRule ruleSame = new WorkspaceAdminRestAccessRule(1, "/path", Set.of(GET));
+        assertEquals(0, rule1.compareTo(ruleSame));
+    }
+
+    @Test
+    public void testCompareToDistinctRulesWithSamePriority() {
+        // distinct rules sharing a priority must not compare as equal, or one of them
+        // would be silently dropped from the sorted set the DAO stores rules in
+        WorkspaceAdminRestAccessRule rule1 = new WorkspaceAdminRestAccessRule(1, "/a", Set.of(GET));
+        WorkspaceAdminRestAccessRule rule2 = new WorkspaceAdminRestAccessRule(1, "/b", Set.of(GET));
+        WorkspaceAdminRestAccessRule rule3 = new WorkspaceAdminRestAccessRule(1, "/a", Set.of(POST));
+
+        assertNotEquals(0, rule1.compareTo(rule2));
+        assertNotEquals(0, rule1.compareTo(rule3));
+
+        Set<WorkspaceAdminRestAccessRule> sorted = new ConcurrentSkipListSet<>(List.of(rule1, rule2, rule3));
+        assertEquals(3, sorted.size());
+    }
+
+    @Test
+    public void testToString() {
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(
+                5, "/test/path", Set.of(GET, HEAD, OPTIONS, TRACE, POST, PUT, PATCH, DELETE));
+
+        // toString should return the attribute representation, with methods sorted alphabetically
+        assertEquals("/test/path=DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE", rule.toString());
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestfulDefinitionSourceTest.java
+++ b/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestfulDefinitionSourceTest.java
@@ -1,0 +1,122 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.ConfigAttribute;
+
+/** Unit tests for {@link WorkspaceAdminRestfulDefinitionSource}. */
+@SuppressWarnings("deprecation")
+public class WorkspaceAdminRestfulDefinitionSourceTest {
+
+    private WorkspaceAdminAuthorizer authorizer;
+    private HttpServletRequest request;
+
+    private WorkspaceAdminRestfulDefinitionSource definitionSource;
+
+    @Before
+    public void setUp() {
+        authorizer = mock(WorkspaceAdminAuthorizer.class);
+        // Setup WorkspaceAdminAuthorizer.get() to return our mock
+        GeoServerExtensionsHelper.singleton("workspaceAdminAuthorization", authorizer, WorkspaceAdminAuthorizer.class);
+
+        definitionSource = new WorkspaceAdminRestfulDefinitionSource(authorizer);
+        request = mock(HttpServletRequest.class);
+
+        // Setup the request
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getRequestURI()).thenReturn("/geoserver/rest/workspaces/topp");
+        when(request.getContextPath()).thenReturn("/geoserver");
+    }
+
+    @After
+    public void tearDown() {
+        // Reset the mock instance for WorkspaceAdminAuthorizer
+        GeoServerExtensionsHelper.init(null);
+    }
+
+    @Test
+    public void testSupports() {
+        // Should support HttpServletRequest
+        assertTrue(definitionSource.supports(HttpServletRequest.class));
+
+        // Should not support other classes
+        assertFalse(definitionSource.supports(String.class));
+        assertFalse(definitionSource.supports(Object.class));
+    }
+
+    @Test
+    public void testGetAttributesNoMatch() {
+        // No matching rule
+        when(authorizer.findMatchingRule(anyString(), any(HttpMethod.class))).thenReturn(Optional.empty());
+
+        // Should return empty list when no rule matches
+        Collection<ConfigAttribute> attributes = definitionSource.getAttributes(request);
+        assertTrue(attributes.isEmpty());
+
+        // Verify the correct URL and method were used
+        verify(authorizer).findMatchingRule(eq("/rest/workspaces/topp"), eq(GET));
+    }
+
+    @Test
+    public void testGetAttributesWithMatch() {
+        // Create a matching rule
+        WorkspaceAdminRestAccessRule rule =
+                new WorkspaceAdminRestAccessRule(1, "/geoserver/rest/workspaces/{workspace}", Set.of(GET));
+
+        // Rule matches
+        when(authorizer.findMatchingRule(anyString(), any(HttpMethod.class))).thenReturn(Optional.of(rule));
+
+        // Should return the rule when it matches
+        @SuppressWarnings("deprecation")
+        Collection<ConfigAttribute> attributes = definitionSource.getAttributes(request);
+        assertFalse(attributes.isEmpty());
+        assertEquals(1, attributes.size());
+
+        // The attribute should be our rule
+        @SuppressWarnings("deprecation")
+        ConfigAttribute attr = attributes.iterator().next();
+        assertTrue(attr instanceof WorkspaceAdminRestAccessRule);
+        assertEquals(rule, attr);
+    }
+
+    @Test
+    public void testGetAllConfigAttributes() {
+        // Create some rules
+        WorkspaceAdminRestAccessRule rule1 =
+                new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/{workspace}", Set.of(GET));
+        WorkspaceAdminRestAccessRule rule2 =
+                new WorkspaceAdminRestAccessRule(2, "/rest/namespaces/{workspace}", Set.of(POST));
+
+        // Authorizer returns these rules
+        when(authorizer.getAccessRules()).thenReturn(List.of(rule1, rule2));
+
+        // Should return all rules
+        @SuppressWarnings("deprecation")
+        Collection<ConfigAttribute> attributes = definitionSource.getAllConfigAttributes();
+        assertEquals(List.of(rule1, rule2), attributes);
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestfulDefinitionSourceTest.java
+++ b/src/main/src/test/java/org/geoserver/security/workspaceadmin/WorkspaceAdminRestfulDefinitionSourceTest.java
@@ -1,0 +1,108 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.workspaceadmin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.ConfigAttribute;
+
+/** Unit tests for {@link WorkspaceAdminRestfulDefinitionSource}. */
+@SuppressWarnings("deprecation")
+public class WorkspaceAdminRestfulDefinitionSourceTest {
+
+    private WorkspaceAdminAuthorizer authorizer;
+    private HttpServletRequest request;
+
+    private WorkspaceAdminRestfulDefinitionSource definitionSource;
+
+    @Before
+    public void setUp() {
+        authorizer = mock(WorkspaceAdminAuthorizer.class);
+        GeoServerExtensionsHelper.singleton("workspaceAdminAuthorization", authorizer, WorkspaceAdminAuthorizer.class);
+
+        definitionSource = new WorkspaceAdminRestfulDefinitionSource(authorizer);
+        request = mock(HttpServletRequest.class);
+
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getRequestURI()).thenReturn("/geoserver/rest/workspaces/topp");
+        when(request.getContextPath()).thenReturn("/geoserver");
+    }
+
+    @After
+    public void tearDown() {
+        GeoServerExtensionsHelper.init(null);
+    }
+
+    @Test
+    public void testSupports() {
+        assertTrue(definitionSource.supports(HttpServletRequest.class));
+
+        assertFalse(definitionSource.supports(String.class));
+        assertFalse(definitionSource.supports(Object.class));
+    }
+
+    @Test
+    public void testGetAttributesNoMatch() {
+        when(authorizer.findMatchingRule(anyString(), any(HttpMethod.class))).thenReturn(Optional.empty());
+
+        Collection<ConfigAttribute> attributes = definitionSource.getAttributes(request);
+        assertTrue(attributes.isEmpty());
+
+        // Verify the correct URL and method were used
+        verify(authorizer).findMatchingRule(eq("/rest/workspaces/topp"), eq(GET));
+    }
+
+    @Test
+    public void testGetAttributesWithMatch() {
+        WorkspaceAdminRestAccessRule rule =
+                new WorkspaceAdminRestAccessRule(1, "/geoserver/rest/workspaces/{workspace}", Set.of(GET));
+
+        when(authorizer.findMatchingRule(anyString(), any(HttpMethod.class))).thenReturn(Optional.of(rule));
+
+        @SuppressWarnings("deprecation")
+        Collection<ConfigAttribute> attributes = definitionSource.getAttributes(request);
+        assertFalse(attributes.isEmpty());
+        assertEquals(1, attributes.size());
+
+        @SuppressWarnings("deprecation")
+        ConfigAttribute attr = attributes.iterator().next();
+        assertTrue(attr instanceof WorkspaceAdminRestAccessRule);
+        assertEquals(rule, attr);
+    }
+
+    @Test
+    public void testGetAllConfigAttributes() {
+        WorkspaceAdminRestAccessRule rule1 =
+                new WorkspaceAdminRestAccessRule(1, "/rest/workspaces/{workspace}", Set.of(GET));
+        WorkspaceAdminRestAccessRule rule2 =
+                new WorkspaceAdminRestAccessRule(2, "/rest/namespaces/{workspace}", Set.of(POST));
+
+        when(authorizer.getAccessRules()).thenReturn(List.of(rule1, rule2));
+
+        @SuppressWarnings("deprecation")
+        Collection<ConfigAttribute> attributes = definitionSource.getAllConfigAttributes();
+        assertEquals(List.of(rule1, rule2), attributes);
+    }
+}

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import javax.imageio.ImageIO;
@@ -124,6 +125,8 @@ import org.geoserver.security.impl.GeoServerUserGroup;
 import org.geoserver.security.password.GeoServerDigestPasswordEncoder;
 import org.geoserver.security.password.GeoServerPBEPasswordEncoder;
 import org.geoserver.security.password.GeoServerPlainTextPasswordEncoder;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminRESTAccessRuleDAO;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminRestAccessRule;
 import org.geoserver.util.EntityResolverProvider;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.data.DataUtilities;
@@ -142,6 +145,7 @@ import org.kordamp.json.JSONException;
 import org.kordamp.json.JSONSerializer;
 import org.locationtech.jts.geom.Coordinate;
 import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -871,6 +875,16 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
         dao.storeRules();
     }
 
+    /**
+     * @param priority the rule priority (lower values are evaluated first)
+     * @param antPattern the Ant-style URL pattern this rule applies to
+     * @param methods the set of HTTP methods allowed by this rule
+     */
+    protected void addWorkspaceAdminAccessRule(int priority, String antPattern, Set<HttpMethod> methods) {
+        WorkspaceAdminRESTAccessRuleDAO dao = GeoServerExtensions.bean(WorkspaceAdminRESTAccessRuleDAO.class);
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(priority, antPattern, methods);
+        dao.addRule(rule);
+    }
     /**
      * Clears the authentication context.
      *

--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import javax.imageio.ImageIO;
@@ -125,6 +126,8 @@ import org.geoserver.security.password.GeoServerDigestPasswordEncoder;
 import org.geoserver.security.password.GeoServerPBEPasswordEncoder;
 import org.geoserver.security.password.GeoServerPasswordEncoder;
 import org.geoserver.security.password.GeoServerPlainTextPasswordEncoder;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminRESTAccessRuleDAO;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminRestAccessRule;
 import org.geoserver.util.EntityResolverProvider;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.data.DataUtilities;
@@ -141,6 +144,7 @@ import org.kordamp.json.JSONException;
 import org.kordamp.json.JSONSerializer;
 import org.locationtech.jts.geom.Coordinate;
 import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -877,6 +881,13 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
         rule.getRoles().addAll(Arrays.asList(roles));
         dao.addRule(rule);
         dao.storeRules();
+    }
+
+    /** Adds a workspace admin REST access rule; lower priority values are evaluated first. */
+    protected void addWorkspaceAdminAccessRule(int priority, String antPattern, Set<HttpMethod> methods) {
+        WorkspaceAdminRESTAccessRuleDAO dao = GeoServerExtensions.bean(WorkspaceAdminRESTAccessRuleDAO.class);
+        WorkspaceAdminRestAccessRule rule = new WorkspaceAdminRestAccessRule(priority, antPattern, methods);
+        dao.addRule(rule);
     }
 
     /**

--- a/src/rest/pom.xml
+++ b/src/rest/pom.xml
@@ -38,6 +38,11 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/rest/src/main/java/org/geoserver/rest/IndexController.java
+++ b/src/rest/src/main/java/org/geoserver/rest/IndexController.java
@@ -11,10 +11,17 @@ import freemarker.template.SimpleHash;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.rest.wrapper.RestWrapper;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
 import org.geoserver.template.TemplateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -24,8 +31,16 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 /**
- * The IndexController lists the paths available for the Spring MVC RequestMappingHandler Specifically, it
- * auto-generates an index page containing all non-templated paths relative to the router root.
+ * The IndexController generates the main entry point for the GeoServer REST API.
+ *
+ * <p>This controller serves as a directory or index page for the REST API, automatically discovering and listing all
+ * available REST endpoints that have GET methods. It filters the displayed endpoints based on the user's access rights
+ * - administrators see all endpoints, while workspace administrators only see endpoints they have access to.
+ *
+ * <p>The controller responds to requests to the REST API root (/rest/) and produces representations in JSON, XML, or
+ * HTML based on the client's Accept header.
+ *
+ * <p>Specifically, it auto-generates an index page containing all non-templated paths relative to the router root.
  */
 @RestController
 @RequestMapping(
@@ -33,34 +48,91 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
         produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_HTML_VALUE})
 public class IndexController extends RestBaseController {
 
+    /**
+     * FreeMarker beans wrapper used for template model creation with full access to methods and properties. This allows
+     * the template to access all properties of the wrapped objects.
+     */
     private final BeansWrapper wrapper = TemplateUtils.getSafeWrapper(null, FULL_ACCESS, null);
 
+    /**
+     * Spring's handler mapping that contains information about all registered request mappings. Used to discover
+     * available REST endpoints.
+     */
     @Autowired
     private RequestMappingHandlerMapping requestMappingHandlerMapping;
 
+    /**
+     * Service that determines whether a user with workspace administrator privileges can access specific REST
+     * endpoints.
+     */
+    @Autowired
+    private WorkspaceAdminAuthorizer wsAdminAuthorizer;
+
+    /**
+     * Handles GET requests to the REST API root and builds a list of available endpoints. This method serves the main
+     * index page of the REST API.
+     *
+     * <p>When accessed by administrators, all available endpoints are shown. When accessed by workspace administrators,
+     * only endpoints they have access to are shown.
+     *
+     * @return a RestWrapper containing the model with the list of links for the template to render
+     */
     @GetMapping(
             value = {"", "index"},
             produces = {MediaType.TEXT_HTML_VALUE})
     public RestWrapper get() {
-
+        // Create the model for the template
         SimpleHash model = new SimpleHash(this.wrapper);
-        model.put("links", getLinks());
+
+        // Get all available REST endpoints
+        Set<String> links = getLinks();
+
+        // Filter links for workspace administrators
+        if (!isAdmin()) {
+            links = filterLinksForWorkspaceAdmin(links);
+        }
+
+        // Add the links and page info to the model
+        model.put("links", links);
         model.put("page", RequestInfo.get());
 
         return wrapObject(model, SimpleHash.class);
     }
 
     /**
+     * Filters the given set of REST endpoint links to only include those that a workspace administrator has access to.
+     *
+     * <p>This method checks each link against the WorkspaceAdminAuthorizer to determine if the current user can access
+     * it.
+     *
+     * @param links the complete set of endpoint links
+     * @return a filtered set containing only the links the workspace admin can access
+     */
+    private Set<String> filterLinksForWorkspaceAdmin(Set<String> links) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return links.stream()
+                .filter(uri -> wsAdminAuthorizer.canAccess(authentication, "/rest/" + uri, HttpMethod.GET))
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    /**
      * Extracts all registered GET links from the RequestMappingHandlerMapping, excluding templated ones.
      *
-     * @return A sorted set of unique link paths.
+     * <p>This method filters the endpoints to only include:
+     *
+     * <ul>
+     *   <li>GET methods (read-only operations)
+     *   <li>Non-templated paths (no path variables like {id})
+     *   <li>Paths under the REST root
+     * </ul>
+     *
+     * @return a sorted set of REST endpoint paths relative to the REST root
      */
-    @SuppressWarnings("deprecation")
     protected Set<String> getLinks() {
-
         // Ensure sorted, unique keys
         Set<String> s = new TreeSet<>();
 
+        // Get all registered handler methods from Spring MVC
         Map<RequestMappingInfo, HandlerMethod> handlerMethods = this.requestMappingHandlerMapping.getHandlerMethods();
 
         for (Map.Entry<RequestMappingInfo, HandlerMethod> item : handlerMethods.entrySet()) {
@@ -92,8 +164,24 @@ public class IndexController extends RestBaseController {
         return s;
     }
 
+    /**
+     * Returns the template name to use for rendering the index page.
+     *
+     * @param o the object being wrapped
+     * @return the name of the FreeMarker template to use
+     */
     @Override
     public String getTemplateName(Object o) {
         return "index";
+    }
+
+    /**
+     * Checks if the current user has administrative privileges.
+     *
+     * @return true if the current user is a GeoServer administrator, false otherwise
+     */
+    private boolean isAdmin() {
+        GeoServerSecurityManager manager = GeoServerExtensions.bean(GeoServerSecurityManager.class);
+        return manager.checkAuthenticationForAdminRole();
     }
 }

--- a/src/rest/src/main/java/org/geoserver/rest/IndexController.java
+++ b/src/rest/src/main/java/org/geoserver/rest/IndexController.java
@@ -11,10 +11,17 @@ import freemarker.template.SimpleHash;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.rest.wrapper.RestWrapper;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
 import org.geoserver.template.TemplateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -25,7 +32,8 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 
 /**
  * The IndexController lists the paths available for the Spring MVC RequestMappingHandler Specifically, it
- * auto-generates an index page containing all non-templated paths relative to the router root.
+ * auto-generates an index page containing all non-templated paths relative to the router root. Workspace administrators
+ * only see the endpoints they have access to.
  */
 @RestController
 @RequestMapping(
@@ -38,16 +46,32 @@ public class IndexController extends RestBaseController {
     @Autowired
     private RequestMappingHandlerMapping requestMappingHandlerMapping;
 
+    @Autowired
+    private WorkspaceAdminAuthorizer wsAdminAuthorizer;
+
     @GetMapping(
             value = {"", "index"},
             produces = {MediaType.TEXT_HTML_VALUE})
     public RestWrapper get() {
-
         SimpleHash model = new SimpleHash(this.wrapper);
-        model.put("links", getLinks());
+
+        Set<String> links = getLinks();
+        if (!isAdmin()) {
+            links = filterLinksForWorkspaceAdmin(links);
+        }
+
+        model.put("links", links);
         model.put("page", RequestInfo.get());
 
         return wrapObject(model, SimpleHash.class);
+    }
+
+    /** Retains only the links the current user can access according to the workspace admin access rules. */
+    private Set<String> filterLinksForWorkspaceAdmin(Set<String> links) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return links.stream()
+                .filter(uri -> wsAdminAuthorizer.canAccess(authentication, "/rest/" + uri, HttpMethod.GET))
+                .collect(Collectors.toCollection(TreeSet::new));
     }
 
     /**
@@ -55,9 +79,7 @@ public class IndexController extends RestBaseController {
      *
      * @return A sorted set of unique link paths.
      */
-    @SuppressWarnings("deprecation")
     protected Set<String> getLinks() {
-
         // Ensure sorted, unique keys
         Set<String> s = new TreeSet<>();
 
@@ -95,5 +117,10 @@ public class IndexController extends RestBaseController {
     @Override
     public String getTemplateName(Object o) {
         return "index";
+    }
+
+    private boolean isAdmin() {
+        GeoServerSecurityManager manager = GeoServerExtensions.bean(GeoServerSecurityManager.class);
+        return manager.checkAuthenticationForAdminRole();
     }
 }

--- a/src/rest/src/test/java/org/geoserver/rest/IndexControllerTest.java
+++ b/src/rest/src/test/java/org/geoserver/rest/IndexControllerTest.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.rest;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -11,9 +12,11 @@ import static org.junit.Assert.assertEquals;
 import jakarta.servlet.Filter;
 import jakarta.servlet.ServletException;
 import java.util.List;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.filters.SpringDelegatingFilter;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.AccessMode;
 import org.geoserver.security.GeoServerSecurityFilterChainProxy;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.junit.Test;
@@ -21,10 +24,22 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 public class IndexControllerTest extends GeoServerSystemTestSupport {
 
+    private final String wsadminUser = "wsadminUser";
+    private final String wsadminPwd = "wsadminPwd";
+
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
         // only setup security, no data needed
         testData.setUpSecurity();
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        WorkspaceInfo workspace = getCatalog().getWorkspaces().get(0);
+        addUser(wsadminUser, wsadminPwd, null, List.of("ROLE_WSADMIN"));
+        // add workspace admin rule
+        addLayerAccessRule(workspace.getName(), "*", AccessMode.ADMIN, "ROLE_WSADMIN");
     }
 
     @Override
@@ -78,7 +93,38 @@ public class IndexControllerTest extends GeoServerSystemTestSupport {
         doTestIndex(null, null, "/rest/index.html");
     }
 
-    private void doTestIndex(String username, String password, String path) throws Exception {
+    @Test
+    public void testRootWithoutExtensionWorkspaceAdmin() throws Exception {
+        doTestIndex(wsadminUser, wsadminPwd, "/rest");
+    }
+
+    @Test
+    public void testRootWithExtensionWorkspaceAdmin() throws Exception {
+        doTestIndex(wsadminUser, wsadminPwd, "/rest.html");
+    }
+
+    @Test
+    public void testIndexWithoutExtensionWorkspaceAdmin() throws Exception {
+        doTestIndex(wsadminUser, wsadminPwd, "/rest/index");
+    }
+
+    @Test
+    public void testIndexWithExtensionWorkspaceAdmin() throws Exception {
+        doTestIndex(wsadminUser, wsadminPwd, "/rest/index.html");
+    }
+
+    @Test
+    public void testIndexLimitedContentsForWorkspaceAdmin() throws Exception {
+        String adminContents = doTestIndex("admin", "geoserver", "/rest");
+        assertThat(adminContents, containsString("href=\"http://localhost:8080/geoserver/rest/index\""));
+        assertThat(adminContents, containsString("href=\"http://localhost:8080/geoserver/rest/gsuser\""));
+
+        String workspaceAdminContent = doTestIndex(wsadminUser, wsadminPwd, "/rest");
+        assertThat(workspaceAdminContent, containsString("href=\"http://localhost:8080/geoserver/rest/index\""));
+        assertThat(workspaceAdminContent, not(containsString("href=\"http://localhost:8080/geoserver/rest/gsuser\"")));
+    }
+
+    private String doTestIndex(String username, String password, String path) throws Exception {
         setRequestAuth(username, password);
         MockHttpServletResponse response = getAsServletResponse(path);
         String content = response.getContentAsString();
@@ -90,5 +136,6 @@ public class IndexControllerTest extends GeoServerSystemTestSupport {
             assertEquals(401, response.getStatus());
             assertEquals("", content);
         }
+        return content;
     }
 }

--- a/src/restconfig-wfs/src/test/java/org/geoserver/rest/service/WFSSettingsWorkspaceAdminIntegrationTest.java
+++ b/src/restconfig-wfs/src/test/java/org/geoserver/rest/service/WFSSettingsWorkspaceAdminIntegrationTest.java
@@ -1,0 +1,185 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.rest.catalog.WorkspaceAdminCatalogRESTTestSupport;
+import org.geoserver.test.TestSetup;
+import org.geoserver.test.TestSetupFrequency;
+import org.geoserver.wfs.WFSInfo;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Test;
+import org.kordamp.json.JSON;
+import org.kordamp.json.JSONObject;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
+
+/**
+ * Tests that workspace administrators can manage per-workspace WFS service settings for workspaces they administer,
+ * cannot access settings for other workspaces, and cannot access or modify global WFS service settings.
+ */
+@TestSetup(run = TestSetupFrequency.ONCE)
+public class WFSSettingsWorkspaceAdminIntegrationTest extends WorkspaceAdminCatalogRESTTestSupport {
+
+    private static final String WS_ENDPOINT = RestBaseController.ROOT_PATH + "/services/wfs/workspaces/%s/settings";
+    private static final String GLOBAL_ENDPOINT = RestBaseController.ROOT_PATH + "/services/wfs/settings";
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        ensureWFSSettings(WS);
+    }
+
+    @After
+    public void revert() {
+        revertService(WFSInfo.class, WS);
+        ensureWFSSettings(WS);
+    }
+
+    private void ensureWFSSettings(String workspace) {
+        GeoServer gs = getGeoServer();
+        WorkspaceInfo ws = gs.getCatalog().getWorkspaceByName(workspace);
+        WFSInfo wfsInfo = gs.getService(ws, WFSInfo.class);
+        if (wfsInfo == null) {
+            wfsInfo = gs.getFactory().create(WFSInfo.class);
+            wfsInfo.setName("WFS");
+            wfsInfo.setWorkspace(ws);
+            gs.add(wfsInfo);
+        }
+    }
+
+    //
+    // Workspace-specific settings (allowed for adminable workspace)
+    //
+
+    @Test
+    public void testGetAsJSON() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        JSON json = getAsJSON(WS_ENDPOINT.formatted(WS) + ".json");
+        JSONObject wfsinfo = ((JSONObject) json).getJSONObject("wfs");
+        assertNotNull(wfsinfo);
+        assertEquals("WFS", wfsinfo.get("name"));
+        assertEquals(WS, wfsinfo.getJSONObject("workspace").get("name"));
+    }
+
+    @Test
+    public void testGetAsXML() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        Document dom = getAsDOM(WS_ENDPOINT.formatted(WS) + ".xml");
+        assertEquals("wfs", dom.getDocumentElement().getLocalName());
+    }
+
+    @Test
+    public void testPutAsJSON() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String json = "{'wfs': {'workspace':{'name':'%s'},'enabled':'false','name':'WFS'}}".formatted(WS);
+        MockHttpServletResponse response = putAsServletResponse(WS_ENDPOINT.formatted(WS), json, "text/json");
+        assertEquals(200, response.getStatus());
+
+        JSONObject updated = ((JSONObject) getAsJSON(WS_ENDPOINT.formatted(WS) + ".json")).getJSONObject("wfs");
+        assertEquals("false", updated.get("enabled").toString().trim());
+    }
+
+    @Test
+    public void testPutAsXML() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<wfs><workspace><name>%s</name></workspace><enabled>false</enabled></wfs>".formatted(WS);
+        MockHttpServletResponse response =
+                putAsServletResponse(WS_ENDPOINT.formatted(WS), xml, MediaType.TEXT_XML_VALUE);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteAllowed() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        assertEquals(200, deleteAsServletResponse(WS_ENDPOINT.formatted(WS)).getStatus());
+    }
+
+    //
+    // Other workspace settings (denied)
+    //
+
+    @Test
+    public void testGetOtherWorkspaceDenied() throws Exception {
+        ensureWFSSettings(WS_OTHER);
+
+        setWorkspaceAdminRequestAuth();
+
+        assertEquals(
+                404,
+                getAsServletResponse(WS_ENDPOINT.formatted(WS_OTHER) + ".xml").getStatus());
+    }
+
+    @Test
+    public void testPutOtherWorkspaceDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<wfs><workspace><name>%s</name></workspace><enabled>false</enabled></wfs>".formatted(WS_OTHER);
+        MockHttpServletResponse response =
+                putAsServletResponse(WS_ENDPOINT.formatted(WS_OTHER), xml, MediaType.TEXT_XML_VALUE);
+        assertThat(
+                "Workspace admin should not be able to modify WFS settings in non-adminable workspace",
+                response.getStatus(),
+                Matchers.oneOf(403, 404));
+    }
+
+    @Test
+    public void testDeleteOtherWorkspaceDenied() throws Exception {
+        ensureWFSSettings(WS_OTHER);
+
+        setWorkspaceAdminRequestAuth();
+
+        assertEquals(
+                404, deleteAsServletResponse(WS_ENDPOINT.formatted(WS_OTHER)).getStatus());
+    }
+
+    //
+    // Global WFS settings (denied for workspace admins)
+    //
+
+    // Verifies workspace admins cannot access global service settings.
+    // The rule /rest/services/*/workspaces/{workspace}/settings=rw only matches
+    // per-workspace endpoints, not /rest/services/wfs/settings (global).
+    @Test
+    public void testGetGlobalSettingsDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        assertEquals(403, getAsServletResponse(GLOBAL_ENDPOINT + ".xml").getStatus());
+    }
+
+    @Test
+    public void testPutGlobalSettingsDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<wfs><name>WFS</name><enabled>false</enabled></wfs>";
+        MockHttpServletResponse response = putAsServletResponse(GLOBAL_ENDPOINT, xml, MediaType.TEXT_XML_VALUE);
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteGlobalSettingsDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = deleteAsServletResponse(GLOBAL_ENDPOINT);
+        assertThat(
+                "Workspace admin should not be able to delete global WFS settings",
+                response.getStatus(),
+                Matchers.oneOf(403, 405));
+    }
+}

--- a/src/restconfig-wms/src/test/java/org/geoserver/rest/service/WMSSettingsWorkspaceAdminIntegrationTest.java
+++ b/src/restconfig-wms/src/test/java/org/geoserver/rest/service/WMSSettingsWorkspaceAdminIntegrationTest.java
@@ -1,0 +1,184 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.rest.catalog.WorkspaceAdminCatalogRESTTestSupport;
+import org.geoserver.test.TestSetup;
+import org.geoserver.test.TestSetupFrequency;
+import org.geoserver.wms.WMSInfo;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Test;
+import org.kordamp.json.JSON;
+import org.kordamp.json.JSONObject;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
+
+/**
+ * Tests that workspace administrators can manage per-workspace WMS service settings for workspaces they administer,
+ * cannot access settings for other workspaces, and cannot access or modify global WMS service settings.
+ */
+@TestSetup(run = TestSetupFrequency.ONCE)
+public class WMSSettingsWorkspaceAdminIntegrationTest extends WorkspaceAdminCatalogRESTTestSupport {
+
+    private static final String WS_ENDPOINT = RestBaseController.ROOT_PATH + "/services/wms/workspaces/%s/settings";
+    private static final String GLOBAL_ENDPOINT = RestBaseController.ROOT_PATH + "/services/wms/settings";
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        ensureWMSSettings(WS);
+    }
+
+    @After
+    public void revert() {
+        revertService(WMSInfo.class, WS);
+        ensureWMSSettings(WS);
+    }
+
+    private void ensureWMSSettings(String workspace) {
+        GeoServer gs = getGeoServer();
+        WorkspaceInfo ws = gs.getCatalog().getWorkspaceByName(workspace);
+        WMSInfo wmsInfo = gs.getService(ws, WMSInfo.class);
+        if (wmsInfo == null) {
+            wmsInfo = gs.getFactory().create(WMSInfo.class);
+            wmsInfo.setName("WMS");
+            wmsInfo.setWorkspace(ws);
+            gs.add(wmsInfo);
+        }
+    }
+
+    //
+    // Workspace-specific settings (allowed for adminable workspace)
+    //
+
+    @Test
+    public void testGetAsJSON() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        JSON json = getAsJSON(WS_ENDPOINT.formatted(WS) + ".json");
+        JSONObject wmsinfo = ((JSONObject) json).getJSONObject("wms");
+        assertNotNull(wmsinfo);
+        assertEquals("WMS", wmsinfo.get("name"));
+        assertEquals(WS, wmsinfo.getJSONObject("workspace").get("name"));
+    }
+
+    @Test
+    public void testGetAsXML() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        Document dom = getAsDOM(WS_ENDPOINT.formatted(WS) + ".xml");
+        assertEquals("wms", dom.getDocumentElement().getLocalName());
+    }
+
+    @Test
+    public void testPutAsJSON() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String json = "{'wms': {'workspace':{'name':'%s'},'enabled':'false','name':'WMS'}}".formatted(WS);
+        MockHttpServletResponse response = putAsServletResponse(WS_ENDPOINT.formatted(WS), json, "text/json");
+        assertEquals(200, response.getStatus());
+
+        JSONObject updated = ((JSONObject) getAsJSON(WS_ENDPOINT.formatted(WS) + ".json")).getJSONObject("wms");
+        assertEquals("false", updated.get("enabled").toString().trim());
+    }
+
+    @Test
+    public void testPutAsXML() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<wms><workspace><name>%s</name></workspace><enabled>false</enabled></wms>".formatted(WS);
+        MockHttpServletResponse response =
+                putAsServletResponse(WS_ENDPOINT.formatted(WS), xml, MediaType.TEXT_XML_VALUE);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteAllowed() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        assertEquals(200, deleteAsServletResponse(WS_ENDPOINT.formatted(WS)).getStatus());
+    }
+
+    //
+    // Other workspace settings (denied)
+    //
+
+    @Test
+    public void testGetOtherWorkspaceDenied() throws Exception {
+        ensureWMSSettings(WS_OTHER);
+
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse(WS_ENDPOINT.formatted(WS_OTHER) + ".xml");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testPutOtherWorkspaceDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<wms><workspace><name>%s</name></workspace><enabled>false</enabled></wms>".formatted(WS_OTHER);
+        MockHttpServletResponse response =
+                putAsServletResponse(WS_ENDPOINT.formatted(WS_OTHER), xml, MediaType.TEXT_XML_VALUE);
+        assertThat(
+                "Workspace admin should not be able to modify WMS settings in non-adminable workspace",
+                response.getStatus(),
+                Matchers.oneOf(403, 404));
+    }
+
+    @Test
+    public void testDeleteOtherWorkspaceDenied() throws Exception {
+        ensureWMSSettings(WS_OTHER);
+
+        setWorkspaceAdminRequestAuth();
+
+        assertEquals(
+                404, deleteAsServletResponse(WS_ENDPOINT.formatted(WS_OTHER)).getStatus());
+    }
+
+    //
+    // Global WMS settings (denied for workspace admins)
+    //
+
+    // Verifies workspace admins cannot access global service settings.
+    // The rule /rest/services/*/workspaces/{workspace}/settings=rw only matches
+    // per-workspace endpoints, not /rest/services/wms/settings (global).
+    @Test
+    public void testGetGlobalSettingsDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        assertEquals(403, getAsServletResponse(GLOBAL_ENDPOINT + ".xml").getStatus());
+    }
+
+    @Test
+    public void testPutGlobalSettingsDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<wms><name>WMS</name><enabled>false</enabled></wms>";
+        MockHttpServletResponse response = putAsServletResponse(GLOBAL_ENDPOINT, xml, MediaType.TEXT_XML_VALUE);
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteGlobalSettingsDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = deleteAsServletResponse(GLOBAL_ENDPOINT);
+        assertThat(
+                "Workspace admin should not be able to delete global WMS settings",
+                response.getStatus(),
+                Matchers.oneOf(403, 405));
+    }
+}

--- a/src/restconfig/pom.xml
+++ b/src/restconfig/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/NamespaceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/NamespaceController.java
@@ -130,7 +130,13 @@ public class NamespaceController extends AbstractCatalogController {
     public void namespacePut(
             @RequestBody NamespaceInfo namespace, @PathVariable String prefix, UriComponentsBuilder builder) {
 
+        // check for full admin, we don't allow workspace admins to change all settings
+        final boolean isFullAdmin = isAuthenticatedAsAdmin();
+
         if ("default".equals(prefix)) {
+            if (!isFullAdmin) {
+                throw new RestException("Can't change default namespace", HttpStatus.FORBIDDEN);
+            }
             catalog.setDefaultNamespace(namespace);
         } else {
             // name must exist

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/NamespaceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/NamespaceController.java
@@ -130,7 +130,13 @@ public class NamespaceController extends AbstractCatalogController {
     public void namespacePut(
             @RequestBody NamespaceInfo namespace, @PathVariable String prefix, UriComponentsBuilder builder) {
 
+        // only full admins can change the default namespace
+        final boolean isFullAdmin = isAuthenticatedAsAdmin();
+
         if ("default".equals(prefix)) {
+            if (!isFullAdmin) {
+                throw new RestException("Can't change default namespace", HttpStatus.FORBIDDEN);
+            }
             catalog.setDefaultNamespace(namespace);
         } else {
             // name must exist

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
@@ -148,7 +148,13 @@ public class WorkspaceController extends AbstractCatalogController {
     public void workspacePut(
             @RequestBody WorkspaceInfo workspace, @PathVariable String workspaceName, UriComponentsBuilder builder) {
 
+        // check for full admin, we don't allow workspace admins to change all settings
+        final boolean isFullAdmin = isAuthenticatedAsAdmin();
+
         if ("default".equals(workspaceName)) {
+            if (!isFullAdmin) {
+                throw new RestException("Can't change default worksapce", HttpStatus.FORBIDDEN);
+            }
             catalog.setDefaultWorkspace(workspace);
         } else {
             // name must exist
@@ -163,6 +169,9 @@ public class WorkspaceController extends AbstractCatalogController {
                 throw new RestException("The workspace name cannot be empty", HttpStatus.FORBIDDEN);
             }
 
+            if (!workspaceName.equals(infoName) && !isFullAdmin) {
+                throw new RestException("Can't change the workspace name", HttpStatus.FORBIDDEN);
+            }
             new CatalogBuilder(catalog).updateWorkspace(wks, workspace);
             catalog.save(wks);
         }

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/WorkspaceController.java
@@ -148,7 +148,13 @@ public class WorkspaceController extends AbstractCatalogController {
     public void workspacePut(
             @RequestBody WorkspaceInfo workspace, @PathVariable String workspaceName, UriComponentsBuilder builder) {
 
+        // only full admins can change the default workspace or rename a workspace
+        final boolean isFullAdmin = isAuthenticatedAsAdmin();
+
         if ("default".equals(workspaceName)) {
+            if (!isFullAdmin) {
+                throw new RestException("Can't change default workspace", HttpStatus.FORBIDDEN);
+            }
             catalog.setDefaultWorkspace(workspace);
         } else {
             // name must exist
@@ -163,6 +169,9 @@ public class WorkspaceController extends AbstractCatalogController {
                 throw new RestException("The workspace name cannot be empty", HttpStatus.FORBIDDEN);
             }
 
+            if (!workspaceName.equals(infoName) && !isFullAdmin) {
+                throw new RestException("Can't change the workspace name", HttpStatus.FORBIDDEN);
+            }
             new CatalogBuilder(catalog).updateWorkspace(wks, workspace);
             catalog.save(wks);
         }

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/ResourceController.java
@@ -84,13 +84,16 @@ public class ResourceController extends RestBaseController {
 
     @Autowired
     public ResourceController(@Qualifier("resourceStore") ResourceStoreFactory factory) throws Exception {
-        super();
-        this.resources = factory.getObject();
+        this(factory.getObject());
     }
 
     public ResourceController(ResourceStore store) {
         super();
-        this.resources = store;
+        this.resources = secureResourceStore(store);
+    }
+
+    private ResourceStore secureResourceStore(ResourceStore store) {
+        return new SecureResourceStore(store);
     }
 
     /** Workaround to support format parameter when extension is in path */

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/SecureResourceStore.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/SecureResourceStore.java
@@ -1,0 +1,265 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resource.Type;
+import org.geoserver.platform.resource.ResourceNotificationDispatcher;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geoserver.rest.RestException;
+import org.geoserver.rest.resources.WorkspaceAdminResourceFilter.ResourceAccess;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * A secure implementation of {@link ResourceStore} that enforces access control based on workspace administration
+ * privileges.
+ *
+ * <p>This class wraps another ResourceStore and mediates access to resources based on the current user's permissions.
+ * It uses {@link WorkspaceAdminResourceFilter} to determine which resources a user can access, and returns
+ * {@link SecuredResource} instances that enforce these permissions at the resource level.
+ *
+ * <p>For users with full admin rights, all operations pass through directly to the delegate store. For workspace
+ * administrators, access is limited to resources within workspaces they administer.
+ *
+ * <p>The {@link ResourceStore#get(String)} contract requires returning a {@link Resource} with
+ * {@link Resource.Type#UNDEFINED} for non-existent paths rather than throwing an exception. Because of this,
+ * {@link #get(String)} cannot reject inaccessible paths upfront, it returns a {@link SecuredResource} that defers
+ * access checks to the actual operation ({@link SecuredResource#in()}, {@link SecuredResource#out()},
+ * {@link SecuredResource#file()}, {@link SecuredResource#dir()}). These methods throw {@link RestException} with the
+ * appropriate HTTP status (404 if the resource is not visible, 403 if it is visible but read-only).
+ *
+ * @see SecuredResource
+ * @see WorkspaceAdminResourceFilter
+ * @see ResourceController
+ */
+class SecureResourceStore implements ResourceStore {
+
+    /** The underlying resource store being secured */
+    private final ResourceStore delegate;
+
+    /** Filter that determines which resources a user can access */
+    private final WorkspaceAdminResourceFilter resourcePathFilter;
+
+    /** Creates a new secure resource store wrapping the given delegate. */
+    SecureResourceStore(ResourceStore delegate) {
+        this.delegate = delegate;
+        WorkspaceAdminAuthorizer workspaceAdminAuthorizer =
+                WorkspaceAdminAuthorizer.get().orElseThrow();
+        this.resourcePathFilter = new WorkspaceAdminResourceFilter(workspaceAdminAuthorizer);
+    }
+
+    // ResourceStore methods //
+
+    /**
+     * Returns a resource for the given path.
+     *
+     * <p>For administrators, this returns the delegate resource directly. For other users, it returns a
+     * {@link SecuredResource} that enforces access control.
+     */
+    @Override
+    public Resource get(String path) {
+        Resource resource = delegate.get(path);
+        if (isAuthenticatedAsAdmin()) {
+            return resource;
+        }
+        // return a secured decorator, it'll hide itself on getType() if not readable by
+        // the current user
+        return new SecuredResource(resource, this);
+    }
+
+    /** Removes the resource at the given path if the current user has write access. */
+    @Override
+    public boolean remove(String path) {
+        return canWrite(path) && delegate.remove(path);
+    }
+
+    /**
+     * Moves a resource from one path to another if the current user has write access to both the source and target
+     * paths.
+     */
+    @Override
+    public boolean move(String source, String target) {
+        return canWrite(source) && canWrite(target) && delegate.move(source, target);
+    }
+
+    /** @return the resource notification dispatcher from the delegate store */
+    @Override
+    public ResourceNotificationDispatcher getResourceNotificationDispatcher() {
+        return delegate.getResourceNotificationDispatcher();
+    }
+
+    // support methods for SecuredResource so all logic is centralized in the store //
+
+    /**
+     * Lists all accessible child resources for the given path.
+     *
+     * <p>This method is used by {@link SecuredResource} to implement its {@link SecuredResource#listInternal()} method.
+     *
+     * @param path the path to list children for
+     * @return a list of accessible child resources, or an empty list if the path is not readable
+     */
+    List<Resource> list(String path) {
+        if (canRead(path)) {
+            // if canRead(path) == true, can't assume it holds true for any children
+            List<Resource> delegateChildren = delegate.get(path).list();
+            List<Resource> visible = new ArrayList<>();
+            for (Resource child : delegateChildren) {
+                if (canRead(child)) {
+                    visible.add(wrap(child));
+                }
+            }
+            return visible;
+        }
+        return List.of();
+    }
+
+    /**
+     * Gets the type of a secured resource, respecting access control.
+     *
+     * <p>Returns {@link Type#UNDEFINED} if the current user doesn't have read access to the resource, making it appear
+     * as if the resource doesn't exist.
+     *
+     * @param securedResource the secured resource to check
+     * @return the resource type, or UNDEFINED if access is denied
+     */
+    Type getType(SecuredResource securedResource) {
+        if (canRead(securedResource.path())) {
+            return securedResource.delegate.getType();
+        }
+        return Type.UNDEFINED;
+    }
+
+    /**
+     * Opens an input stream to read a secured resource if the current user has read access.
+     *
+     * @throws RestException 404 if the user doesn't have read access
+     */
+    InputStream in(SecuredResource resource) {
+        if (canRead(resource)) {
+            return resource.delegate.in();
+        }
+        throw notFound(resource);
+    }
+
+    /**
+     * Opens an output stream to write to a secured resource if the current user has write access.
+     *
+     * @throws RestException 403 if the resource is read-only, 404 if not accessible
+     */
+    OutputStream out(SecuredResource resource) {
+        if (canWrite(resource)) {
+            return resource.delegate.out();
+        }
+        throw denyWrite(resource);
+    }
+
+    File file(SecuredResource resource) {
+        if (canWrite(resource)) {
+            return resource.delegate.file();
+        }
+        throw denyWrite(resource);
+    }
+
+    File dir(SecuredResource resource) {
+        if (canWrite(resource)) {
+            return resource.delegate.dir();
+        }
+        throw denyWrite(resource);
+    }
+
+    // internal methods //
+
+    private RestException denyWrite(SecuredResource resource) {
+        if (canRead(resource)) {
+            return new RestException("Resource is read only: " + resource.path(), HttpStatus.FORBIDDEN);
+        }
+        return notFound(resource);
+    }
+
+    private RestException notFound(SecuredResource resource) {
+        return new RestException("Resource not found: " + resource.path(), HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * Wraps a resource with a SecuredResource.
+     *
+     * @param resource the resource to wrap
+     * @return a secured version of the resource
+     */
+    SecuredResource wrap(Resource resource) {
+        if (resource instanceof SecuredResource secured) {
+            return secured;
+        }
+        return new SecuredResource(resource, this);
+    }
+
+    /** @return true if the user can read the resource, false otherwise */
+    private boolean canRead(Resource resource) {
+        return canRead(resource.path());
+    }
+
+    /** @return true if the user can write to the resource, false otherwise */
+    private boolean canWrite(Resource resource) {
+        return canWrite(resource.path());
+    }
+
+    /** @return true if the user can read the resource, false otherwise */
+    boolean canRead(String path) {
+        boolean isFullAdmin = isAuthenticatedAsAdmin();
+        return isFullAdmin || userCanRead(path);
+    }
+
+    /** @return true if the user can write to the resource, false otherwise */
+    boolean canWrite(String path) {
+        boolean isFullAdmin = isAuthenticatedAsAdmin();
+        return isFullAdmin || userCanWriteTo(path);
+    }
+
+    /** @return true if the user can read the resource, false otherwise */
+    private boolean userCanRead(String path) {
+        ResourceAccess access = getAccess(path);
+        return access.canRead();
+    }
+    /** @return true if the user can write to the resource according to #resourcePathFilter, false otherwise */
+    private boolean userCanWriteTo(String path) {
+        ResourceAccess access = getAccess(path);
+        return access.canWrite();
+    }
+
+    private ResourceAccess getAccess(String path) {
+        Authentication authentication = getAuthentication();
+        if (authentication == null) {
+            return ResourceAccess.NONE;
+        }
+        return resourcePathFilter.getAccessLimits(authentication, path);
+    }
+
+    /** @return true if the user is an administrator, false otherwise */
+    private boolean isAuthenticatedAsAdmin() {
+        return getSecurityManager().checkAuthenticationForAdminRole();
+    }
+
+    /** @return the current authentication, or null if not authenticated */
+    @Nullable
+    private Authentication getAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    /** @return the GeoServer security manager */
+    private GeoServerSecurityManager getSecurityManager() {
+        return GeoServerExtensions.bean(GeoServerSecurityManager.class);
+    }
+}

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/SecureResourceStore.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/SecureResourceStore.java
@@ -1,0 +1,203 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resource.Type;
+import org.geoserver.platform.resource.ResourceNotificationDispatcher;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geoserver.rest.RestException;
+import org.geoserver.rest.resources.WorkspaceAdminResourceFilter.ResourceAccess;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * {@link ResourceStore} decorator that limits what workspace administrators can see and modify, using
+ * {@link WorkspaceAdminResourceFilter} to map resource paths to access levels. Full administrators bypass the checks
+ * entirely.
+ *
+ * <p>The {@link ResourceStore#get(String)} contract requires returning a {@link Resource} of type
+ * {@link Resource.Type#UNDEFINED} for non-existent paths rather than throwing an exception. Because of this,
+ * {@link #get(String)} cannot reject inaccessible paths upfront: it returns a {@link SecuredResource} that defers the
+ * access check to the actual operation ({@code in()}, {@code out()}, {@code file()}, {@code dir()}), which throws a
+ * {@link RestException} with status 404 if the resource is not visible to the user, or 403 if it is visible but
+ * read-only.
+ *
+ * @see ResourceController
+ */
+class SecureResourceStore implements ResourceStore {
+
+    private final ResourceStore delegate;
+
+    private final WorkspaceAdminResourceFilter resourcePathFilter;
+
+    SecureResourceStore(ResourceStore delegate) {
+        this.delegate = delegate;
+        WorkspaceAdminAuthorizer workspaceAdminAuthorizer =
+                WorkspaceAdminAuthorizer.get().orElseThrow();
+        this.resourcePathFilter = new WorkspaceAdminResourceFilter(workspaceAdminAuthorizer);
+    }
+
+    // ResourceStore methods //
+
+    @Override
+    public Resource get(String path) {
+        Resource resource = delegate.get(path);
+        if (isAuthenticatedAsAdmin()) {
+            return resource;
+        }
+        // return a secured decorator, it'll hide itself on getType() if not readable by
+        // the current user
+        return new SecuredResource(resource, this);
+    }
+
+    @Override
+    public boolean remove(String path) {
+        return canWrite(path) && delegate.remove(path);
+    }
+
+    @Override
+    public boolean move(String source, String target) {
+        return canWrite(source) && canWrite(target) && delegate.move(source, target);
+    }
+
+    @Override
+    public ResourceNotificationDispatcher getResourceNotificationDispatcher() {
+        return delegate.getResourceNotificationDispatcher();
+    }
+
+    // support methods for SecuredResource so all logic is centralized in the store //
+
+    /** Lists the children of {@code path} the current user can read, or an empty list if the path itself isn't. */
+    List<Resource> list(String path) {
+        if (canRead(path)) {
+            // if canRead(path) == true, can't assume it holds true for any children
+            List<Resource> delegateChildren = delegate.get(path).list();
+            List<Resource> visible = new ArrayList<>();
+            for (Resource child : delegateChildren) {
+                if (canRead(child)) {
+                    visible.add(wrap(child));
+                }
+            }
+            return visible;
+        }
+        return List.of();
+    }
+
+    /** Returns {@link Type#UNDEFINED} if the current user can't read the resource, making it appear non-existent. */
+    Type getType(SecuredResource securedResource) {
+        if (canRead(securedResource.path())) {
+            return securedResource.delegate.getType();
+        }
+        return Type.UNDEFINED;
+    }
+
+    InputStream in(SecuredResource resource) {
+        if (canRead(resource)) {
+            return resource.delegate.in();
+        }
+        throw notFound(resource);
+    }
+
+    OutputStream out(SecuredResource resource) {
+        if (canWrite(resource)) {
+            return resource.delegate.out();
+        }
+        throw denyWrite(resource);
+    }
+
+    File file(SecuredResource resource) {
+        if (canWrite(resource)) {
+            return resource.delegate.file();
+        }
+        throw denyWrite(resource);
+    }
+
+    File dir(SecuredResource resource) {
+        if (canWrite(resource)) {
+            return resource.delegate.dir();
+        }
+        throw denyWrite(resource);
+    }
+
+    // internal methods //
+
+    private RestException denyWrite(SecuredResource resource) {
+        if (canRead(resource)) {
+            return new RestException("Resource is read only: " + resource.path(), HttpStatus.FORBIDDEN);
+        }
+        return notFound(resource);
+    }
+
+    private RestException notFound(SecuredResource resource) {
+        return new RestException("Resource not found: " + resource.path(), HttpStatus.NOT_FOUND);
+    }
+
+    SecuredResource wrap(Resource resource) {
+        if (resource instanceof SecuredResource secured) {
+            return secured;
+        }
+        return new SecuredResource(resource, this);
+    }
+
+    private boolean canRead(Resource resource) {
+        return canRead(resource.path());
+    }
+
+    private boolean canWrite(Resource resource) {
+        return canWrite(resource.path());
+    }
+
+    boolean canRead(String path) {
+        boolean isFullAdmin = isAuthenticatedAsAdmin();
+        return isFullAdmin || userCanRead(path);
+    }
+
+    boolean canWrite(String path) {
+        boolean isFullAdmin = isAuthenticatedAsAdmin();
+        return isFullAdmin || userCanWriteTo(path);
+    }
+
+    private boolean userCanRead(String path) {
+        ResourceAccess access = getAccess(path);
+        return access.canRead();
+    }
+
+    private boolean userCanWriteTo(String path) {
+        ResourceAccess access = getAccess(path);
+        return access.canWrite();
+    }
+
+    private ResourceAccess getAccess(String path) {
+        Authentication authentication = getAuthentication();
+        if (authentication == null) {
+            return ResourceAccess.NONE;
+        }
+        return resourcePathFilter.getAccessLimits(authentication, path);
+    }
+
+    private boolean isAuthenticatedAsAdmin() {
+        return getSecurityManager().checkAuthenticationForAdminRole();
+    }
+
+    @Nullable
+    private Authentication getAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    private GeoServerSecurityManager getSecurityManager() {
+        return GeoServerExtensions.bean(GeoServerSecurityManager.class);
+    }
+}

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/SecuredResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/SecuredResource.java
@@ -1,0 +1,171 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Objects;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceListener;
+
+/**
+ * A secured implementation of {@link Resource} that delegates to an underlying resource while enforcing access control
+ * through a {@link SecureResourceStore}.
+ *
+ * <p>Navigation methods ({@link #parent()}, {@link #get(String)}, {@link #list()}) wrap returned resources as
+ * {@code SecuredResource} instances to maintain security throughout the resource hierarchy. I/O methods delegate to the
+ * store for access checks.
+ */
+class SecuredResource implements Resource {
+
+    /** The underlying resource being secured */
+    final Resource delegate;
+
+    /** The resource store responsible for enforcing security */
+    private final SecureResourceStore store;
+
+    /**
+     * Creates a new secured resource.
+     *
+     * @param delegate the underlying resource to secure
+     * @param store the security enforcement store
+     */
+    public SecuredResource(Resource delegate, SecureResourceStore store) {
+        Objects.requireNonNull(delegate);
+        Objects.requireNonNull(store);
+        this.delegate = delegate;
+        this.store = store;
+    }
+
+    @Override
+    public String path() {
+        return delegate.path();
+    }
+
+    @Override
+    public String name() {
+        return delegate.name();
+    }
+
+    /**
+     * Returns the type of this resource, or {@link Type#UNDEFINED} if the current user does not have read access to the
+     * resource.
+     *
+     * @return the resource type, or UNDEFINED if access is denied
+     */
+    @Override
+    public Type getType() {
+        return store.getType(this);
+    }
+
+    /**
+     * Lists child resources the current user has access to, wrapped as {@code SecuredResource} instances.
+     *
+     * @return a list of accessible child resources
+     */
+    @Override
+    public List<Resource> list() {
+        return store.list(path());
+    }
+
+    /**
+     * Deletes this resource if the current user has write access.
+     *
+     * @return true if the resource was deleted, false otherwise
+     */
+    @Override
+    public boolean delete() {
+        return store.remove(path());
+    }
+
+    /**
+     * Renames this resource if the current user has write access to both the source and destination.
+     *
+     * @param dest the destination resource
+     * @return true if the resource was renamed, false otherwise
+     */
+    @Override
+    public boolean renameTo(Resource dest) {
+        return store.move(path(), dest.path());
+    }
+
+    /**
+     * Opens an input stream to read this resource if the current user has read access.
+     *
+     * @return an input stream to the resource
+     * @throws org.geoserver.rest.RestException 404 if the user doesn't have read access
+     */
+    @Override
+    public InputStream in() {
+        return store.in(this);
+    }
+
+    /**
+     * Opens an output stream to write to this resource if the current user has write access.
+     *
+     * @return an output stream to the resource
+     * @throws org.geoserver.rest.RestException 403 if the resource is read-only, 404 if not visible
+     */
+    @Override
+    public OutputStream out() {
+        return store.out(this);
+    }
+
+    /**
+     * Returns the file handle for this resource if the current user has write access.
+     *
+     * @return the file for this resource
+     * @throws org.geoserver.rest.RestException 403 if the resource is read-only, 404 if not visible
+     */
+    @Override
+    public File file() {
+        return store.file(this);
+    }
+
+    /**
+     * Returns the directory handle for this resource if the current user has write access.
+     *
+     * @return the directory for this resource
+     * @throws org.geoserver.rest.RestException 403 if the resource is read-only, 404 if not visible
+     */
+    @Override
+    public File dir() {
+        return store.dir(this);
+    }
+
+    @Override
+    public long lastmodified() {
+        return delegate.lastmodified();
+    }
+
+    /** Returns the parent resource, wrapped as a {@code SecuredResource}. */
+    @Override
+    public Resource parent() {
+        return store.wrap(delegate.parent());
+    }
+
+    /** Returns a child resource, wrapped as a {@code SecuredResource}. */
+    @Override
+    public Resource get(String childPath) {
+        return store.wrap(delegate.get(childPath));
+    }
+
+    @Override
+    public Lock lock() {
+        return delegate.lock();
+    }
+
+    @Override
+    public void addListener(ResourceListener listener) {
+        delegate.addListener(listener);
+    }
+
+    @Override
+    public void removeListener(ResourceListener listener) {
+        delegate.removeListener(listener);
+    }
+}

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/SecuredResource.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/SecuredResource.java
@@ -1,0 +1,114 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Objects;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceListener;
+
+/**
+ * {@link Resource} decorator that routes every access-controlled operation through its {@link SecureResourceStore}.
+ *
+ * <p>Navigation methods ({@link #parent()}, {@link #get(String)}, {@link #list()}) wrap returned resources as
+ * {@code SecuredResource} instances to keep the whole hierarchy secured. {@link #getType()} reports
+ * {@link Type#UNDEFINED} for resources the user can't read, making them appear non-existent.
+ */
+class SecuredResource implements Resource {
+
+    final Resource delegate;
+
+    private final SecureResourceStore store;
+
+    public SecuredResource(Resource delegate, SecureResourceStore store) {
+        Objects.requireNonNull(delegate);
+        Objects.requireNonNull(store);
+        this.delegate = delegate;
+        this.store = store;
+    }
+
+    @Override
+    public String path() {
+        return delegate.path();
+    }
+
+    @Override
+    public String name() {
+        return delegate.name();
+    }
+
+    @Override
+    public Type getType() {
+        return store.getType(this);
+    }
+
+    @Override
+    public List<Resource> list() {
+        return store.list(path());
+    }
+
+    @Override
+    public boolean delete() {
+        return store.remove(path());
+    }
+
+    @Override
+    public boolean renameTo(Resource dest) {
+        return store.move(path(), dest.path());
+    }
+
+    @Override
+    public InputStream in() {
+        return store.in(this);
+    }
+
+    @Override
+    public OutputStream out() {
+        return store.out(this);
+    }
+
+    @Override
+    public File file() {
+        return store.file(this);
+    }
+
+    @Override
+    public File dir() {
+        return store.dir(this);
+    }
+
+    @Override
+    public long lastmodified() {
+        return delegate.lastmodified();
+    }
+
+    @Override
+    public Resource parent() {
+        return store.wrap(delegate.parent());
+    }
+
+    @Override
+    public Resource get(String childPath) {
+        return store.wrap(delegate.get(childPath));
+    }
+
+    @Override
+    public Lock lock() {
+        return delegate.lock();
+    }
+
+    @Override
+    public void addListener(ResourceListener listener) {
+        delegate.addListener(listener);
+    }
+
+    @Override
+    public void removeListener(ResourceListener listener) {
+        delegate.removeListener(listener);
+    }
+}

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/WorkspaceAdminResourceFilter.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/WorkspaceAdminResourceFilter.java
@@ -1,0 +1,197 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geoserver.security.WorkspaceAccessLimits;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.AntPathMatcher;
+
+/**
+ * A filter interface for {@link SecureResourceStore} to determine which {@link Resource resources} an authenticated
+ * user can see and/or write to, based on the {@link WorkspaceAdminAuthorizer} ability to determine whether an
+ * {@link Authentication} belongs to a workspace administrator, and if so, which workspaces it's allowed to see.
+ *
+ * <p>This can be used, for example, to secure the {@link ResourceStore}, or to determine which REST API URIs to allow
+ * access to.
+ *
+ * <p>For {@link WorkspaceAdminAuthorizer#isWorkspaceAdmin(Authentication) workspace administrators},
+ * {@link #canRead(Authentication, String) canRead} and {@link #canWrite(Authentication, String) canWrite} will tell
+ * whether it has read or read-write access to a resource based on its {@link Resource#path() path}.
+ *
+ * <p>For workspace administrator users, the following resources will be accessible, expressed as Ant-patterns:
+ *
+ * <ul>
+ *   <li>{@literal ""}: the root folder, read-only.
+ *   <li>{@literal "styles/**"}: global styles folder, read-only.
+ *   <li>{@literal "workspaces"}: workspaces folder listing, read-only.
+ *   <li>{@literal "workspaces/{workspace}/**"}: read-write access limited to workspaces the user is an admin of
+ * </ul>
+ *
+ * @see SecureResourceStore
+ * @see WorkspaceAdminAuthorizer
+ */
+class WorkspaceAdminResourceFilter {
+
+    /** Represents the access level to a resource. */
+    public enum ResourceAccess {
+        /** No access to the resource */
+        NONE(false, false),
+        /** Read-only access to the resource */
+        READ(true, false),
+        /** Read-write access to the resource */
+        WRITE(true, true);
+
+        private final boolean canRead;
+        private final boolean canWrite;
+
+        /**
+         * Creates a new access level with the specified read and write permissions.
+         *
+         * @param r whether reading is permitted
+         * @param w whether writing is permitted
+         */
+        private ResourceAccess(boolean r, boolean w) {
+            this.canRead = r;
+            this.canWrite = w;
+        }
+
+        /**
+         * Checks if reading is permitted for this access level.
+         *
+         * @return true if reading is permitted, false otherwise
+         */
+        public boolean canRead() {
+            return canRead;
+        }
+
+        /**
+         * Checks if writing is permitted for this access level.
+         *
+         * @return true if writing is permitted, false otherwise
+         */
+        public boolean canWrite() {
+            return canWrite;
+        }
+    }
+
+    /**
+     * List of root resource names to allow access to a user that is a workspace administrator. Usually as derived from
+     * REST calls to {@literal /rest/resource/**}
+     */
+    private static final List<String> collectionsAntPatterns = List.of("", "styles", "styles/**", "workspaces");
+
+    private static final List<String> workspaceAntPatterns =
+            List.of("workspaces/{workspace}", "workspaces/{workspace}/**");
+
+    private final AntPathMatcher matcher = new AntPathMatcher();
+
+    private final WorkspaceAdminAuthorizer authorizer;
+
+    /**
+     * Creates a new resource filter with the given workspace admin authorizer.
+     *
+     * @param authorizer the authorizer to use for checking workspace admin permissions
+     * @throws NullPointerException if authorizer is null
+     */
+    public WorkspaceAdminResourceFilter(WorkspaceAdminAuthorizer authorizer) {
+        this.authorizer = Objects.requireNonNull(authorizer);
+    }
+
+    /**
+     * Determines the {@link ResourceAccess access level} for the authenticated user on the {@link Resource} denoted by
+     * {@code path}.
+     *
+     * @param authentication the authentication to check permissions for
+     * @param path the resource path to check access for
+     * @return the access level (NONE, READ, or WRITE) for the given user and resource
+     */
+    public ResourceAccess getAccessLimits(Authentication authentication, String path) {
+
+        return extractWorkspace(path)
+                .map(workspace -> workspaceResourceAccess(authentication, workspace))
+                .orElseGet(() -> noWorkspaceResourceAccess(authentication, path));
+    }
+
+    /**
+     * Determines access for resources that are not within a specific workspace. These are typically collection
+     * resources like the root or workspaces directory.
+     *
+     * @param authentication the authentication to check permissions for
+     * @param path the resource path to check access for
+     * @return READ access if the path is an allowed collection and the user is a workspace admin, NONE otherwise
+     */
+    private ResourceAccess noWorkspaceResourceAccess(Authentication authentication, String path) {
+        boolean readable = isAllowedCollectionPath(path) && authorizer.isWorkspaceAdmin(authentication);
+        return readable ? ResourceAccess.READ : ResourceAccess.NONE;
+    }
+
+    /**
+     * Determines access for resources within a specific workspace.
+     *
+     * @param authentication the authentication to check permissions for
+     * @param workspace the workspace name
+     * @return WRITE access if the user has admin rights to the workspace, NONE otherwise
+     */
+    private ResourceAccess workspaceResourceAccess(Authentication authentication, final String workspace) {
+
+        WorkspaceAccessLimits wsAccessLimits = authorizer.getWorkspaceAccessLimits(authentication, workspace);
+        boolean adminable = wsAccessLimits != null && wsAccessLimits.isAdminable();
+        return adminable ? ResourceAccess.WRITE : ResourceAccess.NONE;
+    }
+
+    /**
+     * Removes a trailing slash from a path if present.
+     *
+     * @param path the path to normalize
+     * @return the path without a trailing slash
+     */
+    private String pathWithNoTrailingSlash(final String path) {
+        if (path.endsWith("/")) return path.substring(0, path.length() - 1);
+        return path;
+    }
+
+    /**
+     * Extracts the workspace name from a resource path if it matches any workspace pattern.
+     *
+     * @param resource the resource path to check
+     * @return an Optional containing the workspace name if found, empty otherwise
+     */
+    private Optional<String> extractWorkspace(String resource) {
+        final String path = pathWithNoTrailingSlash(resource);
+        return workspaceAntPatterns.stream()
+                .map(pattern -> extractWorkspace(pattern, path))
+                .filter(Objects::nonNull)
+                .findFirst();
+    }
+
+    /**
+     * Extracts the workspace name from a path using an Ant pattern.
+     *
+     * @param pattern the Ant pattern with a {workspace} variable
+     * @param path the path to extract from
+     * @return the workspace name if the path matches the pattern, null otherwise
+     */
+    private String extractWorkspace(String pattern, String path) {
+        if (matcher.match(pattern, path))
+            return matcher.extractUriTemplateVariables(pattern, path).get("workspace");
+        return null;
+    }
+
+    /**
+     * Checks if the path is one of the allowed collection paths that workspace admins can access.
+     *
+     * @param path the path to check
+     * @return true if the path matches an allowed collection pattern, false otherwise
+     */
+    private boolean isAllowedCollectionPath(String path) {
+        return collectionsAntPatterns.stream().anyMatch(pattern -> matcher.match(pattern, path));
+    }
+}

--- a/src/restconfig/src/main/java/org/geoserver/rest/resources/WorkspaceAdminResourceFilter.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/resources/WorkspaceAdminResourceFilter.java
@@ -1,0 +1,107 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.security.WorkspaceAccessLimits;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.AntPathMatcher;
+
+/**
+ * Maps {@link Resource#path() resource paths} to the {@link ResourceAccess access level} a workspace administrator has
+ * on them, on behalf of {@link SecureResourceStore}.
+ *
+ * <p>Workspace administrators get read-write access to {@literal workspaces/{workspace}/**} for the workspaces they
+ * administer, read-only access to the root folder, the {@literal workspaces} listing, and the global {@literal styles}
+ * folder, and no access to anything else.
+ *
+ * @see WorkspaceAdminAuthorizer
+ */
+class WorkspaceAdminResourceFilter {
+
+    /** Access level to a resource: {@code NONE}, {@code READ} (read-only), or {@code WRITE} (read-write). */
+    public enum ResourceAccess {
+        NONE(false, false),
+        READ(true, false),
+        WRITE(true, true);
+
+        private final boolean canRead;
+        private final boolean canWrite;
+
+        private ResourceAccess(boolean r, boolean w) {
+            this.canRead = r;
+            this.canWrite = w;
+        }
+
+        public boolean canRead() {
+            return canRead;
+        }
+
+        public boolean canWrite() {
+            return canWrite;
+        }
+    }
+
+    /** Paths outside any workspace that workspace administrators can read. */
+    private static final List<String> collectionsAntPatterns = List.of("", "styles", "styles/**", "workspaces");
+
+    private static final List<String> workspaceAntPatterns =
+            List.of("workspaces/{workspace}", "workspaces/{workspace}/**");
+
+    private final AntPathMatcher matcher = new AntPathMatcher();
+
+    private final WorkspaceAdminAuthorizer authorizer;
+
+    public WorkspaceAdminResourceFilter(WorkspaceAdminAuthorizer authorizer) {
+        this.authorizer = Objects.requireNonNull(authorizer);
+    }
+
+    /** Determines the access level for the authenticated user on the resource denoted by {@code path}. */
+    public ResourceAccess getAccessLimits(Authentication authentication, String path) {
+
+        return extractWorkspace(path)
+                .map(workspace -> workspaceResourceAccess(authentication, workspace))
+                .orElseGet(() -> noWorkspaceResourceAccess(authentication, path));
+    }
+
+    private ResourceAccess noWorkspaceResourceAccess(Authentication authentication, String path) {
+        boolean readable = isAllowedCollectionPath(path) && authorizer.isWorkspaceAdmin(authentication);
+        return readable ? ResourceAccess.READ : ResourceAccess.NONE;
+    }
+
+    private ResourceAccess workspaceResourceAccess(Authentication authentication, final String workspace) {
+
+        WorkspaceAccessLimits wsAccessLimits = authorizer.getWorkspaceAccessLimits(authentication, workspace);
+        boolean adminable = wsAccessLimits != null && wsAccessLimits.isAdminable();
+        return adminable ? ResourceAccess.WRITE : ResourceAccess.NONE;
+    }
+
+    private String pathWithNoTrailingSlash(final String path) {
+        if (path.endsWith("/")) return path.substring(0, path.length() - 1);
+        return path;
+    }
+
+    private Optional<String> extractWorkspace(String resource) {
+        final String path = pathWithNoTrailingSlash(resource);
+        return workspaceAntPatterns.stream()
+                .map(pattern -> extractWorkspace(pattern, path))
+                .filter(Objects::nonNull)
+                .findFirst();
+    }
+
+    private String extractWorkspace(String pattern, String path) {
+        if (matcher.match(pattern, path))
+            return matcher.extractUriTemplateVariables(pattern, path).get("workspace");
+        return null;
+    }
+
+    private boolean isAllowedCollectionPath(String path) {
+        return collectionsAntPatterns.stream().anyMatch(pattern -> matcher.match(pattern, path));
+    }
+}

--- a/src/restconfig/src/main/java/org/geoserver/rest/service/ServiceSettingsController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/service/ServiceSettingsController.java
@@ -7,6 +7,7 @@ package org.geoserver.rest.service;
 
 import freemarker.template.ObjectWrapper;
 import java.util.Collections;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.ServiceInfo;
@@ -60,7 +61,13 @@ public abstract class ServiceSettingsController<T extends ServiceInfo> extends A
 
     public void serviceSettingsPut(T info, String workspaceName) {
         WorkspaceInfo ws = null;
-        if (workspaceName != null) ws = geoServer.getCatalog().getWorkspaceByName(workspaceName);
+        if (workspaceName != null) {
+            Catalog catalog = geoServer.getCatalog();
+            ws = catalog.getWorkspaceByName(workspaceName);
+            if (ws == null) {
+                throw new RestException("Workspace " + workspaceName + " does not exist", HttpStatus.NOT_FOUND);
+            }
+        }
 
         T originalInfo;
         if (ws != null) {

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceAdminCatalogRESTTestSupport.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceAdminCatalogRESTTestSupport.java
@@ -1,0 +1,66 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.catalog;
+
+import jakarta.servlet.Filter;
+import java.util.ArrayList;
+import java.util.List;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.AccessMode;
+
+/**
+ * Base test support class for workspace administrator REST API integration tests.
+ *
+ * <p>Enables the Spring Security filter chain and sets up a workspace admin user with admin access to the {@code cite}
+ * workspace from the default test data. The {@code sf} workspace is not administrable by this user.
+ *
+ * <p>Admin authentication is inherited from {@link CatalogRESTTestSupport#login()} which calls {@code loginAsAdmin()}
+ * in {@code @Before}. Workspace admin tests should call {@link #setWorkspaceAdminRequestAuth()} to switch to the
+ * workspace admin user for HTTP Basic auth.
+ *
+ * @see WorkspaceAdminRestIntegrationTest
+ */
+public abstract class WorkspaceAdminCatalogRESTTestSupport extends CatalogRESTTestSupport {
+
+    protected static final String ROLE_WS_ADMIN = "ROLE_CITE_WORKSPACE_ADMIN";
+
+    protected static final String WSADMIN_USER = "wsadmin";
+    protected static final String WSADMIN_PASSWORD = "wsadmin";
+
+    /** Workspace the test user can administer (from default test data) */
+    protected static final String WS = MockData.CITE_PREFIX;
+
+    /** Workspace the test user cannot administer (from default test data) */
+    protected static final String WS_OTHER = MockData.SF_PREFIX;
+
+    /** A layer known to exist in the adminable workspace */
+    protected static final String CITE_LAYER = MockData.BUILDINGS.getLocalPart();
+
+    /** Enable spring security */
+    @Override
+    protected List<Filter> getFilters() {
+        List<Filter> filters = new ArrayList<>(super.getFilters());
+        filters.add((Filter) GeoServerExtensions.bean("filterChainProxy"));
+        return filters;
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        addUser(WSADMIN_USER, WSADMIN_PASSWORD, null, List.of(ROLE_WS_ADMIN));
+        addLayerAccessRule(WS, "*", AccessMode.ADMIN, ROLE_WS_ADMIN);
+    }
+
+    protected void setAdminRequestAuth() {
+        setRequestAuth("admin", "geoserver");
+    }
+
+    protected void setWorkspaceAdminRequestAuth() {
+        setRequestAuth(WSADMIN_USER, WSADMIN_PASSWORD);
+    }
+}

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceAdminRestIntegrationTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/WorkspaceAdminRestIntegrationTest.java
@@ -1,0 +1,536 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.catalog;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.TestSetup;
+import org.geoserver.test.TestSetupFrequency;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
+
+/**
+ * Integration tests for the workspace administrator REST API functionality.
+ *
+ * <p>Uses the default test data workspaces: {@code cite} as the workspace the test user can administer, and {@code sf}
+ * as a workspace without admin access, to verify that workspace administrators have appropriate access to REST API
+ * endpoints according to the security rules defined in rest.workspaceadmin.properties.
+ */
+@TestSetup(run = TestSetupFrequency.ONCE)
+public class WorkspaceAdminRestIntegrationTest extends WorkspaceAdminCatalogRESTTestSupport {
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        // Create a workspace-specific style in cite for style tests
+        Catalog cat = getCatalog();
+        if (cat.getStyleByName(cat.getWorkspaceByName(WS), "citeStyle") == null) {
+            StyleInfo style = cat.getFactory().createStyle();
+            style.setName("citeStyle");
+            style.setWorkspace(cat.getWorkspaceByName(WS));
+            style.setFilename("citeStyle.sld");
+            cat.add(style);
+        }
+    }
+
+    //
+    // Workspace access tests
+    //
+
+    @Test
+    public void testListWorkspaces() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/workspaces.xml");
+        assertEquals(200, response.getStatus());
+
+        Document dom = dom(response, true);
+        // SecureCatalog filters: should only see administrable workspace
+        assertXpathExists("//workspace[name='%s']".formatted(WS), dom);
+        assertXpathNotExists("//workspace[name='%s']".formatted(WS_OTHER), dom);
+    }
+
+    @Test
+    public void testGetWorkspaceWithAccess() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/workspaces/%s.xml".formatted(WS));
+        assertEquals(200, response.getStatus());
+
+        assertXpathEvaluatesTo(WS, "/workspace/name", dom(response, true));
+    }
+
+    @Test
+    public void testGetWorkspaceWithoutAccess() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        // SecureCatalog hides non-adminable workspaces -> 404
+        MockHttpServletResponse response = getAsServletResponse("/rest/workspaces/%s.xml".formatted(WS_OTHER));
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testUpdateWorkspaceWithAccess() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<workspace><name>%s</name></workspace>".formatted(WS);
+        MockHttpServletResponse response =
+                putAsServletResponse("/rest/workspaces/" + WS, xml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testRenameWorkspaceDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<workspace><name>renamed</name></workspace>";
+        MockHttpServletResponse response =
+                putAsServletResponse("/rest/workspaces/" + WS, xml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testUpdateWorkspaceWithoutAccess() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        // SecureCatalog hides it -> 404
+        String xml = "<workspace><name>%s</name></workspace>".formatted(WS_OTHER);
+        MockHttpServletResponse response =
+                putAsServletResponse("/rest/workspaces/" + WS_OTHER, xml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteWorkspaceDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = deleteAsServletResponse("/rest/workspaces/" + WS);
+        assertEquals(403, response.getStatus());
+    }
+
+    //
+    // Namespace access tests
+    //
+
+    @Test
+    public void testListNamespaces() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/namespaces.xml");
+        assertEquals(200, response.getStatus());
+
+        String content = response.getContentAsString();
+        assertThat(content, containsString(WS));
+    }
+
+    @Test
+    public void testGetNamespaceWithAccess() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/namespaces/%s.xml".formatted(WS));
+        assertEquals(200, response.getStatus());
+
+        assertXpathEvaluatesTo(WS, "/namespace/prefix", dom(response, true));
+    }
+
+    @Test
+    public void testUpdateNamespaceWithAccess() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String originalUri = MockData.CITE_URI;
+        String updatedUri = "http://updated-cite-uri";
+
+        String xml = "<namespace><prefix>%s</prefix><uri>%s</uri></namespace>".formatted(WS, updatedUri);
+        MockHttpServletResponse response =
+                putAsServletResponse("/rest/namespaces/" + WS, xml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(200, response.getStatus());
+
+        // Verify
+        response = getAsServletResponse("/rest/namespaces/%s.xml".formatted(WS));
+        assertXpathEvaluatesTo(updatedUri, "/namespace/uri", dom(response, true));
+
+        // Restore original URI
+        xml = "<namespace><prefix>%s</prefix><uri>%s</uri></namespace>".formatted(WS, originalUri);
+        putAsServletResponse("/rest/namespaces/" + WS, xml, MediaType.APPLICATION_XML_VALUE);
+    }
+
+    @Test
+    public void testRenameNamespaceDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<namespace><prefix>renamed</prefix><uri>%s</uri></namespace>".formatted(MockData.CITE_URI);
+        MockHttpServletResponse response =
+                putAsServletResponse("/rest/namespaces/" + WS, xml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(403, response.getStatus());
+    }
+
+    //
+    // Styles access tests
+    //
+
+    @Test
+    public void testListGlobalStyles() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/styles.xml");
+        assertEquals(200, response.getStatus());
+
+        Document dom = dom(response, true);
+        assertXpathExists("//style[name='generic']", dom);
+        assertXpathExists("//style[name='line']", dom);
+    }
+
+    @Test
+    public void testGetGlobalStyle() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/styles/line.xml");
+        assertEquals(200, response.getStatus());
+        assertXpathEvaluatesTo("line", "/style/name", dom(response, true));
+    }
+
+    @Test
+    public void testUpdateGlobalStyleDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<style><name>line</name><filename>line.sld</filename></style>";
+        MockHttpServletResponse response =
+                putAsServletResponse("/rest/styles/line", xml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testCreateGlobalStyleDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String xml = "<style><name>newGlobalStyle</name><filename>newGlobalStyle.sld</filename></style>";
+        MockHttpServletResponse response = postAsServletResponse("/rest/styles", xml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteGlobalStyleDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = deleteAsServletResponse("/rest/styles/line");
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testWorkspaceSpecificStyles() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/workspaces/%s/styles.xml".formatted(WS));
+        assertEquals(200, response.getStatus());
+
+        Document dom = dom(response, true);
+        assertXpathExists("//style[name='citeStyle']", dom);
+
+        // Update workspace style (should be allowed)
+        String xml = "<style><name>citeStyle</name><filename>citeStyle.sld</filename></style>";
+        response = putAsServletResponse(
+                "/rest/workspaces/%s/styles/citeStyle".formatted(WS), xml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(200, response.getStatus());
+    }
+
+    //
+    // Layer group access tests
+    //
+
+    @Test
+    public void testGlobalLayerGroupsDenied() throws Exception {
+        // Create a global layer group as admin
+        login("admin", "geoserver");
+        Catalog cat = getCatalog();
+        if (cat.getLayerGroupByName("testGlobalLayerGroup") == null) {
+            LayerGroupInfo lg = cat.getFactory().createLayerGroup();
+            lg.setName("testGlobalLayerGroup");
+            lg.getLayers().add(cat.getLayers().get(0));
+            cat.add(lg);
+        }
+
+        setWorkspaceAdminRequestAuth();
+
+        assertEquals(403, getAsServletResponse("/rest/layergroups.xml").getStatus());
+        assertEquals(
+                403,
+                getAsServletResponse("/rest/layergroups/testGlobalLayerGroup.xml")
+                        .getStatus());
+        assertEquals(
+                403,
+                deleteAsServletResponse("/rest/layergroups/testGlobalLayerGroup")
+                        .getStatus());
+    }
+
+    @Test
+    public void testWorkspaceSpecificLayerGroups() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        Catalog cat = getCatalog();
+        LayerInfo layer = cat.getLayerByName(WS + ":" + CITE_LAYER);
+        assertNotNull("Layer %s:%s not found".formatted(WS, CITE_LAYER), layer);
+
+        // Create a workspace-specific layer group using an existing cite layer
+        String createXml =
+                """
+                <layerGroup>
+                  <name>wsLayerGroup</name>
+                  <title>WS Layer Group</title>
+                  <publishables>
+                    <published type="layer"><name>%s:%s</name></published>
+                  </publishables>
+                  <styles><style><name>polygon</name></style></styles>
+                </layerGroup>
+                """
+                        .formatted(WS, CITE_LAYER);
+
+        MockHttpServletResponse response = postAsServletResponse(
+                "/rest/workspaces/%s/layergroups".formatted(WS), createXml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(201, response.getStatus());
+
+        // Verify it exists
+        response = getAsServletResponse("/rest/workspaces/%s/layergroups/wsLayerGroup.xml".formatted(WS));
+        assertEquals(200, response.getStatus());
+        assertXpathEvaluatesTo("wsLayerGroup", "/layerGroup/name", dom(response, true));
+
+        // Update it
+        String updateXml =
+                """
+                <layerGroup>
+                  <name>wsLayerGroup</name>
+                  <title>Updated Title</title>
+                </layerGroup>
+                """;
+        response = putAsServletResponse(
+                "/rest/workspaces/%s/layergroups/wsLayerGroup".formatted(WS),
+                updateXml,
+                MediaType.APPLICATION_XML_VALUE);
+        assertEquals(200, response.getStatus());
+
+        // Verify update
+        response = getAsServletResponse("/rest/workspaces/%s/layergroups/wsLayerGroup.xml".formatted(WS));
+        assertXpathEvaluatesTo("Updated Title", "/layerGroup/title", dom(response, true));
+
+        // POST to unauthorized workspace — SecureCatalog hides workspace -> 404
+        response = postAsServletResponse(
+                "/rest/workspaces/%s/layergroups".formatted(WS_OTHER), createXml, MediaType.APPLICATION_XML_VALUE);
+        assertThat("Should deny in unauthorized workspace", response.getStatus(), Matchers.oneOf(403, 404));
+
+        // Delete
+        response = deleteAsServletResponse("/rest/workspaces/%s/layergroups/wsLayerGroup".formatted(WS));
+        assertEquals(200, response.getStatus());
+    }
+
+    //
+    // Templates access tests
+    //
+
+    @Test
+    public void testListGlobalTemplates() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/templates.json");
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testGetGlobalTemplate() throws Exception {
+        setAdminRequestAuth();
+        String templateContent = "This is a test template for ${name}";
+        MockHttpServletResponse adminResponse =
+                putAsServletResponse("/rest/templates/test_template.ftl", templateContent, MediaType.TEXT_PLAIN_VALUE);
+        assertThat("Admin should be able to create template", adminResponse.getStatus(), Matchers.oneOf(200, 201));
+
+        setWorkspaceAdminRequestAuth();
+        MockHttpServletResponse response = getAsServletResponse("/rest/templates/test_template.ftl");
+        assertEquals(200, response.getStatus());
+        assertEquals(templateContent, response.getContentAsString());
+    }
+
+    @Test
+    public void testUpdateGlobalTemplateDenied() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response =
+                putAsServletResponse("/rest/templates/test_template.ftl", "updated", MediaType.TEXT_PLAIN_VALUE);
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testWorkspaceSpecificTemplates() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        String content = "This is a workspace template for ${name}";
+        MockHttpServletResponse response = putAsServletResponse(
+                "/rest/workspaces/%s/templates/ws_template.ftl".formatted(WS), content, MediaType.TEXT_PLAIN_VALUE);
+        assertThat(response.getStatus(), Matchers.oneOf(200, 201));
+
+        // Verify it exists
+        response = getAsServletResponse("/rest/workspaces/%s/templates/ws_template.ftl".formatted(WS));
+        assertEquals(200, response.getStatus());
+        assertEquals(content, response.getContentAsString());
+
+        // Try in unauthorized workspace — should be denied
+        response = putAsServletResponse(
+                "/rest/workspaces/%s/templates/ws_template.ftl".formatted(WS_OTHER),
+                content,
+                MediaType.TEXT_PLAIN_VALUE);
+        assertThat(
+                "Should deny template creation in unauthorized workspace",
+                response.getStatus(),
+                Matchers.oneOf(403, 404));
+    }
+
+    //
+    // Layer access tests
+    //
+
+    @Test
+    public void testListLayers() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/layers.xml");
+        assertEquals(200, response.getStatus());
+
+        String content = response.getContentAsString();
+        // Should see cite layers, not sf layers
+        assertThat(content, containsString(CITE_LAYER));
+        assertThat(content, not(containsString(WS_OTHER + ":")));
+    }
+
+    @Test
+    public void testCreateLayerInUnauthorizedWorkspace() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        // SecureCatalog hides the sf workspace -> datastore not found -> 404
+        String xml = "<featureType><name>testLayer</name><nativeName>testLayer</nativeName></featureType>";
+        MockHttpServletResponse response = postAsServletResponse(
+                "/rest/workspaces/%s/datastores/sf/featuretypes".formatted(WS_OTHER),
+                xml,
+                MediaType.APPLICATION_XML_VALUE);
+        assertEquals(404, response.getStatus());
+    }
+
+    //
+    // CRS endpoint (read-only)
+    //
+
+    @Test
+    public void testCrsAccessible() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/crs");
+        assertEquals(200, response.getStatus());
+    }
+
+    // REST Resource access tests are in ResourceControllerWorkspaceAdminTest
+
+    //
+    // Workspace-specific settings tests
+    //
+
+    @Test
+    public void testWorkspaceSettings() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest/workspaces/%s/settings.xml".formatted(WS));
+        assertEquals(200, response.getStatus());
+
+        String settingsXml =
+                """
+                <settings>
+                  <contact><addressCity>TestCity</addressCity></contact>
+                  <charset>UTF-8</charset>
+                  <numDecimals>8</numDecimals>
+                  <verbose>false</verbose>
+                  <verboseExceptions>false</verboseExceptions>
+                </settings>
+                """;
+        response = putAsServletResponse(
+                "/rest/workspaces/%s/settings".formatted(WS), settingsXml, MediaType.APPLICATION_XML_VALUE);
+        assertEquals(200, response.getStatus());
+
+        // Verify
+        response = getAsServletResponse("/rest/workspaces/%s/settings.xml".formatted(WS));
+        Document dom = dom(response, true);
+        assertXpathEvaluatesTo("TestCity", "//contact/addressCity", dom);
+
+        // SecureCatalog hides the workspace -> LocalSettingsController returns 404
+        response = getAsServletResponse("/rest/workspaces/%s/settings.xml".formatted(WS_OTHER));
+        assertEquals(404, response.getStatus());
+    }
+
+    //
+    // REST Index filtering tests
+    //
+
+    @Test
+    public void testRestIndexFiltering() throws Exception {
+        setWorkspaceAdminRequestAuth();
+
+        MockHttpServletResponse response = getAsServletResponse("/rest");
+        assertEquals(200, response.getStatus());
+
+        String content = response.getContentAsString();
+        assertThat(content, containsString("workspaces"));
+        assertThat(content, containsString("namespaces"));
+        assertThat(content, containsString("styles"));
+        assertThat(content, containsString("templates"));
+
+        assertThat(content, not(containsString("href=\"security")));
+    }
+
+    //
+    // Admin-only endpoint access tests
+    //
+
+    @Test
+    public void testAdminOnlyEndpoints() throws Exception {
+        String[] adminOnlyPaths = {
+            "/rest/security/roles",
+            "/rest/security/masterpw",
+            "/rest/security/usergroup/groups",
+            "/rest/settings",
+            "/rest/settings/contact",
+            "/rest/urlchecks",
+            "/rest/about/manifest",
+            "/rest/about/status",
+            "/rest/about/version"
+        };
+
+        setAdminRequestAuth();
+        for (String path : adminOnlyPaths) {
+            assertEquals(
+                    "Admin should have access to " + path,
+                    200,
+                    getAsServletResponse(path).getStatus());
+        }
+
+        setWorkspaceAdminRequestAuth();
+        for (String path : adminOnlyPaths) {
+            assertEquals(
+                    "WS admin should NOT have access to " + path,
+                    403,
+                    getAsServletResponse(path).getStatus());
+        }
+    }
+}

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerTest.java
@@ -32,6 +32,7 @@ import org.geoserver.platform.resource.Resources;
 import org.geoserver.rest.RestBaseController;
 import org.geoserver.rest.util.IOUtils;
 import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -114,6 +115,14 @@ public class ResourceControllerTest extends GeoServerSystemTestSupport {
 
         getDataDirectory().get("mydir3/test.html").file();
         getDataDirectory().get("mydir3/test.js").file();
+
+        // all requests must be authenticated due to ResourceController's use of SecureResourceStore
+        super.login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+    }
+
+    @After
+    public void after() {
+        super.logout();
     }
 
     @Test

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerWorkspaceAdminTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/ResourceControllerWorkspaceAdminTest.java
@@ -1,0 +1,346 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.servlet.Filter;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resources;
+import org.geoserver.security.AccessMode;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geoserver.test.TestSetup;
+import org.geoserver.test.TestSetupFrequency;
+import org.junit.Before;
+import org.junit.Test;
+import org.kordamp.json.JSONObject;
+import org.kordamp.json.test.JSONAssert;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Integration tests for {@link ResourceController} with workspace administrator access.
+ *
+ * <p>Verifies that the resource browser ({@code /rest/resource/**}) correctly enforces access control for workspace
+ * administrators: full access to resources within their workspace, read-only access to collection listings, and no
+ * access to resources in other workspaces.
+ */
+@TestSetup(run = TestSetupFrequency.ONCE)
+public class ResourceControllerWorkspaceAdminTest extends GeoServerSystemTestSupport {
+
+    private static final String ROLE_WS_ADMIN = "ROLE_WS_ADMIN";
+
+    private static final String WS_ADMIN_USER = "wsresadmin";
+    private static final String WS_ADMIN_PASSWORD = "wsresadmin";
+
+    private static final String WORKSPACE = "restest";
+    private static final String WORKSPACE_NS = "http://www.geoserver.org/restest";
+
+    private static final String OTHER_WORKSPACE = "resother";
+    private static final String OTHER_WORKSPACE_NS = "http://www.geoserver.org/resother";
+
+    @Override
+    protected List<Filter> getFilters() {
+        List<Filter> filters = new ArrayList<>(super.getFilters());
+        filters.add((Filter) GeoServerExtensions.bean("filterChainProxy"));
+        return filters;
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        testData.addWorkspace(WORKSPACE, WORKSPACE_NS, getCatalog());
+        testData.addWorkspace(OTHER_WORKSPACE, OTHER_WORKSPACE_NS, getCatalog());
+
+        addUser(WS_ADMIN_USER, WS_ADMIN_PASSWORD, null, List.of(ROLE_WS_ADMIN));
+        addLayerAccessRule(WORKSPACE, "*", AccessMode.ADMIN, ROLE_WS_ADMIN);
+
+        // create some test resources in the data directory
+        writeResource("workspaces/%s/testfile.txt".formatted(WORKSPACE), "workspace content");
+        writeResource("workspaces/%s/otherfile.txt".formatted(OTHER_WORKSPACE), "other content");
+        writeResource("styles/teststyle.sld", "<sld/>");
+    }
+
+    private void writeResource(String path, String content) throws Exception {
+        Resource res = getDataDirectory().get(path);
+        try (OutputStreamWriter w = new OutputStreamWriter(res.out(), UTF_8)) {
+            w.write(content);
+        }
+    }
+
+    @Before
+    public void loginAsWorkspaceAdmin() {
+        setRequestAuth(WS_ADMIN_USER, WS_ADMIN_PASSWORD);
+    }
+
+    // -- Root and collection listings (read-only) --
+
+    @Test
+    public void testGetRootDirectory() throws Exception {
+        // workspace admin should only see "workspaces" in the root listing,
+        // not global config files (global.xml, wfs.xml, etc.) or other directories
+        JSONObject json = (JSONObject) getAsJSON("/rest/resource?format=json");
+        ((JSONObject) json.get("ResourceDirectory")).remove("lastModified");
+
+        String expected =
+                """
+                {'ResourceDirectory': {
+                  'name': '',
+                  'children': {'child': [
+                    {
+                      'name': 'styles',
+                      'link': {
+                        'href': 'http://localhost:8080/geoserver/rest/resource/styles',
+                        'rel': 'alternate',
+                        'type': 'application/json'
+                      }
+                    },
+                    {
+                      'name': 'workspaces',
+                      'link': {
+                        'href': 'http://localhost:8080/geoserver/rest/resource/workspaces',
+                        'rel': 'alternate',
+                        'type': 'application/json'
+                      }
+                    }
+                  ]}
+                }}
+                """;
+        JSONAssert.assertEquals(expected, json);
+    }
+
+    @Test
+    public void testGetWorkspacesCollection() throws Exception {
+        JSONObject json = (JSONObject) getAsJSON("/rest/resource/workspaces?format=json");
+        JSONObject dir = json.getJSONObject("ResourceDirectory");
+        dir.remove("lastModified");
+
+        String content = json.toString();
+        // should only see the administrable workspace, not the other one
+        assertTrue("Should contain administrable workspace", content.contains(WORKSPACE));
+        assertFalse("Should not contain non-administrable workspace", content.contains(OTHER_WORKSPACE));
+    }
+
+    @Test
+    public void testRootIsReadOnly() throws Exception {
+        // trying to create a file at root should fail
+        MockHttpServletResponse response =
+                putAsServletResponse("/rest/resource/rootfile.txt", "data", MediaType.TEXT_PLAIN_VALUE);
+        // not writable for ws admin
+        assertEquals(403, response.getStatus());
+    }
+
+    // -- Own workspace resources --
+
+    @Test
+    public void testReadOwnWorkspaceResource() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse("/rest/resource/workspaces/%s/testfile.txt".formatted(WORKSPACE));
+        assertEquals(200, response.getStatus());
+        assertEquals("workspace content", response.getContentAsString());
+    }
+
+    @Test
+    public void testReadOwnWorkspaceDirectory() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse("/rest/resource/workspaces/%s?format=json".formatted(WORKSPACE));
+        assertEquals(200, response.getStatus());
+
+        String content = response.getContentAsString();
+        assertTrue(content.contains("testfile.txt"));
+    }
+
+    @Test
+    public void testUploadToOwnWorkspace() throws Exception {
+        String content = "new file content";
+        MockHttpServletResponse response = putAsServletResponse(
+                "/rest/resource/workspaces/%s/uploaded.txt".formatted(WORKSPACE), content, MediaType.TEXT_PLAIN_VALUE);
+        assertEquals(201, response.getStatus());
+
+        // verify it was written
+        Resource uploaded = getDataDirectory().get("workspaces/%s/uploaded.txt".formatted(WORKSPACE));
+        assertTrue(Resources.exists(uploaded));
+
+        // read it back through the API
+        response = getAsServletResponse("/rest/resource/workspaces/%s/uploaded.txt".formatted(WORKSPACE));
+        assertEquals(200, response.getStatus());
+        assertEquals(content, response.getContentAsString());
+    }
+
+    @Test
+    public void testDeleteOwnWorkspaceResource() throws Exception {
+        writeResource("workspaces/%s/todelete.txt".formatted(WORKSPACE), "delete me");
+        Resource res = getDataDirectory().get("workspaces/%s/todelete.txt".formatted(WORKSPACE));
+        assertTrue(Resources.exists(res));
+
+        MockHttpServletResponse response =
+                deleteAsServletResponse("/rest/resource/workspaces/%s/todelete.txt".formatted(WORKSPACE));
+        assertEquals(200, response.getStatus());
+
+        assertFalse(Resources.exists(res));
+    }
+
+    @Test
+    public void testMoveWithinOwnWorkspace() throws Exception {
+        writeResource("workspaces/%s/moveme.txt".formatted(WORKSPACE), "move content");
+
+        String path = "/rest/resource/workspaces/%s/moved.txt?operation=move".formatted(WORKSPACE);
+        String body = "/workspaces/%s/moveme.txt".formatted(WORKSPACE);
+        MockHttpServletResponse response = putAsServletResponse(path, body, "text/plain");
+        assertEquals(201, response.getStatus());
+
+        assertFalse(Resources.exists(getDataDirectory().get("workspaces/%s/moveme.txt".formatted(WORKSPACE))));
+        assertTrue(Resources.exists(getDataDirectory().get("workspaces/%s/moved.txt".formatted(WORKSPACE))));
+    }
+
+    @Test
+    public void testCopyWithinOwnWorkspace() throws Exception {
+        writeResource("workspaces/%s/copyme.txt".formatted(WORKSPACE), "copy content");
+
+        String path = "/rest/resource/workspaces/%s/copied.txt?operation=copy".formatted(WORKSPACE);
+        String body = "/workspaces/%s/copyme.txt".formatted(WORKSPACE);
+        MockHttpServletResponse response = putAsServletResponse(path, body, "text/plain");
+        assertEquals(201, response.getStatus());
+
+        // both should exist
+        assertTrue(Resources.exists(getDataDirectory().get("workspaces/%s/copyme.txt".formatted(WORKSPACE))));
+        assertTrue(Resources.exists(getDataDirectory().get("workspaces/%s/copied.txt".formatted(WORKSPACE))));
+    }
+
+    @Test
+    public void testMetadataOwnWorkspaceResource() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse(
+                "/rest/resource/workspaces/%s/testfile.txt?operation=metadata&format=json".formatted(WORKSPACE));
+        assertEquals(200, response.getStatus());
+
+        String content = response.getContentAsString();
+        assertTrue(content.contains("testfile.txt"));
+        assertTrue(content.contains("resource"));
+    }
+
+    // -- Other workspace resources (denied) --
+
+    @Test
+    public void testReadOtherWorkspaceResourceDenied() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse("/rest/resource/workspaces/%s/otherfile.txt".formatted(OTHER_WORKSPACE));
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testListOtherWorkspaceDirectoryDenied() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse("/rest/resource/workspaces/%s?format=json".formatted(OTHER_WORKSPACE));
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testUploadToOtherWorkspaceDenied() throws Exception {
+        MockHttpServletResponse response = putAsServletResponse(
+                "/rest/resource/workspaces/%s/hack.txt".formatted(OTHER_WORKSPACE),
+                "malicious",
+                MediaType.TEXT_PLAIN_VALUE);
+        assertEquals(404, response.getStatus());
+
+        // verify file was not created regardless of status code
+        assertFalse(Resources.exists(getDataDirectory().get("workspaces/%s/hack.txt".formatted(OTHER_WORKSPACE))));
+    }
+
+    @Test
+    public void testDeleteOtherWorkspaceResourceDenied() throws Exception {
+        Resource res = getDataDirectory().get("workspaces/%s/otherfile.txt".formatted(OTHER_WORKSPACE));
+        assertTrue(Resources.exists(res));
+
+        MockHttpServletResponse response =
+                deleteAsServletResponse("/rest/resource/workspaces/%s/otherfile.txt".formatted(OTHER_WORKSPACE));
+        assertEquals(404, response.getStatus());
+
+        // verify file still exists
+        assertTrue(Resources.exists(res));
+    }
+
+    // -- Global styles resources (read-only) --
+
+    @Test
+    public void testGlobalStylesDirectoryListsAllStyles() throws Exception {
+        JSONObject json = (JSONObject) getAsJSON("/rest/resource/styles?format=json");
+        String content = json.toString();
+
+        // should list all global styles, including our test style and built-in ones
+        assertTrue(content.contains("teststyle.sld"));
+        assertTrue(content.contains("default_point.sld"));
+        assertTrue(content.contains("default_line.sld"));
+        assertTrue(content.contains("default_polygon.sld"));
+    }
+
+    @Test
+    public void testReadGlobalStyleResource() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse("/rest/resource/styles/teststyle.sld");
+        assertEquals(200, response.getStatus());
+        assertEquals("<sld/>", response.getContentAsString());
+    }
+
+    @Test
+    public void testUploadToGlobalStylesDenied() throws Exception {
+        MockHttpServletResponse response =
+                putAsServletResponse("/rest/resource/styles/injected.sld", "<sld/>", MediaType.TEXT_PLAIN_VALUE);
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteGlobalStyleResourceDenied() throws Exception {
+        MockHttpServletResponse response = deleteAsServletResponse("/rest/resource/styles/teststyle.sld");
+        assertEquals(403, response.getStatus());
+
+        // verify file still exists
+        assertTrue(Resources.exists(getDataDirectory().get("styles/teststyle.sld")));
+    }
+
+    // -- Admin has full access --
+
+    @Test
+    public void testAdminCanAccessAllResources() throws Exception {
+        setRequestAuth("admin", "geoserver");
+
+        MockHttpServletResponse response =
+                getAsServletResponse("/rest/resource/workspaces/%s/testfile.txt".formatted(WORKSPACE));
+        assertEquals(200, response.getStatus());
+
+        response = getAsServletResponse("/rest/resource/workspaces/%s/otherfile.txt".formatted(OTHER_WORKSPACE));
+        assertEquals(200, response.getStatus());
+    }
+
+    // -- Resource headers --
+
+    @Test
+    public void testResourceHeadersOwnWorkspace() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse("/rest/resource/workspaces/%s/testfile.txt".formatted(WORKSPACE));
+        assertEquals(200, response.getStatus());
+
+        assertNotNull(response.getHeader("Last-Modified"));
+        assertEquals("resource", response.getHeader("Resource-Type"));
+        assertNotNull(response.getHeader("Resource-Parent"));
+    }
+
+    @Test
+    public void testDirectoryHeadersOwnWorkspace() throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse("/rest/resource/workspaces/%s?format=json".formatted(WORKSPACE));
+        assertEquals(200, response.getStatus());
+
+        assertEquals("directory", response.getHeader("Resource-Type"));
+    }
+}

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/SecureResourceStoreTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/SecureResourceStoreTest.java
@@ -1,0 +1,195 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+/** Unit tests for {@link SecureResourceStore}. */
+public class SecureResourceStoreTest {
+
+    private SecureResourceStore secureStore;
+    private ResourceStore delegate;
+    private WorkspaceAdminAuthorizer authorizer;
+    private Authentication authentication;
+    private GeoServerSecurityManager securityManager;
+    private Resource workspacesDir;
+    private Resource toppWorkspace;
+    private Resource sfWorkspace;
+    private Resource styleDir;
+
+    @Before
+    public void setUp() {
+        delegate = mock(ResourceStore.class);
+        authorizer = mock(WorkspaceAdminAuthorizer.class);
+        authentication = mock(Authentication.class);
+        securityManager = mock(GeoServerSecurityManager.class);
+
+        // Set up security context with our mocked authentication
+        SecurityContextImpl securityContext = new SecurityContextImpl();
+        securityContext.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        // Set up mock resources
+        workspacesDir = mock(Resource.class);
+        when(workspacesDir.path()).thenReturn("workspaces");
+        when(workspacesDir.name()).thenReturn("workspaces");
+
+        toppWorkspace = mock(Resource.class);
+        when(toppWorkspace.path()).thenReturn("workspaces/topp");
+        when(toppWorkspace.name()).thenReturn("topp");
+
+        sfWorkspace = mock(Resource.class);
+        when(sfWorkspace.path()).thenReturn("workspaces/sf");
+        when(sfWorkspace.name()).thenReturn("sf");
+
+        styleDir = mock(Resource.class);
+        when(styleDir.path()).thenReturn("styles");
+        when(styleDir.name()).thenReturn("styles");
+
+        // Configure delegate to return our mock resources
+        when(delegate.get("workspaces")).thenReturn(workspacesDir);
+        when(delegate.get("workspaces/topp")).thenReturn(toppWorkspace);
+        when(delegate.get("workspaces/sf")).thenReturn(sfWorkspace);
+        when(delegate.get("styles")).thenReturn(styleDir);
+
+        // Configure workspaces directory to return workspace resources
+        when(workspacesDir.list()).thenReturn(Arrays.asList(toppWorkspace, sfWorkspace));
+
+        GeoServerExtensionsHelper.singleton("mockSecurityManager", securityManager, GeoServerSecurityManager.class);
+        GeoServerExtensionsHelper.singleton("mockWorkspaceAdminAuthorizer", authorizer, WorkspaceAdminAuthorizer.class);
+
+        // Create the secure store
+        secureStore = new SecureResourceStore(delegate);
+    }
+
+    @After
+    public void tearDown() {
+        // Reset static mocks
+        GeoServerExtensionsHelper.init(null);
+
+        // Clear security context
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void testGetResourceAsAdmin() {
+        // Setup user as admin
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(true);
+
+        // When user is admin, should get direct access to resources without security wrapping
+        Resource resource = secureStore.get("workspaces/topp");
+        assertEquals(toppWorkspace, resource);
+        assertFalse(resource instanceof SecuredResource);
+    }
+
+    @Test
+    public void testGetResourceAsWorkspaceAdmin() {
+        // Setup user as workspace admin, but not global admin
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // When user is workspace admin, resources should be security wrapped
+        Resource resource = secureStore.get("workspaces/topp");
+        assertNotNull(resource);
+        assertTrue(resource instanceof SecuredResource);
+    }
+
+    @Test
+    public void testRemoveAllowed() {
+        // Setup security so user can write to the resource
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        // Create a spied secureStore so we can mock the canWrite method
+        secureStore = spy(secureStore);
+        doReturn(true).when(secureStore).canWrite(anyString());
+
+        // Should delegate to underlying store when allowed
+        when(delegate.remove("workspaces/topp")).thenReturn(true);
+
+        assertTrue(secureStore.remove("workspaces/topp"));
+        verify(delegate).remove("workspaces/topp");
+    }
+
+    @Test
+    public void testRemoveDenied() {
+        // Setup security so user cannot write to the resource
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        // Create a spied secureStore so we can mock the canWrite method
+        secureStore = spy(secureStore);
+        doReturn(false).when(secureStore).canWrite(anyString());
+
+        // Should not delegate to underlying store when not allowed
+        assertFalse(secureStore.remove("workspaces/sf"));
+
+        // Note: verify that remove was not called on delegate
+    }
+
+    @Test
+    public void testMoveAllowed() {
+        // Setup security so user can write to both source and target
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        // Create a spied secureStore so we can mock the canWrite method
+        secureStore = spy(secureStore);
+        doReturn(true).when(secureStore).canWrite(anyString());
+
+        // Should delegate to underlying store when allowed
+        when(delegate.move("workspaces/topp/old", "workspaces/topp/new")).thenReturn(true);
+
+        assertTrue(secureStore.move("workspaces/topp/old", "workspaces/topp/new"));
+        verify(delegate).move("workspaces/topp/old", "workspaces/topp/new");
+    }
+
+    @Test
+    public void testMoveDeniedSourceNotWritable() {
+        // Setup security so user cannot write to source
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        // Create a spied secureStore so we can mock the canWrite method
+        secureStore = spy(secureStore);
+        doReturn(false).when(secureStore).canWrite("workspaces/sf/source");
+        doReturn(true).when(secureStore).canWrite("workspaces/topp/dest");
+
+        // Should not delegate to underlying store when source not writable
+        assertFalse(secureStore.move("workspaces/sf/source", "workspaces/topp/dest"));
+    }
+
+    @Test
+    public void testMoveDeniedTargetNotWritable() {
+        // Setup security so user cannot write to target
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        // Create a spied secureStore so we can mock the canWrite method
+        secureStore = spy(secureStore);
+        doReturn(true).when(secureStore).canWrite("workspaces/topp/source");
+        doReturn(false).when(secureStore).canWrite("workspaces/sf/dest");
+
+        // Should not delegate to underlying store when target not writable
+        assertFalse(secureStore.move("workspaces/topp/source", "workspaces/sf/dest"));
+    }
+}

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/SecureResourceStoreTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/SecureResourceStoreTest.java
@@ -1,0 +1,176 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.ResourceStore;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+/** Unit tests for {@link SecureResourceStore}. */
+public class SecureResourceStoreTest {
+
+    private SecureResourceStore secureStore;
+    private ResourceStore delegate;
+    private WorkspaceAdminAuthorizer authorizer;
+    private Authentication authentication;
+    private GeoServerSecurityManager securityManager;
+    private Resource workspacesDir;
+    private Resource toppWorkspace;
+    private Resource sfWorkspace;
+    private Resource styleDir;
+
+    @Before
+    public void setUp() {
+        delegate = mock(ResourceStore.class);
+        authorizer = mock(WorkspaceAdminAuthorizer.class);
+        authentication = mock(Authentication.class);
+        securityManager = mock(GeoServerSecurityManager.class);
+
+        SecurityContextImpl securityContext = new SecurityContextImpl();
+        securityContext.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        workspacesDir = mock(Resource.class);
+        when(workspacesDir.path()).thenReturn("workspaces");
+        when(workspacesDir.name()).thenReturn("workspaces");
+
+        toppWorkspace = mock(Resource.class);
+        when(toppWorkspace.path()).thenReturn("workspaces/topp");
+        when(toppWorkspace.name()).thenReturn("topp");
+
+        sfWorkspace = mock(Resource.class);
+        when(sfWorkspace.path()).thenReturn("workspaces/sf");
+        when(sfWorkspace.name()).thenReturn("sf");
+
+        styleDir = mock(Resource.class);
+        when(styleDir.path()).thenReturn("styles");
+        when(styleDir.name()).thenReturn("styles");
+
+        when(delegate.get("workspaces")).thenReturn(workspacesDir);
+        when(delegate.get("workspaces/topp")).thenReturn(toppWorkspace);
+        when(delegate.get("workspaces/sf")).thenReturn(sfWorkspace);
+        when(delegate.get("styles")).thenReturn(styleDir);
+
+        when(workspacesDir.list()).thenReturn(Arrays.asList(toppWorkspace, sfWorkspace));
+
+        GeoServerExtensionsHelper.singleton("mockSecurityManager", securityManager, GeoServerSecurityManager.class);
+        GeoServerExtensionsHelper.singleton("mockWorkspaceAdminAuthorizer", authorizer, WorkspaceAdminAuthorizer.class);
+
+        secureStore = new SecureResourceStore(delegate);
+    }
+
+    @After
+    public void tearDown() {
+        GeoServerExtensionsHelper.init(null);
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void testGetResourceAsAdmin() {
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(true);
+
+        // When user is admin, should get direct access to resources without security wrapping
+        Resource resource = secureStore.get("workspaces/topp");
+        assertEquals(toppWorkspace, resource);
+        assertFalse(resource instanceof SecuredResource);
+    }
+
+    @Test
+    public void testGetResourceAsWorkspaceAdmin() {
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // When user is workspace admin, resources should be security wrapped
+        Resource resource = secureStore.get("workspaces/topp");
+        assertNotNull(resource);
+        assertTrue(resource instanceof SecuredResource);
+    }
+
+    @Test
+    public void testRemoveAllowed() {
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        secureStore = spy(secureStore);
+        doReturn(true).when(secureStore).canWrite(anyString());
+
+        // Should delegate to underlying store when allowed
+        when(delegate.remove("workspaces/topp")).thenReturn(true);
+
+        assertTrue(secureStore.remove("workspaces/topp"));
+        verify(delegate).remove("workspaces/topp");
+    }
+
+    @Test
+    public void testRemoveDenied() {
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        secureStore = spy(secureStore);
+        doReturn(false).when(secureStore).canWrite(anyString());
+
+        // Should not delegate to underlying store when not allowed
+        assertFalse(secureStore.remove("workspaces/sf"));
+        verify(delegate, never()).remove(anyString());
+    }
+
+    @Test
+    public void testMoveAllowed() {
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        secureStore = spy(secureStore);
+        doReturn(true).when(secureStore).canWrite(anyString());
+
+        // Should delegate to underlying store when allowed
+        when(delegate.move("workspaces/topp/old", "workspaces/topp/new")).thenReturn(true);
+
+        assertTrue(secureStore.move("workspaces/topp/old", "workspaces/topp/new"));
+        verify(delegate).move("workspaces/topp/old", "workspaces/topp/new");
+    }
+
+    @Test
+    public void testMoveDeniedSourceNotWritable() {
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        secureStore = spy(secureStore);
+        doReturn(false).when(secureStore).canWrite("workspaces/sf/source");
+        doReturn(true).when(secureStore).canWrite("workspaces/topp/dest");
+
+        // Should not delegate to underlying store when source not writable
+        assertFalse(secureStore.move("workspaces/sf/source", "workspaces/topp/dest"));
+    }
+
+    @Test
+    public void testMoveDeniedTargetNotWritable() {
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+
+        secureStore = spy(secureStore);
+        doReturn(true).when(secureStore).canWrite("workspaces/topp/source");
+        doReturn(false).when(secureStore).canWrite("workspaces/sf/dest");
+
+        // Should not delegate to underlying store when target not writable
+        assertFalse(secureStore.move("workspaces/topp/source", "workspaces/sf/dest"));
+    }
+}

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/SecuredResourceTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/SecuredResourceTest.java
@@ -1,0 +1,262 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.rest.RestException;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.WorkspaceAccessLimits;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+/** Unit tests for {@link SecuredResource}. */
+public class SecuredResourceTest {
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    private Path root;
+
+    private FileSystemResourceStore delegate;
+    private SecureResourceStore store;
+
+    private GeoServerSecurityManager securityManager;
+    private WorkspaceAdminAuthorizer authorizer;
+    private Authentication authentication;
+
+    @Before
+    public void setUp() throws IOException {
+        root = tmpDir.getRoot().toPath();
+        delegate = new FileSystemResourceStore(tmpDir.getRoot());
+
+        // create directory structure
+        tmpDir.newFolder("workspaces", "topp", "datastores");
+        tmpDir.newFolder("workspaces", "sf");
+        tmpDir.newFolder("styles");
+
+        securityManager = mock(GeoServerSecurityManager.class);
+        authorizer = mock(WorkspaceAdminAuthorizer.class);
+
+        GeoServerExtensionsHelper.singleton("securityManager", securityManager, GeoServerSecurityManager.class);
+        GeoServerExtensionsHelper.singleton("workspaceAdminAuthorizer", authorizer, WorkspaceAdminAuthorizer.class);
+
+        // default: non-admin workspace admin user for "topp"
+        authentication = new TestingAuthenticationToken("wsadmin", "password", "ROLE_USER");
+        authentication.setAuthenticated(true);
+        setAuthentication(authentication);
+
+        when(securityManager.checkAuthenticationForAdminRole()).thenReturn(false);
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // "topp" is administrable
+        WorkspaceAccessLimits toppLimits = mock(WorkspaceAccessLimits.class);
+        when(toppLimits.isAdminable()).thenReturn(true);
+        when(authorizer.getWorkspaceAccessLimits(authentication, "topp")).thenReturn(toppLimits);
+
+        // "sf" is not administrable
+        WorkspaceAccessLimits sfLimits = mock(WorkspaceAccessLimits.class);
+        when(sfLimits.isAdminable()).thenReturn(false);
+        when(authorizer.getWorkspaceAccessLimits(authentication, "sf")).thenReturn(sfLimits);
+
+        store = new SecureResourceStore(delegate);
+    }
+
+    @After
+    public void tearDown() {
+        GeoServerExtensionsHelper.init(null);
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setAuthentication(Authentication auth) {
+        SecurityContextImpl ctx = new SecurityContextImpl();
+        ctx.setAuthentication(auth);
+        SecurityContextHolder.setContext(ctx);
+    }
+
+    private SecuredResource securedResource(String path) {
+        Resource resource = delegate.get(path);
+        return new SecuredResource(resource, store);
+    }
+
+    // -- getType --
+
+    @Test
+    public void testGetType_readable() {
+        SecuredResource resource = securedResource("workspaces/topp/datastores");
+        assertEquals(Resource.Type.DIRECTORY, resource.getType());
+    }
+
+    @Test
+    public void testGetType_notReadable() {
+        SecuredResource resource = securedResource("workspaces/sf");
+        assertEquals(Resource.Type.UNDEFINED, resource.getType());
+    }
+
+    // -- list --
+
+    @Test
+    public void testList() {
+        SecuredResource resource = securedResource("workspaces/topp");
+        List<Resource> children = resource.list();
+        assertFalse(children.isEmpty());
+        for (Resource child : children) {
+            assertTrue(child instanceof SecuredResource);
+        }
+        assertTrue(children.stream().anyMatch(r -> "datastores".equals(r.name())));
+    }
+
+    @Test
+    public void testList_notReadable() {
+        SecuredResource resource = securedResource("workspaces/sf");
+        assertTrue(resource.list().isEmpty());
+    }
+
+    // -- delete --
+
+    @Test
+    public void testDelete_writable() throws IOException {
+        tmpDir.newFile("workspaces/topp/datastores/todelete.txt");
+        SecuredResource resource = securedResource("workspaces/topp/datastores/todelete.txt");
+        assertTrue(resource.delete());
+        assertFalse(Files.isRegularFile(root.resolve("workspaces/topp/datastores/todelete.txt")));
+    }
+
+    @Test
+    public void testDelete_notWritable() throws IOException {
+        tmpDir.newFile("workspaces/sf/protected.txt");
+        SecuredResource resource = securedResource("workspaces/sf/protected.txt");
+        assertFalse(resource.delete());
+        assertTrue(Files.isRegularFile(root.resolve("workspaces/sf/protected.txt")));
+    }
+
+    // -- renameTo --
+
+    @Test
+    public void testRenameTo_writable() throws IOException {
+        tmpDir.newFile("workspaces/topp/datastores/old.txt");
+        SecuredResource source = securedResource("workspaces/topp/datastores/old.txt");
+        Resource target = delegate.get("workspaces/topp/datastores/new.txt");
+
+        assertTrue(source.renameTo(target));
+        assertFalse(Files.exists(root.resolve("workspaces/topp/datastores/old.txt")));
+        assertTrue(Files.isRegularFile(root.resolve("workspaces/topp/datastores/new.txt")));
+    }
+
+    @Test
+    public void testRenameTo_notWritable() throws IOException {
+        tmpDir.newFile("workspaces/sf/old.txt");
+        SecuredResource source = securedResource("workspaces/sf/old.txt");
+        Resource target = delegate.get("workspaces/sf/new.txt");
+
+        assertFalse(source.renameTo(target));
+        assertTrue(Files.isRegularFile(root.resolve("workspaces/sf/old.txt")));
+    }
+
+    @Test
+    public void testIn_readable() throws IOException {
+        File f = tmpDir.newFile("workspaces/topp/datastores/data.txt");
+        Files.writeString(f.toPath(), "hello");
+        SecuredResource resource = securedResource("workspaces/topp/datastores/data.txt");
+
+        try (InputStream in = resource.in()) {
+            assertEquals("hello", new String(in.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test(expected = RestException.class)
+    public void testIn_notReadable() {
+        securedResource("workspaces/sf/secret.txt").in();
+    }
+
+    @Test
+    public void testOut_writable() throws IOException {
+        SecuredResource resource = securedResource("workspaces/topp/datastores/output.txt");
+
+        try (OutputStream out = resource.out()) {
+            out.write("written".getBytes(StandardCharsets.UTF_8));
+        }
+
+        String content = Files.readString(root.resolve("workspaces/topp/datastores/output.txt"));
+        assertEquals("written", content);
+    }
+
+    @Test(expected = RestException.class)
+    public void testOut_notWritable() {
+        securedResource("workspaces/sf/blocked.txt").out();
+    }
+
+    @Test
+    public void testFile_writable() {
+        SecuredResource resource = securedResource("workspaces/topp/datastores/test.txt");
+        File file = resource.file();
+        assertNotNull(file);
+        assertEquals(root.resolve("workspaces/topp/datastores/test.txt").toFile(), file);
+    }
+
+    @Test(expected = RestException.class)
+    public void testFile_notWritable() {
+        securedResource("workspaces/sf/blocked.txt").file();
+    }
+
+    @Test
+    public void testDir_writable() {
+        SecuredResource resource = securedResource("workspaces/topp/datastores");
+        File dir = resource.dir();
+        assertNotNull(dir);
+        assertEquals(root.resolve("workspaces/topp/datastores").toFile(), dir);
+        assertTrue(dir.isDirectory());
+    }
+
+    @Test(expected = RestException.class)
+    public void testDir_notWritable() {
+        securedResource("workspaces/sf").dir();
+    }
+
+    @Test
+    public void testLastModified() {
+        assertTrue(securedResource("workspaces/topp/datastores").lastmodified() > 0);
+    }
+
+    @Test
+    public void testParent() {
+        Resource parent = securedResource("workspaces/topp/datastores").parent();
+        assertNotNull(parent);
+        assertTrue(parent instanceof SecuredResource);
+        assertEquals("topp", parent.name());
+    }
+
+    @Test
+    public void testGet() {
+        Resource child = securedResource("workspaces/topp").get("datastores");
+        assertNotNull(child);
+        assertTrue(child instanceof SecuredResource);
+        assertEquals("datastores", child.name());
+    }
+}

--- a/src/restconfig/src/test/java/org/geoserver/rest/resources/WorkspaceAdminResourceFilterTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/resources/WorkspaceAdminResourceFilterTest.java
@@ -1,0 +1,187 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.geoserver.rest.resources.WorkspaceAdminResourceFilter.ResourceAccess;
+import org.geoserver.security.WorkspaceAccessLimits;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.core.Authentication;
+
+/** Unit tests for {@link WorkspaceAdminResourceFilter}. */
+public class WorkspaceAdminResourceFilterTest {
+
+    private WorkspaceAdminResourceFilter filter;
+    private WorkspaceAdminAuthorizer authorizer;
+    private Authentication authentication;
+
+    @Before
+    public void setUp() {
+        authorizer = mock(WorkspaceAdminAuthorizer.class);
+        authentication = mock(Authentication.class);
+        filter = new WorkspaceAdminResourceFilter(authorizer);
+    }
+
+    @Test
+    public void testAccessLevelsEnum() {
+        // Test the ResourceAccess enum values behave as expected
+        assertTrue(ResourceAccess.READ.canRead());
+        assertFalse(ResourceAccess.READ.canWrite());
+
+        assertTrue(ResourceAccess.WRITE.canRead());
+        assertTrue(ResourceAccess.WRITE.canWrite());
+
+        assertFalse(ResourceAccess.NONE.canRead());
+        assertFalse(ResourceAccess.NONE.canWrite());
+    }
+
+    @Test
+    public void testGetAccessLimitsRootPath() {
+        // Setup user as workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // Root path should be readable but not writable
+        ResourceAccess access = filter.getAccessLimits(authentication, "");
+        assertTrue(access.canRead());
+        assertFalse(access.canWrite());
+        assertEquals(ResourceAccess.READ, access);
+    }
+
+    @Test
+    public void testGetAccessLimitsWorkspacesPath() {
+        // Setup user as workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // Workspaces path should be readable but not writable
+        ResourceAccess access = filter.getAccessLimits(authentication, "workspaces");
+        assertTrue(access.canRead());
+        assertFalse(access.canWrite());
+        assertEquals(ResourceAccess.READ, access);
+    }
+
+    @Test
+    public void testGetAccessLimitsSpecificWorkspacePath() {
+        // Setup user as workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // Setup workspace access limits for the "topp" workspace
+        WorkspaceAccessLimits limits = mock(WorkspaceAccessLimits.class);
+        when(limits.isAdminable()).thenReturn(true);
+        when(authorizer.getWorkspaceAccessLimits(eq(authentication), eq("topp")))
+                .thenReturn(limits);
+
+        // User should have full access to the workspace path
+        ResourceAccess access = filter.getAccessLimits(authentication, "workspaces/topp");
+        assertTrue(access.canRead());
+        assertTrue(access.canWrite());
+        assertEquals(ResourceAccess.WRITE, access);
+    }
+
+    @Test
+    public void testGetAccessLimitsSubPathWithinWorkspace() {
+        // Setup user as workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // Setup workspace access limits for the "topp" workspace
+        WorkspaceAccessLimits limits = mock(WorkspaceAccessLimits.class);
+        when(limits.isAdminable()).thenReturn(true);
+        when(authorizer.getWorkspaceAccessLimits(eq(authentication), eq("topp")))
+                .thenReturn(limits);
+
+        // User should have full access to paths within the workspace
+        ResourceAccess access = filter.getAccessLimits(authentication, "workspaces/topp/datastores/tiger/featuretypes");
+        assertTrue(access.canRead());
+        assertTrue(access.canWrite());
+        assertEquals(ResourceAccess.WRITE, access);
+    }
+
+    @Test
+    public void testGetAccessLimitsUnauthorizedWorkspace() {
+        // Setup user as workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // Setup no access to "sf" workspace
+        when(authorizer.getWorkspaceAccessLimits(eq(authentication), eq("sf"))).thenReturn(null);
+
+        // User should not have access to unauthorized workspace
+        ResourceAccess access = filter.getAccessLimits(authentication, "workspaces/sf");
+        assertFalse(access.canRead());
+        assertFalse(access.canWrite());
+        assertEquals(ResourceAccess.NONE, access);
+    }
+
+    @Test
+    public void testGetAccessLimitsNonAdminableWorkspace() {
+        // Setup user as workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // Setup workspace access limits for the "topp" workspace, but not adminable
+        WorkspaceAccessLimits limits = mock(WorkspaceAccessLimits.class);
+        when(limits.isAdminable()).thenReturn(false);
+        when(authorizer.getWorkspaceAccessLimits(eq(authentication), eq("topp")))
+                .thenReturn(limits);
+
+        // User should not have access to non-adminable workspace
+        ResourceAccess access = filter.getAccessLimits(authentication, "workspaces/topp");
+        assertFalse(access.canRead());
+        assertFalse(access.canWrite());
+        assertEquals(ResourceAccess.NONE, access);
+    }
+
+    @Test
+    public void testGetAccessLimitsNonWorkspaceAdmin() {
+        // Setup user not as workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(false);
+
+        // User should not have access to any paths
+        ResourceAccess access = filter.getAccessLimits(authentication, "workspaces");
+        assertFalse(access.canRead());
+        assertFalse(access.canWrite());
+        assertEquals(ResourceAccess.NONE, access);
+
+        access = filter.getAccessLimits(authentication, "workspaces/topp");
+        assertFalse(access.canRead());
+        assertFalse(access.canWrite());
+        assertEquals(ResourceAccess.NONE, access);
+    }
+
+    @Test
+    public void testGetAccessLimitsWithTrailingSlash() {
+        // Setup user as workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // Setup workspace access limits for the "topp" workspace
+        WorkspaceAccessLimits limits = mock(WorkspaceAccessLimits.class);
+        when(limits.isAdminable()).thenReturn(true);
+        when(authorizer.getWorkspaceAccessLimits(eq(authentication), eq("topp")))
+                .thenReturn(limits);
+
+        // Trailing slash should be handled correctly
+        ResourceAccess access = filter.getAccessLimits(authentication, "workspaces/topp/");
+        assertTrue(access.canRead());
+        assertTrue(access.canWrite());
+        assertEquals(ResourceAccess.WRITE, access);
+    }
+
+    @Test
+    public void testGetAccessLimitsNonMatchingPath() {
+        // Setup user as workspace admin
+        when(authorizer.isWorkspaceAdmin(authentication)).thenReturn(true);
+
+        // Non-matching path should not be accessible
+        ResourceAccess access = filter.getAccessLimits(authentication, "logging");
+        assertFalse(access.canRead());
+        assertFalse(access.canWrite());
+        assertEquals(ResourceAccess.NONE, access);
+    }
+}

--- a/src/web/core/src/main/java/org/geoserver/web/WorkspaceAdminComponentAuthorizer.java
+++ b/src/web/core/src/main/java/org/geoserver/web/WorkspaceAdminComponentAuthorizer.java
@@ -5,28 +5,17 @@
  */
 package org.geoserver.web;
 
-import org.geoserver.catalog.Catalog;
-import org.geoserver.security.ResourceAccessManager;
-import org.geoserver.security.SecureCatalogImpl;
-import org.jspecify.annotations.Nullable;
+import org.geoserver.security.workspaceadmin.WorkspaceAdminAuthorizer;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
 
 /**
  * Authorizer that allows access if the user has admin rights to any workspace.
  *
  * @author Justin Deoliveira, OpenGeo
- * @see ResourceAccessManager#isWorkspaceAdmin(Authentication, Catalog)
+ * @see WorkspaceAdminAuthorizer#isWorkspaceAdmin(Authentication)
  */
 @SuppressWarnings("serial")
 public class WorkspaceAdminComponentAuthorizer extends AdminComponentAuthorizer {
-
-    /**
-     * Key to cache the result of {@link #isWorkspaceAdmin(Authentication)} on the request's {@link RequestAttributes}
-     * in {@link RequestAttributes#SCOPE_REQUEST request scope}
-     */
-    static final String REQUEST_CONTEXT_CACHE_KEY = "WORKSPACEADMIN_COMPONENT_AUTHORIZER_VALUE";
 
     @Override
     public boolean isAccessAllowed(Class<?> componentClass, Authentication authentication) {
@@ -36,50 +25,10 @@ public class WorkspaceAdminComponentAuthorizer extends AdminComponentAuthorizer 
             return true;
         }
 
-        // if not authenticated deny access
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return false;
-        }
-
-        // this authorizer may be called several times per request, use a per-request cached value
-        Boolean workspaceAdmin = getCachedValue();
-        if (null == workspaceAdmin) {
-            workspaceAdmin = isWorkspaceAdmin(authentication);
-            setCachedValue(workspaceAdmin.booleanValue());
-        }
-        return workspaceAdmin;
+        return getWorkspaceAdminAuthorizer().isWorkspaceAdmin(authentication);
     }
 
-    /** Check if the current user has any admin privilege on at least one workspace. */
-    boolean isWorkspaceAdmin(Authentication authentication) {
-        ResourceAccessManager manager = getAccessManager();
-        return null != manager && manager.isWorkspaceAdmin(authentication, getCatalog());
-    }
-
-    private Catalog getCatalog() {
-        return getSecurityManager().getCatalog();
-    }
-
-    ResourceAccessManager getAccessManager() {
-        // the secure catalog builds and owns the ResourceAccessManager
-        SecureCatalogImpl secureCatalog = GeoServerApplication.get().getBeanOfType(SecureCatalogImpl.class);
-        if (null == secureCatalog) return null;
-        return secureCatalog.getResourceAccessManager();
-    }
-
-    void setCachedValue(boolean workspaceAdmin) {
-        RequestAttributes atts = RequestContextHolder.getRequestAttributes();
-        if (null != atts) {
-            atts.setAttribute(REQUEST_CONTEXT_CACHE_KEY, workspaceAdmin, RequestAttributes.SCOPE_REQUEST);
-        }
-    }
-
-    @Nullable
-    Boolean getCachedValue() {
-        RequestAttributes atts = RequestContextHolder.getRequestAttributes();
-        if (null != atts) {
-            return (Boolean) atts.getAttribute(REQUEST_CONTEXT_CACHE_KEY, RequestAttributes.SCOPE_REQUEST);
-        }
-        return null;
+    WorkspaceAdminAuthorizer getWorkspaceAdminAuthorizer() {
+        return WorkspaceAdminAuthorizer.get().orElseThrow();
     }
 }


### PR DESCRIPTION
[![GEOS-11421](https://badgen.net/badge/JIRA/GEOS-11421/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11421) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Extends workspace admin access control to the REST API, matching the permissions workspace administrators already have in the web UI.

The default `rest.properties` restricts the whole REST API to `ROLE_ADMINISTRATOR`. It can be edited to open endpoints to other roles, but it has no concept of workspace scoping.

This change adds a complementary configuration file, `security/rest.workspaceadmin.properties`, that opens selected endpoints to any user the security subsystem identifies as a workspace administrator. Which workspaces and resources are visible is decided by the existing catalog security, based on the admin access rules in `layers.properties`. 

In short: `rest.workspaceadmin.properties` opens the door to endpoints, `layers.properties` determines what's behind the door.

### How it works

- `WorkspaceAdminAuthorizer`: shared authorization logic shared by the web UI and the REST API. The workspace admin check is cached per request.
- `WorkspaceAdminAuthorizationManager`: joins the Spring Security filter chain next to the existing authenticated/role managers. Grants access when a workspace admin rule matches and abstains otherwise.
- `WorkspaceAdminRESTAccessRuleDAO` / `WorkspaceAdminRestfulDefinitionSource`: load and match the URL pattern rules from `rest.workspaceadmin.properties`, created from a template on first startup.
- `RESTfulDefinitionSourceProxy`: combines the standard `rest.properties` rules and the workspace admin rules into a single `SecurityMetadataSource`.
- `SecureResourceStore` / `SecuredResource`: wrap the data directory `ResourceStore` behind `/rest/resource`, restricting workspace admins to their workspaces plus read-only global collections. Hidden resources return 404; visible but read-only ones return 403 on write.

### Default access rules

First match wins; unmatched endpoints fall through to `rest.properties` (admin-only by default).

| Endpoint pattern | Access | Notes |
|---|---|---|
| `/rest/workspaces`, `/rest/namespaces` | read | Listings, filtered to administrable workspaces |
| `/rest/workspaces/{workspace}` | read + PUT | Update allowed, rename and delete denied |
| `/rest/workspaces/{workspace}/**` | read/write | Datastores, styles, layergroups, etc. |
| `/rest/layers/**` | read/write | Filtered to administrable workspaces |
| `/rest/styles/**`, `/rest/templates/**` | read | Global styles/templates are read-only |
| `/rest/resource/workspaces/{workspace}/**` | read/write | Resource browser |
| `/rest/resource/styles/**` | read | Global style resources |
| `/rest/services/*/workspaces/{workspace}/**` | read/write | Per-workspace service config (WFS, WMS, etc.) |
| `/rest/crs/**`, `/rest/fonts/**` | read | CRS lookups and fonts |
| `/rest/services/*/settings` | *(no rule)* | Global service settings stay admin-only |

Noteworthy:

- Workspace admins cannot rename workspaces/namespaces or change the default ones (403).
- The REST index (`/rest`) lists only the endpoints the caller can access.
- `ServiceSettingsController` now returns `404` when the requested workspace does not exist (or is hidden from the caller), instead of falling through to the global service settings. This also affects full admins using a wrong workspace name.

### Documentation

New Workspace Administration section under security: a landing page explaining the three configuration layers, a reference for the REST access rules, and a hands-on tutorial using the default data directory. Cross-links added from the layer security, sandbox, production config, and data admin pages.

### Testing

Unit tests for each new class, plus REST integration tests covering the catalog endpoints (`WorkspaceAdminRestIntegrationTest`), the resource browser (`ResourceControllerWorkspaceAdminTest`), and per-workspace WFS/WMS settings.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 