### PR TITLE
Follow up to GEOT-7633, Move ZoomContext/ZoomContextFinder class set from YSLD to main

### DIFF
--- a/src/extension/ysld/pom.xml
+++ b/src/extension/ysld/pom.xml
@@ -26,11 +26,6 @@
       <version>${gs.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.geoserver</groupId>
-      <artifactId>gs-gwc</artifactId>
-      <version>${gs.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
@@ -64,6 +59,12 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-gwc</artifactId>
+      <version>${gs.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/extension/ysld/src/main/resources/applicationContext.xml
+++ b/src/extension/ysld/src/main/resources/applicationContext.xml
@@ -10,9 +10,6 @@
     <bean id="ysldUomMapper" class="org.geotools.ysld.UomMapper">
     </bean>
 
-    <bean id="gwcZoomContextFinder" class="org.geoserver.ysld.GWCZoomContextFinder">
-      <constructor-arg ref="gwcGridSetBroker"/>
-    </bean>
     <bean id="ysldExtension"
 		class="org.geoserver.platform.ModuleStatusImpl">
 		<property name="module" value="gs-ysld" />
@@ -21,8 +18,5 @@
 		<property name="available" value="true" />
 		<property name="enabled" value="true" />
   </bean>
-    <!--<bean class="org.geoserver.web.HeaderContribution">-->
-        <!--<property name="scope" value="com.boundlessgeo.ysld.YsldHandler"/>-->
-        <!--<property name="javaScriptFilename" value="yaml.js"/>-->
-    <!--</bean>-->
+
 </beans>

--- a/src/gwc/pom.xml
+++ b/src/gwc/pom.xml
@@ -137,6 +137,13 @@
       <version>${gt.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-main</artifactId>
+      <version>${gt.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWCZoomContextFinder.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWCZoomContextFinder.java
@@ -4,13 +4,13 @@
  * application directory.
  */
 
-package org.geoserver.ysld;
+package org.geoserver.gwc;
 
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.geotools.ysld.parse.MedialZoomContext;
-import org.geotools.ysld.parse.ZoomContext;
-import org.geotools.ysld.parse.ZoomContextFinder;
+import org.geotools.styling.zoom.MedialZoomContext;
+import org.geotools.styling.zoom.ZoomContext;
+import org.geotools.styling.zoom.ZoomContextFinder;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetBroker;
 

--- a/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
@@ -169,4 +169,9 @@
     <constructor-arg ref="gwcFacade" />
     <constructor-arg ref="geoServer" />
   </bean>
+
+  <bean id="gwcZoomContextFinder" class="org.geoserver.gwc.GWCZoomContextFinder">
+    <constructor-arg ref="gwcGridSetBroker"/>
+  </bean>
+
 </beans>

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCZoomContextFinderTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCZoomContextFinderTest.java
@@ -4,26 +4,26 @@
  * application directory.
  */
 
-package org.geoserver.ysld;
+package org.geoserver.gwc;
 
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.geotools.ysld.TestUtils.rangeContains;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-import org.geotools.ysld.parse.ScaleRange;
-import org.geotools.ysld.parse.ZoomContext;
-import org.geotools.ysld.parse.ZoomContextFinder;
+import org.geotools.styling.zoom.ScaleRange;
+import org.geotools.styling.zoom.TestUtils;
+import org.geotools.styling.zoom.ZoomContext;
+import org.geotools.styling.zoom.ZoomContextFinder;
 import org.geowebcache.grid.Grid;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetBroker;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -161,9 +161,9 @@ public class GWCZoomContextFinderTest {
 
         ScaleRange range = zContext.getRange(2, 2);
 
-        assertThat(range, rangeContains(200_000_000d));
-        assertThat(range, not(rangeContains(500_000_000d)));
-        assertThat(range, not(rangeContains(100_000_000d)));
+        MatcherAssert.assertThat(range, TestUtils.rangeContains(200_000_000d));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(500_000_000d)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(100_000_000d)));
 
         verify(broker, set, grid1, grid2, grid3);
     }
@@ -187,11 +187,11 @@ public class GWCZoomContextFinderTest {
 
         ScaleRange range = zContext.getRange(0, 1);
 
-        assertThat(range, rangeContains(1 / EPSILON));
-        assertThat(range, rangeContains(500_000_000d));
-        assertThat(range, rangeContains(200_000_000d));
-        assertThat(range, not(rangeContains(100_000_000d)));
-        assertThat(range, not(rangeContains(EPSILON)));
+        MatcherAssert.assertThat(range, TestUtils.rangeContains(1 / EPSILON));
+        MatcherAssert.assertThat(range, TestUtils.rangeContains(500_000_000d));
+        MatcherAssert.assertThat(range, TestUtils.rangeContains(200_000_000d));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(100_000_000d)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(EPSILON)));
 
         verify(broker, set, grid0, grid1, grid2);
     }
@@ -215,11 +215,11 @@ public class GWCZoomContextFinderTest {
 
         ScaleRange range = zContext.getRange(3, 4);
 
-        assertThat(range, not(rangeContains(1 / EPSILON)));
-        assertThat(range, not(rangeContains(500_000_000d)));
-        assertThat(range, rangeContains(200_000_000d));
-        assertThat(range, rangeContains(100_000_000d));
-        assertThat(range, rangeContains(EPSILON));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(1 / EPSILON)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(500_000_000d)));
+        MatcherAssert.assertThat(range, TestUtils.rangeContains(200_000_000d));
+        MatcherAssert.assertThat(range, TestUtils.rangeContains(100_000_000d));
+        MatcherAssert.assertThat(range, TestUtils.rangeContains(EPSILON));
 
         verify(broker, set, grid2, grid3, grid4);
     }
@@ -243,11 +243,11 @@ public class GWCZoomContextFinderTest {
 
         ScaleRange range = zContext.getRange(6, 7);
 
-        assertThat(range, not(rangeContains(1 / EPSILON)));
-        assertThat(range, not(rangeContains(500_000_000d)));
-        assertThat(range, not(rangeContains(200_000_000d)));
-        assertThat(range, not(rangeContains(100_000_000d)));
-        assertThat(range, not(rangeContains(EPSILON)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(1 / EPSILON)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(500_000_000d)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(200_000_000d)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(100_000_000d)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(EPSILON)));
 
         verify(broker, set, grid2, grid3, grid4);
     }
@@ -271,11 +271,11 @@ public class GWCZoomContextFinderTest {
 
         ScaleRange range = zContext.getRange(-2, -1);
 
-        assertThat(range, not(rangeContains(1 / EPSILON)));
-        assertThat(range, not(rangeContains(500_000_000d)));
-        assertThat(range, not(rangeContains(200_000_000d)));
-        assertThat(range, not(rangeContains(100_000_000d)));
-        assertThat(range, not(rangeContains(EPSILON)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(1 / EPSILON)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(500_000_000d)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(200_000_000d)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(100_000_000d)));
+        MatcherAssert.assertThat(range, Matchers.not(TestUtils.rangeContains(EPSILON)));
 
         verify(broker, set, grid2, grid3, grid4);
     }


### PR DESCRIPTION
[![GEOT-7633](https://badgen.net/badge/JIRA/GEOT-7633/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7633) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Follow up to https://github.com/geotools/geotools/pull/4879

In addition to adapting to the GeoTools API change and deprecations, this PR also makes the YSLD module only optionally dependent on GWC, failing back on the well known zoom context finder, in case the GWC one is missing.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->