### PR TITLE
[Backport 2.24.x] Re-align expected outputs due to improvement in GT envelope reprojection

### DIFF
--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLControllerTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLControllerTest.java
@@ -371,9 +371,9 @@ public class MapMLControllerTest extends WMSTestSupport {
         String zoom = doc.select("mapml-viewer").attr("zoom");
         // zoom is calculated based on a display size and the extent of the
         // layer.  In the case of the test layer group "layerGroup", the extent is the
-        // maximum extent, so zoom should be 0;
+        // maximum extent, so zoom should be 1;
         if (layerName.equalsIgnoreCase("layerGroup")) {
-            assertTrue("0".equalsIgnoreCase(zoom));
+            assertTrue("1".equalsIgnoreCase(zoom));
         } else {
             assertTrue(!"0".equalsIgnoreCase(zoom));
         }
@@ -462,20 +462,12 @@ public class MapMLControllerTest extends WMSTestSupport {
                                 || input.getType() == InputType.WIDTH
                                 || input.getType() == InputType.HEIGHT);
                 if (input.getType() == InputType.LOCATION && input.getAxis() == AxisType.EASTING) {
-                    assertTrue(
-                            "map-input[type=location/@min must equal -2.0037508342789244E7",
-                            "-2.0037508342789244E7".equalsIgnoreCase(input.getMin()));
-                    assertTrue(
-                            "map-input[type=location/@max must equal 2.0037508342789244E7",
-                            "2.0037508342789244E7".equalsIgnoreCase(input.getMax()));
+                    assertEquals(-2E7, Double.parseDouble(input.getMin()), 1E6);
+                    assertEquals(2E7, Double.parseDouble(input.getMax()), 1E6);
                 } else if (input.getType() == InputType.LOCATION
                         && input.getAxis() == AxisType.NORTHING) {
-                    assertTrue(
-                            "map-input[type=location/@min must equal -2.0037508342780735E7",
-                            "-2.0037508342780735E7".equalsIgnoreCase(input.getMin()));
-                    assertTrue(
-                            "map-input[type=location/@max must equal 2.003750834278071E7",
-                            "2.003750834278071E7".equalsIgnoreCase(input.getMax()));
+                    assertEquals(-2E7, Double.parseDouble(input.getMin()), 5E6);
+                    assertEquals(2E7, Double.parseDouble(input.getMax()), 5E6);
                 }
             } else {
                 fail("Unrecognized test object type:" + o.getClass().getTypeName());

--- a/src/wms/src/test/java/org/geoserver/wms/DefaultWebMapServiceTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/DefaultWebMapServiceTest.java
@@ -85,12 +85,12 @@ public class DefaultWebMapServiceTest extends WMSTestSupport {
         assertTrue("EPSG:41001".equalsIgnoreCase(srs));
         // mockGMR.getBbox() actually returns (-180 , 90 , -90 , 180 ) <- foo
         assertTrue(
-                Math.abs(bbox.getMinX() + 1.9236008009077676E7) < 1E-4
-                        && Math.abs(bbox.getMinY() + 2.2026354993694823E7) < 1E-4
-                        && Math.abs(bbox.getMaxX() - 1.9236008009077676E7) < 1E-4
-                        && Math.abs(bbox.getMaxY() - 2.2026354993694823E7) < 1E-4);
+                Math.abs(bbox.getMinX() + 2.0037508342789244E7) < 1E-4
+                        && Math.abs(bbox.getMinY() + 2.360164725876146E7) < 1E-4
+                        && Math.abs(bbox.getMaxX() - 2.0037508342789244E7) < 1E-4
+                        && Math.abs(bbox.getMaxY() - 2.360164725876146E7) < 1E-4);
         assertEquals("image/gif", format);
-        assertEquals(670, width);
+        assertEquals(652, width);
         assertEquals(768, height);
     }
 
@@ -131,12 +131,12 @@ public class DefaultWebMapServiceTest extends WMSTestSupport {
         assertTrue("WGS84 / Simple Mercator".equalsIgnoreCase(crsString));
         assertTrue("EPSG:41001".equalsIgnoreCase(srs));
         assertTrue(
-                Math.abs(bbox.getMinX() + 1.9236008009077676E7) < 1E-4
-                        && Math.abs(bbox.getMinY() + 2.2026354993694823E7) < 1E-4
-                        && Math.abs(bbox.getMaxX() - 1.9236008009077676E7) < 1E-4
-                        && Math.abs(bbox.getMaxY() - 2.2026354993694823E7) < 1E-4);
+                Math.abs(bbox.getMinX() + 2.0037508342789244E7) < 1E-4
+                        && Math.abs(bbox.getMinY() + 2.360164725876146E7) < 1E-4
+                        && Math.abs(bbox.getMaxX() - 2.0037508342789244E7) < 1E-4
+                        && Math.abs(bbox.getMaxY() - 2.360164725876146E7) < 1E-4);
         assertEquals("image/gif", format);
-        assertEquals(670, width);
+        assertEquals(652, width);
         assertEquals(768, height);
     }
 


### PR DESCRIPTION
Updates tests to match https://github.com/geotools/geotools/pull/4861. Backports the equivalent changes made on 
https://github.com/geoserver/geoserver/pull/7524

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->