### PR TITLE
Follow up to GEOT-7636 changes 

### DIFF
--- a/src/wms/src/test/java/org/geoserver/wms/map/RenderedImageMapOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/RenderedImageMapOutputFormatTest.java
@@ -318,7 +318,7 @@ public class RenderedImageMapOutputFormatTest extends WMSTestSupport {
         ArgumentCaptor<Shape> shape = ArgumentCaptor.forClass(Shape.class);
         Mockito.verify(graphics).draw(shape.capture());
         LiteShape2 drawnShape = (LiteShape2) shape.getValue();
-        assertEquals(64, drawnShape.getGeometry().getCoordinates().length);
+        assertEquals(127, drawnShape.getGeometry().getCoordinates().length);
     }
 
     @Test
@@ -362,7 +362,7 @@ public class RenderedImageMapOutputFormatTest extends WMSTestSupport {
         ArgumentCaptor<Shape> shape = ArgumentCaptor.forClass(Shape.class);
         Mockito.verify(graphics).draw(shape.capture());
         LiteShape2 drawnShape = (LiteShape2) shape.getValue();
-        assertEquals(64, drawnShape.getGeometry().getCoordinates().length);
+        assertEquals(127, drawnShape.getGeometry().getCoordinates().length);
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7636](https://badgen.net/badge/JIRA/GEOT-7636/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7636) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The changes in GeoTools corrected the axis along which the densification should be computed, shows up in these tests with very elongated area of interest.

Needs to be merged along with https://github.com/geotools/geotools/pull/4881

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->