### PR TITLE
Remove unnecessary SEVERE log message from StructuredCoverageController

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/StructuredCoverageController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/StructuredCoverageController.java
@@ -14,8 +14,6 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.geoserver.catalog.AttributeTypeInfo;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
@@ -46,7 +44,6 @@ import org.geotools.feature.FeatureTypes;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.util.factory.Hints;
-import org.geotools.util.logging.Logging;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.MethodParameter;
@@ -70,8 +67,6 @@ import org.springframework.web.bind.annotation.RestController;
                 RestBaseController.ROOT_PATH
                         + "/workspaces/{workspaceName}/coveragestores/{storeName}/coverages/{coverageName}/index")
 public class StructuredCoverageController extends AbstractCatalogController {
-
-    private static final Logger LOGGER = Logging.getLogger(StructuredCoverageController.class);
 
     static final FilterFactory FF = CommonFactoryFinder.getFilterFactory();
 
@@ -134,9 +129,6 @@ public class StructuredCoverageController extends AbstractCatalogController {
 
         GranuleSource source = getGranuleSource(workspaceName, storeName, coverageName);
         Query q = toQuery(filter, offset, limit);
-
-        LOGGER.log(Level.SEVERE, "Still need to parse the filters");
-
         return forceNonNullNamespace(source.getGranules(q));
     }
 


### PR DESCRIPTION
This PR removes a SEVERE logging message every time a GET request with a filter is sent to StructuredCoverageController. It appears to be a debugging message that wasn't removed from the original implementation. There is no ticket or unit test.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->