### PR TITLE
[Backport 2.25.x] Update expectactions on envelope reprojection

### DIFF
--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
@@ -1294,7 +1294,7 @@ public class MapMLWMSTest extends MapMLTestSupport {
         // check alternate projections have appropriate bounds too
         List<Link> alternateLinks = getLinkByRelType(mapml.getHead().getLinks(), RelType.ALTERNATE);
         testAlternateBounds(
-                alternateLinks, ProjType.OSMTILE, new Envelope(-2E7, 2E7, -2E7, 2E7), 1e6);
+                alternateLinks, ProjType.OSMTILE, new Envelope(-2E7, 2E7, -2E7, 2E7), 5e6);
         testAlternateBounds(
                 alternateLinks, ProjType.APSTILE, new Envelope(-1E7, 1.4E7, -1E7, 1.4E7), 1e6);
         testAlternateBounds(
@@ -1457,20 +1457,11 @@ public class MapMLWMSTest extends MapMLTestSupport {
                                 || input.getType() == InputType.WIDTH
                                 || input.getType() == InputType.HEIGHT);
                 if (input.getType() == InputType.LOCATION && input.getAxis() == AxisType.EASTING) {
-                    assertTrue(
-                            "map-input[type=location/@min must equal -2.0037508342789244E7",
-                            "-2.0037508342789244E7".equalsIgnoreCase(input.getMin()));
-                    assertTrue(
-                            "map-input[type=location/@max must equal 2.0037508342789244E7",
-                            "2.0037508342789244E7".equalsIgnoreCase(input.getMax()));
+                    assertEquals(-2E7, Double.parseDouble(input.getMin()), 1E6);
                 } else if (input.getType() == InputType.LOCATION
                         && input.getAxis() == AxisType.NORTHING) {
-                    assertTrue(
-                            "map-input[type=location/@min must equal -2.0037508342780735E7",
-                            "-2.0037508342780735E7".equalsIgnoreCase(input.getMin()));
-                    assertTrue(
-                            "map-input[type=location/@max must equal 2.003750834278071E7",
-                            "2.003750834278071E7".equalsIgnoreCase(input.getMax()));
+                    assertEquals(-2.3E7, Double.parseDouble(input.getMin()), 3E6);
+                    assertEquals(2.3E7, Double.parseDouble(input.getMax()), 3E6);
                 }
             } else {
                 fail("Unrecognized test object type:" + o.getClass().getTypeName());

--- a/src/wms/src/test/java/org/geoserver/wms/DefaultWebMapServiceTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/DefaultWebMapServiceTest.java
@@ -85,12 +85,12 @@ public class DefaultWebMapServiceTest extends WMSTestSupport {
         assertTrue("EPSG:41001".equalsIgnoreCase(srs));
         // mockGMR.getBbox() actually returns (-180 , 90 , -90 , 180 ) <- foo
         assertTrue(
-                Math.abs(bbox.getMinX() + 1.9236008009077676E7) < 1E-4
-                        && Math.abs(bbox.getMinY() + 2.2026354993694823E7) < 1E-4
-                        && Math.abs(bbox.getMaxX() - 1.9236008009077676E7) < 1E-4
-                        && Math.abs(bbox.getMaxY() - 2.2026354993694823E7) < 1E-4);
+                Math.abs(bbox.getMinX() + 2.0037508342789244E7) < 1E-4
+                        && Math.abs(bbox.getMinY() + 2.360164725876146E7) < 1E-4
+                        && Math.abs(bbox.getMaxX() - 2.0037508342789244E7) < 1E-4
+                        && Math.abs(bbox.getMaxY() - 2.360164725876146E7) < 1E-4);
         assertEquals("image/gif", format);
-        assertEquals(670, width);
+        assertEquals(652, width);
         assertEquals(768, height);
     }
 
@@ -131,12 +131,12 @@ public class DefaultWebMapServiceTest extends WMSTestSupport {
         assertTrue("WGS84 / Simple Mercator".equalsIgnoreCase(crsString));
         assertTrue("EPSG:41001".equalsIgnoreCase(srs));
         assertTrue(
-                Math.abs(bbox.getMinX() + 1.9236008009077676E7) < 1E-4
-                        && Math.abs(bbox.getMinY() + 2.2026354993694823E7) < 1E-4
-                        && Math.abs(bbox.getMaxX() - 1.9236008009077676E7) < 1E-4
-                        && Math.abs(bbox.getMaxY() - 2.2026354993694823E7) < 1E-4);
+                Math.abs(bbox.getMinX() + 2.0037508342789244E7) < 1E-4
+                        && Math.abs(bbox.getMinY() + 2.360164725876146E7) < 1E-4
+                        && Math.abs(bbox.getMaxX() - 2.0037508342789244E7) < 1E-4
+                        && Math.abs(bbox.getMaxY() - 2.360164725876146E7) < 1E-4);
         assertEquals("image/gif", format);
-        assertEquals(670, width);
+        assertEquals(652, width);
         assertEquals(768, height);
     }
 


### PR DESCRIPTION
Update test expectactions to match changes in https://github.com/geotools/geotools/pull/4862
Backport from main.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->