### PR TITLE
Fixing random test failure in WPS importer process test

### DIFF
--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ImportProcess.java
@@ -498,6 +498,8 @@ public class ImportProcess implements GeoServerProcess {
             listener.progress(100);
             listener.complete();
             return layerInfo.prefixedName();
+        } catch (ProcessException e) {
+            throw e;
         } catch (MalformedURLException e) {
             throw new ProcessException("URL Error", e);
         } catch (IOException e) {
@@ -580,6 +582,8 @@ public class ImportProcess implements GeoServerProcess {
             listener.complete();
 
             return layerInfo.prefixedName();
+        } catch (ProcessException pe) {
+            throw pe;
         } catch (Exception e) {
             throw new ProcessException(
                     "Failed to complete the import inside the GeoServer catalog", e);

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/ImportProcessTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/ImportProcessTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.apache.commons.lang3.function.Failable;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.CoverageStoreInfo;
 import org.geoserver.catalog.DataStoreInfo;
@@ -152,7 +153,7 @@ public class ImportProcessTest extends WPSTestSupport {
                         return new DecoratingSimpleFeatureIterator(super.features()) {
                             @Override
                             public SimpleFeature next() throws NoSuchElementException {
-
+                                Failable.run(() -> latch.await());
                                 return super.next();
                             }
                         };


### PR DESCRIPTION
Noticed a random failure in WPS, likely due to the countdown latch not being used at all to stop the data iteration.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->