### PR TITLE
[Backport 2.23.x] [GEOS-11385] Demo Requests functionality does not honour ENV variable PROXY_BASE_URL

### DIFF
--- a/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
+++ b/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
@@ -283,6 +283,9 @@ public class TestWfsPost extends HttpServlet {
     }
 
     String getProxyBaseURL() {
+        if (GeoServerExtensions.getProperty("PROXY_BASE_URL") != null) {
+    		return GeoServerExtensions.getProperty("PROXY_BASE_URL");
+    	}
         GeoServer geoServer = getGeoServer();
         if (geoServer != null) {
             return geoServer.getGlobal().getSettings().getProxyBaseUrl();

--- a/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
+++ b/src/wfs/src/main/java/org/vfny/geoserver/wfs/servlets/TestWfsPost.java
@@ -284,8 +284,8 @@ public class TestWfsPost extends HttpServlet {
 
     String getProxyBaseURL() {
         if (GeoServerExtensions.getProperty("PROXY_BASE_URL") != null) {
-    		return GeoServerExtensions.getProperty("PROXY_BASE_URL");
-    	}
+            return GeoServerExtensions.getProperty("PROXY_BASE_URL");
+        }
         GeoServer geoServer = getGeoServer();
         if (geoServer != null) {
             return geoServer.getGlobal().getSettings().getProxyBaseUrl();

--- a/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
+++ b/src/wfs/src/test/java/org/vfny/geoserver/wfs/servlets/TestWfsPostTest.java
@@ -256,6 +256,31 @@ public class TestWfsPostTest {
         assertEquals("https://foo.com/geoserver", servlet.getProxyBaseURL());
     }
 
+    @Test
+    // https://osgeo-org.atlassian.net/browse/GEOS-11385
+    public void testGetProxyBaseURLfromEnv() {
+        SettingsInfo settings = new SettingsInfoImpl();
+        settings.setProxyBaseUrl("https://foo.com/geoserver1");
+        // Override the Proxy Base Url with the Environment variable
+        System.setProperty("PROXY_BASE_URL", "https://foo.com/geoserver2");
+
+        GeoServerInfo info = new GeoServerInfoImpl();
+        info.setSettings(settings);
+
+        GeoServer gs = new GeoServerImpl();
+        gs.setGlobal(info);
+
+        TestWfsPost servlet =
+                new TestWfsPost() {
+                    @Override
+                    protected GeoServer getGeoServer() {
+                        return gs;
+                    }
+                };
+        assertEquals("https://foo.com/geoserver2", servlet.getProxyBaseURL());
+        System.clearProperty("PROXY_BASE_URL");
+    }
+
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     protected static MockHttpServletRequest buildMockRequest() {
         MockHttpServletRequest request = new MockHttpServletRequest();


### PR DESCRIPTION
[![CVE-2024-34696](https://badgen.net/badge/JIRA/CVE-2024/0052CC)](https://osgeo-org.atlassian.net/browse/CVE-2024) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Here is a vulnerability which is fixed in the main branch and 2.25.x(https://github.com/geoserver/geoserver/commit/30cf3972b48c0549e60f84aeb9e3ef94fa3cee74) but is not fixed in the branch of 2.23.x, maybe it should be backported?