### PR TITLE
[GEOS-11556] Fix NPE when DiskQuotaMonitor is disabled

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/ConfigurableQuotaStoreProvider.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/ConfigurableQuotaStoreProvider.java
@@ -129,6 +129,13 @@ public class ConfigurableQuotaStoreProvider extends QuotaStoreProvider {
     }
 
     @Override
+    public void destroy() throws Exception {
+        if (store != null) {
+            store.close();
+        }
+    }
+
+    @Override
     protected QuotaStore getQuotaStoreByName(String quotaStoreName)
             throws ConfigurationException, IOException {
         if ("JDBC".equals(quotaStoreName)) {

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCQuotaStoreDisabledTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCQuotaStoreDisabledTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 -2015 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 -2024 Open Source Geospatial Foundation - all rights reserved
  * (c) 2001 - 2013 OpenPlans
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
@@ -7,6 +7,7 @@ package org.geoserver.gwc;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import org.geoserver.data.test.SystemTestData;
@@ -44,5 +45,18 @@ public class GWCQuotaStoreDisabledTest extends GeoServerSystemTestSupport {
         // check there is no quota database
         File hsqlQuotaStore = new File("diskquota_page_store_hsql");
         assertFalse(hsqlQuotaStore.exists());
+    }
+
+    @Test
+    public void testQuotaDisabledOnDestroy() throws Exception {
+        ConfigurableQuotaStoreProvider provider =
+                GeoServerExtensions.bean(ConfigurableQuotaStoreProvider.class);
+
+        // check that no NPE is thrown on destroy() (because the store is null)
+        try {
+            provider.destroy();
+        } catch (NullPointerException e) {
+            fail("NullPointerException was thrown when destroying ConfigurableQuotaStoreProvider");
+        }
     }
 }


### PR DESCRIPTION
[![GEOS-11556](https://badgen.net/badge/JIRA/GEOS-11556/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11556) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When disabling the disk quota monitoring (environment variable GWC_DISKQUOTA_DISABLED set to true) there is a NullPointerException in the logs on shut down:

```
WARN 1 --- [ionShutdownHook] o.s.b.f.support.DisposableBeanAdapter    : Invocation of destroy method failed on bean with name 'DiskQuotaStoreProvider': java.lang.NullPointerException: Cannot invoke "org.geowebcache.diskquota.QuotaStore.close()" because "this.store" is null
```

This happens because the store is set to null here https://github.com/geoserver/geoserver/blob/f23c089fb922e217c138c063b5d8aadf5391c881/src/gwc/src/main/java/org/geoserver/gwc/ConfigurableQuotaStoreProvider.java#L65 and the `destroy()` method of the parent class later tries to close it:
https://github.com/GeoWebCache/geowebcache/blob/a642c8b9cd839d2866dc174784356838b62b3b9a/geowebcache/diskquota/core/src/main/java/org/geowebcache/diskquota/QuotaStoreProvider.java#L51

Here I suggest to overload the `destroy()` method in `ConfigurableQuotaStoreProvider` to add a null check before closing the store.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->