### PR TITLE
[GEOS-11502] Permit resize on user/group/role palette textbox to allow for extra long role names

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -159,6 +159,7 @@ a img {
 .palette-theme-default .palette-choices > div {
   width: 100%;
   overflow-x: scroll;
+  resize: both;
   border: 1px solid rgb(187, 187, 187);
   margin: 0.5em 0;
 }
@@ -166,6 +167,7 @@ a img {
 .palette-theme-default .palette-selected > div {
   width: 100%;
   overflow-x: scroll;
+  resize: both;
   border: 1px solid rgb(187, 187, 187);
   margin: 0.5em 0;
 }

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/PaletteFormComponent.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/PaletteFormComponent.java
@@ -64,7 +64,7 @@ public class PaletteFormComponent<T extends Serializable> extends FormComponentP
                             public Component newAvailableHeader(final String componentId) {
                                 return new Label(
                                         componentId,
-                                        new ResourceModel(getAvaliableHeaderPropertyKey()));
+                                        new ResourceModel(getAvailableHeaderPropertyKey()));
                             }
                         });
         palette.add(new DefaultTheme());
@@ -81,7 +81,7 @@ public class PaletteFormComponent<T extends Serializable> extends FormComponentP
     /**
      * @return the default key, subclasses may override, if "Available" is not illustrative enough
      */
-    protected String getAvaliableHeaderPropertyKey() {
+    protected String getAvailableHeaderPropertyKey() {
         return "PaletteFormComponent.availableHeader";
     }
 

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/role/RolePaletteFormComponent.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/role/RolePaletteFormComponent.java
@@ -103,7 +103,7 @@ public class RolePaletteFormComponent extends PaletteFormComponent<GeoServerRole
     }
 
     @Override
-    protected String getAvaliableHeaderPropertyKey() {
+    protected String getAvailableHeaderPropertyKey() {
         // TODO Auto-generated method stub
         return "RolePaletteFormComponent.availableHeader";
     }

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/role/RuleRolesFormComponent.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/role/RuleRolesFormComponent.java
@@ -59,7 +59,7 @@ public class RuleRolesFormComponent extends RolePaletteFormComponent {
     }
 
     @Override
-    protected String getAvaliableHeaderPropertyKey() {
+    protected String getAvailableHeaderPropertyKey() {
         return "RuleRolesFormComponent.availableHeader";
     }
 

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/user/UserGroupPaletteFormComponent.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/user/UserGroupPaletteFormComponent.java
@@ -104,7 +104,7 @@ public class UserGroupPaletteFormComponent extends PaletteFormComponent<GeoServe
     }
 
     @Override
-    protected String getAvaliableHeaderPropertyKey() {
+    protected String getAvailableHeaderPropertyKey() {
         return "UserGroupPaletteFormComponent.availableHeader";
     }
 }


### PR DESCRIPTION
[![GEOS-11502](https://badgen.net/badge/JIRA/GEOS-11502/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11502) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The presence of a very long role name (e.g. A_VERY_LONG_ROLE_NAME_THAT_CAUSES_THE_TEXTBOX_TO_OVERFLOW) combined with many (in my case over 1000) roles makes it difficult to find and select a role because the vertical scrollbar is “hidden” (off to the right of the “Available” textbox).

e.g.  
![Screenshot 2024-08-16 121729](https://github.com/user-attachments/assets/314b350b-4541-47b9-90e5-b78045efeebe)


I propose to add a resize:both CSS to both .palette-choices and .palette-selected to allow a user to temporarily expand the size of the textbox if desired, to easily access a role (e.g. extra750) that would otherwise be more difficult to find:
![Screenshot 2024-08-16 122442](https://github.com/user-attachments/assets/6d8538ef-e1d3-4cb1-8466-d4da76638e8b)

When reopening the page, the original size will be used.

Is this approach acceptable?  It is similar to the GeoServer Logs GUI page

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->