### PR TITLE
[Backport 2.25.x] [GEOS-11508] Update OSHI from 6.4.10 to 6.6.3

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1458,7 +1458,7 @@
       <dependency>
         <groupId>com.github.oshi</groupId>
         <artifactId>oshi-core</artifactId>
-        <version>6.4.10</version>
+        <version>6.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>


### PR DESCRIPTION
[![GEOS-11508](https://badgen.net/badge/JIRA/GEOS-11508/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11508) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #7848
 **Authored by:** @mprins