### PR TITLE
[GEOS-11559] The customized attributes editor is prone to setting the  wrong attribute source

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/AttributeTypeInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/AttributeTypeInfo.java
@@ -89,6 +89,12 @@ public interface AttributeTypeInfo extends Serializable {
     boolean equalsIngnoreFeatureType(Object obj);
 
     /**
+     * Returns the actual value of source, eventually null if not set yet (unlike #getsSource(),
+     * which returns the attribute name, if the source field is null)
+     */
+    String getRawSource();
+
+    /**
      * Source expression (a valid CQL expression). If not set, it will default to the attribute name
      * (no renaming)
      */

--- a/src/main/src/main/java/org/geoserver/catalog/impl/AttributeTypeInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AttributeTypeInfoImpl.java
@@ -135,6 +135,11 @@ public class AttributeTypeInfoImpl implements AttributeTypeInfo {
     }
 
     @Override
+    public String getRawSource() {
+        return source;
+    }
+
+    @Override
     public String getSource() {
         if (source == null && name != null) {
             try {

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/AttributeTypeInfoEditor.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/AttributeTypeInfoEditor.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -176,7 +177,7 @@ class AttributeTypeInfoEditor extends Panel {
             if (property == NAME) {
                 Fragment f = new Fragment(id, "text", getParent());
                 TextField<String> nameField = new TextField<>("text", model);
-                nameField.add(new UpdateModelBehavior());
+                nameField.add(new SourceUpdateBehavior(itemModel));
                 f.add(nameField);
                 return f;
             } else if (property == BINDING) {
@@ -238,6 +239,44 @@ class AttributeTypeInfoEditor extends Panel {
         protected void onUpdate(AjaxRequestTarget ajaxRequestTarget) {
             // nothing to do, the mere presence is enough to update the server side model
             // before up/down/drag actions are performed
+        }
+    }
+
+    /**
+     * Behavior that updates the source of an {@link AttributeTypeInfo} when the associated form
+     * component loses focus. This behavior ensures that if the raw source is null and the name of
+     * the attribute has changed, the source is set to the previous name (the original name of the
+     * attribute).
+     */
+    private class SourceUpdateBehavior extends AjaxFormComponentUpdatingBehavior {
+
+        private final IModel<AttributeTypeInfo> itemModel;
+        private final String previousName;
+
+        /**
+         * Constructs a new SourceUpdateBehavior.
+         *
+         * @param itemModel the model of the {@link AttributeTypeInfo} being edited
+         */
+        public SourceUpdateBehavior(IModel<AttributeTypeInfo> itemModel) {
+            super("blur");
+            this.itemModel = itemModel;
+            this.previousName = itemModel.getObject().getName();
+        }
+
+        /**
+         * Called when the form component loses focus and updates the source of the attribute if
+         * necessary.
+         *
+         * @param ajaxRequestTarget the AJAX request target
+         */
+        @Override
+        protected void onUpdate(AjaxRequestTarget ajaxRequestTarget) {
+            AttributeTypeInfo attribute = itemModel.getObject();
+            if (attribute.getRawSource() == null
+                    && !Objects.equals(attribute.getName(), previousName)) {
+                attribute.setSource(previousName);
+            }
         }
     }
 


### PR DESCRIPTION
[![GEOS-11559](https://badgen.net/badge/JIRA/GEOS-11559/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11559) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details on how to reproduce the issue

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->