### PR TITLE
[Backport 2.24.x] [GEOS-11502] Permit resize on user/group/role palette textbox to allow for extra long role names

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -159,6 +159,7 @@ a img {
 .palette-theme-default .palette-choices > div {
   width: 100%;
   overflow-x: scroll;
+  resize: both;
   border: 1px solid rgb(187, 187, 187);
   margin: 0.5em 0;
 }
@@ -166,6 +167,7 @@ a img {
 .palette-theme-default .palette-selected > div {
   width: 100%;
   overflow-x: scroll;
+  resize: both;
   border: 1px solid rgb(187, 187, 187);
   margin: 0.5em 0;
 }

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/PaletteFormComponent.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/PaletteFormComponent.java
@@ -64,7 +64,7 @@ public class PaletteFormComponent<T extends Serializable> extends FormComponentP
                             public Component newAvailableHeader(final String componentId) {
                                 return new Label(
                                         componentId,
-                                        new ResourceModel(getAvaliableHeaderPropertyKey()));
+                                        new ResourceModel(getAvailableHeaderPropertyKey()));
                             }
                         });
         palette.add(new DefaultTheme());
@@ -81,7 +81,7 @@ public class PaletteFormComponent<T extends Serializable> extends FormComponentP
     /**
      * @return the default key, subclasses may override, if "Available" is not illustrative enough
      */
-    protected String getAvaliableHeaderPropertyKey() {
+    protected String getAvailableHeaderPropertyKey() {
         return "PaletteFormComponent.availableHeader";
     }
 

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/role/RolePaletteFormComponent.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/role/RolePaletteFormComponent.java
@@ -103,7 +103,7 @@ public class RolePaletteFormComponent extends PaletteFormComponent<GeoServerRole
     }
 
     @Override
-    protected String getAvaliableHeaderPropertyKey() {
+    protected String getAvailableHeaderPropertyKey() {
         // TODO Auto-generated method stub
         return "RolePaletteFormComponent.availableHeader";
     }

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/role/RuleRolesFormComponent.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/role/RuleRolesFormComponent.java
@@ -59,7 +59,7 @@ public class RuleRolesFormComponent extends RolePaletteFormComponent {
     }
 
     @Override
-    protected String getAvaliableHeaderPropertyKey() {
+    protected String getAvailableHeaderPropertyKey() {
         return "RuleRolesFormComponent.availableHeader";
     }
 

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/user/UserGroupPaletteFormComponent.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/user/UserGroupPaletteFormComponent.java
@@ -104,7 +104,7 @@ public class UserGroupPaletteFormComponent extends PaletteFormComponent<GeoServe
     }
 
     @Override
-    protected String getAvaliableHeaderPropertyKey() {
+    protected String getAvailableHeaderPropertyKey() {
         return "UserGroupPaletteFormComponent.availableHeader";
     }
 }


### PR DESCRIPTION
[![GEOS-11502](https://badgen.net/badge/JIRA/GEOS-11502/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11502) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7837
 **Authored by:** @petersmythe