### PR TITLE
Added missing reference in ImageMosaic Example

### DIFF
--- a/doc/en/user/source/community/cog/mosaic.rst
+++ b/doc/en/user/source/community/cog/mosaic.rst
@@ -41,7 +41,7 @@ timeregex.properties:
 
 The previous indexer refers to a time dimension and the related time column in the index's schema that will get populated by extracting the time value from the filename (the 8 digits, representing YEAR, MONTH, DAY) using the regex specified in the timeregex.properties file. An example of sample file for this collection as stored on the S3 bucket is 2018.01.01.tif so the time regex will reflect that. Note the 3 groups of digits and the 'format' of the date. 
 
-. literalinclude:: src/modisvi/timeregex.properties
+.. literalinclude:: src/modisvi/timeregex.properties
 
 datastore.properties:
 """""""""""""""""""""


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
Added a "." in the mosaic documentation. The ImageMosaic is confusing without the correct reference.  

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->