### PR TITLE
[GEOS-11504] ResourceAccessManagerWrapper misses some delegating methods

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/ResourceAccessManagerWrapper.java
+++ b/src/main/src/main/java/org/geoserver/security/ResourceAccessManagerWrapper.java
@@ -8,6 +8,8 @@ package org.geoserver.security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourceInfo;
@@ -246,6 +248,16 @@ public abstract class ResourceAccessManagerWrapper implements ResourceAccessMana
     public LayerGroupAccessLimits getAccessLimits(
             Authentication user, LayerGroupInfo layerGroup, List<LayerGroupInfo> containers) {
         return delegate.getAccessLimits(user, layerGroup, containers);
+    }
+
+    @Override
+    public Filter getSecurityFilter(Authentication user, final Class<? extends CatalogInfo> clazz) {
+        return delegate.getSecurityFilter(user, clazz);
+    }
+
+    @Override
+    public boolean isWorkspaceAdmin(Authentication user, Catalog catalog) {
+        return delegate.isWorkspaceAdmin(user, catalog);
     }
 
     public ResourceAccessManager unwrap() {

--- a/src/main/src/test/java/org/geoserver/security/ResourceAccessManagerWrapperTest.java
+++ b/src/main/src/test/java/org/geoserver/security/ResourceAccessManagerWrapperTest.java
@@ -1,0 +1,120 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.core.Authentication;
+
+public class ResourceAccessManagerWrapperTest {
+
+    private ResourceAccessManagerWrapper wrapper;
+    private ResourceAccessManager delegate;
+    private Authentication user;
+
+    @Before
+    public void setUp() {
+        user = mock(Authentication.class);
+        delegate = mock(ResourceAccessManager.class);
+        wrapper = new ResourceAccessManagerWrapper() {};
+        wrapper.setDelegate(delegate);
+    }
+
+    @Test
+    public void getAccessLimitsWorkspaceInfo() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        wrapper.getAccessLimits(user, ws);
+        verify(delegate, times(1)).getAccessLimits(user, ws);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void getAccessLimitsLayerInfo() {
+        LayerInfo layer = mock(LayerInfo.class);
+        wrapper.getAccessLimits(user, layer);
+        verify(delegate, times(1)).getAccessLimits(user, layer);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void getAccessLimitsLayerInfoContainers() {
+        LayerInfo layer = mock(LayerInfo.class);
+        List<LayerGroupInfo> containers = List.of();
+        wrapper.getAccessLimits(user, layer, containers);
+        verify(delegate, times(1)).getAccessLimits(user, layer, containers);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void getAccessLimitsResourceInfo() {
+        ResourceInfo res = mock(ResourceInfo.class);
+        wrapper.getAccessLimits(user, res);
+        verify(delegate, times(1)).getAccessLimits(user, res);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void getAccessLimitsStyleInfo() {
+        StyleInfo style = mock(StyleInfo.class);
+        wrapper.getAccessLimits(user, style);
+        verify(delegate, times(1)).getAccessLimits(user, style);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void getAccessLimitsLayerGroupInfo() {
+        LayerGroupInfo lg = mock(LayerGroupInfo.class);
+        wrapper.getAccessLimits(user, lg);
+        verify(delegate, times(1)).getAccessLimits(user, lg);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void getAccessLimitsLayerGroupInfoContainers() {
+        LayerGroupInfo lg = mock(LayerGroupInfo.class);
+        List<LayerGroupInfo> containers = List.of();
+        wrapper.getAccessLimits(user, lg, containers);
+        verify(delegate, times(1)).getAccessLimits(user, lg, containers);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void getSecurityFilter() {
+        wrapper.getSecurityFilter(user, ResourceInfo.class);
+        verify(delegate, times(1)).getSecurityFilter(user, ResourceInfo.class);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void isWorkspaceAdmin() {
+        Catalog catalog = mock(Catalog.class);
+        wrapper.isWorkspaceAdmin(user, catalog);
+        verify(delegate, times(1)).isWorkspaceAdmin(user, catalog);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void unwrap() {
+        assertSame(delegate, wrapper.unwrap());
+        wrapper.setDelegate(null);
+        assertNull(wrapper.unwrap());
+        wrapper.setDelegate(delegate);
+        assertSame(delegate, wrapper.unwrap());
+    }
+}


### PR DESCRIPTION
Add missing delegating methods `ResourceAccessManagerWrapper.isWorkspaceAdmin()`
    and `ResourceAccessManagerWrapper.getSecurityFilter()`.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->