### PR TITLE
[Backport 2.24.x] [GEOS-11453] Failure to look-up default value of custom dimensions on vector layers

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/CustomDimensionFilterConverter.java
+++ b/src/wms/src/main/java/org/geoserver/wms/CustomDimensionFilterConverter.java
@@ -149,7 +149,7 @@ class CustomDimensionFilterConverter {
 
     private Object getDefaultCustomDimension(String name, Class<?> binding) {
         // check the time metadata
-        final DimensionInfo dimensionInfo = customDimensions.get(name);
+        final DimensionInfo dimensionInfo = customDimensions.get(unrollDimPrefix(name));
         if (dimensionInfo == null || !dimensionInfo.isEnabled()) {
             throw new ServiceException(
                     "Layer "

--- a/src/wms/src/test/java/org/geoserver/wms/WMSTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSTest.java
@@ -5,17 +5,23 @@
  */
 package org.geoserver.wms;
 
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.geotools.factory.CommonFactoryFinder.getFilterFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -24,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import javax.xml.namespace.QName;
+import org.geoserver.catalog.DimensionDefaultValueSetting;
 import org.geoserver.catalog.DimensionInfo;
 import org.geoserver.catalog.DimensionPresentation;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -34,7 +41,6 @@ import org.geoserver.data.test.SystemTestData;
 import org.geoserver.platform.ServiceException;
 import org.geotools.api.data.FeatureSource;
 import org.geotools.api.filter.Filter;
-import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.renderer.style.DynamicSymbolFactoryFinder;
@@ -57,7 +63,7 @@ public class WMSTest extends WMSTestSupport {
         super.onSetUp(testData);
         testData.addVectorLayer(
                 TIME_WITH_START_END,
-                Collections.emptyMap(),
+                emptyMap(),
                 "TimeElevationWithStartEnd.properties",
                 getClass(),
                 getCatalog());
@@ -75,9 +81,35 @@ public class WMSTest extends WMSTestSupport {
         getCatalog().save(info);
     }
 
+    /**
+     * set up a feature dimension, but additionally allow to set a default value setting
+     *
+     * @param featureTypeName the feature type name
+     * @param dimensionName the dimension name
+     * @param start the start attribute name
+     * @param end the end attribute name
+     * @param defaultValue the default value setting
+     */
+    protected void setupStartEndTimeDimension(
+            String featureTypeName,
+            String dimensionName,
+            String start,
+            String end,
+            DimensionDefaultValueSetting defaultValue) {
+        FeatureTypeInfo info = getCatalog().getFeatureTypeByName(featureTypeName);
+        DimensionInfo di = new DimensionInfoImpl();
+        di.setEnabled(true);
+        di.setAttribute(start);
+        di.setEndAttribute(end);
+        di.setDefaultValue(defaultValue);
+        di.setPresentation(DimensionPresentation.LIST);
+        info.getMetadata().put(dimensionName, di);
+        getCatalog().save(info);
+    }
+
     @Before
-    public void setWMS() throws Exception {
-        wms = new WMS(getGeoServer());
+    public void setWMS() {
+        wms = getWMS();
     }
 
     @Test
@@ -160,13 +192,15 @@ public class WMSTest extends WMSTestSupport {
 
         FeatureTypeInfo timeWithStartEnd =
                 getCatalog().getFeatureTypeByName(TIME_WITH_START_END.getLocalPart());
+
+        setupStartEndTimeDimension(
+                TIME_WITH_START_END.getLocalPart(), "elevation", "startElevation", "endElevation");
         FeatureSource fs = timeWithStartEnd.getFeatureSource(null, null);
 
         List<Object> times = time == null ? null : Arrays.asList(time);
         List<Object> elevations = elevation == null ? null : Arrays.asList(elevation);
 
-        DimensionFilterBuilder builder =
-                new DimensionFilterBuilder(CommonFactoryFinder.getFilterFactory());
+        DimensionFilterBuilder builder = new DimensionFilterBuilder(getFilterFactory());
         wms.getTimeFilter(times, timeWithStartEnd, builder);
         wms.getElevationFilter(elevations, timeWithStartEnd, builder);
         Filter filter = builder.getFilter();
@@ -184,6 +218,150 @@ public class WMSTest extends WMSTestSupport {
         assertTrue(
                 "expected " + Arrays.toString(expectedIds) + " but got " + results,
                 Arrays.asList(expectedIds).containsAll(results));
+    }
+
+    private static String CUSTOM_DIMENSION_NAME = WMS.DIM_ + "reference_time";
+
+    @Test
+    public void
+            custom_dimension_filter_should_return_all_for_featureInfo_without_custom_dimensions()
+                    throws IOException {
+
+        // clear away the custom dimension
+        FeatureTypeInfo featureTypeInfo =
+                getCatalog().getFeatureTypeByName(TIME_WITH_START_END.getLocalPart());
+        featureTypeInfo.getMetadata().remove(CUSTOM_DIMENSION_NAME);
+        getCatalog().save(featureTypeInfo);
+
+        // without request
+        DimensionFilterBuilder filterBuilder = new DimensionFilterBuilder(getFilterFactory(null));
+        assertEquals(
+                "Custom dimension filter should return 'Filter.INCLUDE' when no custom dimensions are defined.",
+                Filter.INCLUDE,
+                wms.getCustomDimensionFilter(new HashMap<>(), featureTypeInfo, filterBuilder));
+
+        // with request
+        Map<String, String> rawKvp = new HashMap<>();
+        rawKvp.put(
+                CUSTOM_DIMENSION_NAME.toUpperCase(),
+                ISO_INSTANT.format(Instant.parse("2012-02-12T09:05:00Z")));
+
+        assertEquals(
+                "Custom dimension filter should return 'Filter.INCLUDE' when no custom dimensions are defined.",
+                Filter.INCLUDE,
+                wms.getCustomDimensionFilter(rawKvp, featureTypeInfo, filterBuilder));
+    }
+
+    @Test
+    public void custom_dimension_filter_should_return_features_matching_request() throws Exception {
+
+        Map<String, String> rawKvp = new HashMap<>();
+        // matching
+        rawKvp.put(
+                CUSTOM_DIMENSION_NAME.toUpperCase(),
+                ISO_INSTANT.format(Instant.parse("2012-02-12T09:05:00Z")));
+        doCustomDimensionFilter(rawKvp, null, List.of(1, 2));
+
+        // too early
+        rawKvp.put(
+                CUSTOM_DIMENSION_NAME.toUpperCase(),
+                ISO_INSTANT.format(Instant.parse("2012-02-10T09:05:00Z")));
+        doCustomDimensionFilter(rawKvp, null, emptyList());
+
+        // too late
+        rawKvp.put(
+                CUSTOM_DIMENSION_NAME.toUpperCase(),
+                ISO_INSTANT.format(Instant.parse("2012-02-20T09:05:00Z")));
+        doCustomDimensionFilter(rawKvp, null, emptyList());
+    }
+
+    @Test
+    public void
+            custom_dimension_filter_should_return_minimum_default_without_default_settings_and_no_request()
+                    throws Exception {
+        doCustomDimensionFilter(new HashMap<>(), null, List.of(0, 2));
+    }
+
+    @Test
+    public void
+            custom_dimension_filter_should_return_matching_features_using_default_strategy_when_dimension_missing_from_request()
+                    throws IOException {
+        DimensionDefaultValueSetting defaultValueSetting = new DimensionDefaultValueSetting();
+
+        // minimum
+        defaultValueSetting.setStrategyType(DimensionDefaultValueSetting.Strategy.MINIMUM);
+        doCustomDimensionFilter(new HashMap<>(), defaultValueSetting, List.of(0, 2));
+
+        // maximum
+        defaultValueSetting.setStrategyType(DimensionDefaultValueSetting.Strategy.MAXIMUM);
+        doCustomDimensionFilter(new HashMap<>(), defaultValueSetting, List.of(0, 1, 2));
+
+        // nearest
+        defaultValueSetting.setStrategyType(DimensionDefaultValueSetting.Strategy.NEAREST);
+        defaultValueSetting.setReferenceValue("2012-02-14Z");
+        doCustomDimensionFilter(new HashMap<>(), defaultValueSetting, List.of(0, 1, 2));
+    }
+
+    @Test
+    public void
+            custom_dimension_filter_should_return_matching_features_using_default_strategy_when_dimensionValue_missing_from_request()
+                    throws IOException {
+        DimensionDefaultValueSetting defaultValueSetting = new DimensionDefaultValueSetting();
+        defaultValueSetting.setStrategyType(DimensionDefaultValueSetting.Strategy.FIXED);
+        defaultValueSetting.setReferenceValue("2012-02-14Z");
+
+        Map<String, String> rawKvp = new HashMap<>();
+        rawKvp.put(CUSTOM_DIMENSION_NAME.toUpperCase(), null);
+        doCustomDimensionFilter(rawKvp, defaultValueSetting, List.of(2));
+    }
+
+    /**
+     * executes the custom dimension filter and asserts for the presence of the expected features
+     * ids.
+     *
+     * @param rawKvp the request represented by the raw KVP
+     * @param defaultValueSetting the default value strategy (can be null)
+     * @param expectedFeatureIds the expected feature ids (can be emptyList())
+     * @throws IOException in case the feature source crashes
+     */
+    public void doCustomDimensionFilter(
+            Map<String, String> rawKvp,
+            DimensionDefaultValueSetting defaultValueSetting,
+            List<Integer> expectedFeatureIds)
+            throws IOException {
+
+        FeatureTypeInfo typeInfo =
+                getCatalog().getFeatureTypeByName(TIME_WITH_START_END.getLocalPart());
+        FeatureSource<?, ?> fs = typeInfo.getFeatureSource(null, null);
+
+        // set up a custom dimension
+        setupStartEndTimeDimension(
+                TIME_WITH_START_END.getLocalPart(),
+                CUSTOM_DIMENSION_NAME,
+                "startTime",
+                "endTime",
+                defaultValueSetting);
+
+        DimensionFilterBuilder filterBuilder = new DimensionFilterBuilder(getFilterFactory(null));
+        Filter filter = wms.getCustomDimensionFilter(rawKvp, typeInfo, filterBuilder);
+        FeatureCollection<?, ?> features = fs.getFeatures(filter);
+
+        Set<Integer> results = new HashSet<>();
+        try (FeatureIterator<?> it = features.features()) {
+            while (it.hasNext()) {
+                results.add((Integer) it.next().getProperty("id").getValue());
+            }
+        }
+        assertEquals(
+                "We are expecting "
+                        + expectedFeatureIds.size()
+                        + " features but got "
+                        + results.size(),
+                expectedFeatureIds.size(),
+                results.size());
+        assertTrue(
+                "We are expecting feature ids " + expectedFeatureIds + " but got " + results,
+                results.containsAll(expectedFeatureIds));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-11453](https://badgen.net/badge/JIRA/GEOS-11453/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11453) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7777
 **Authored by:** @skalesse