### PR TITLE
Adding CycloneDX to generate a Software Bill Of Materials

### DIFF
--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -237,6 +237,33 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>2.8.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>makeAggregateBom</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <projectType>library</projectType>
+          <schemaVersion>1.5</schemaVersion>
+          <includeBomSerialNumber>true</includeBomSerialNumber>
+          <includeCompileScope>true</includeCompileScope>
+          <includeProvidedScope>true</includeProvidedScope>
+          <includeRuntimeScope>true</includeRuntimeScope>
+          <includeSystemScope>true</includeSystemScope>
+          <includeTestScope>false</includeTestScope>
+          <includeLicenseText>false</includeLicenseText>
+          <outputReactorProjects>true</outputReactorProjects>
+          <outputFormat>all</outputFormat>
+          <outputName>CycloneDX-Sbom</outputName>
+        </configuration>
+      </plugin>
       <!-- Builds a valid data directory into the web app -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
Experimenting with the CycloneDX plugin to generate a Software Bill Of Materials in said format.
Apparently this is becoming a common request to validate software contents.

Here is an example output tested on GeoServer 2.24.3 with a given set of plugins enabled via profiles, so that you can get an idea:
[CycloneDX-Sbom.json](https://github.com/user-attachments/files/17164424/CycloneDX-Sbom.json)

The command to generate it was:

```
> cd web/app
> mvn clean install -nsu -fae -PsldService,printing,monitor,control-flow,wps,kmlppio,wps-download,excel,querylayer,gdal,authkey,css,ysld,importer,wmts-multi-dimensional,backup-restore,oauth2-geonode,oauth2-openid-connect,geofence-server,geofence-wps
```

and then grab the results in web/app/target.

This would help supporting the EU [Cyber Resilence Act](https://digital-strategy.ec.europa.eu/en/library/cyber-resilience-act), which among the other things, requires a SBOM structure (I've been told this is already active in Germany). See also [this article by OWASP](https://owasp.org/blog/2024/03/07/OWASP-CycloneDX-is-ready-to-support-your-CRA-compliance-journey).

I've also noticed software, like PMD, that is adding these SBOM files as part of their release process:
https://github.com/pmd/pmd/releases/tag/pmd_releases%2F7.6.0

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->