### PR TITLE
[GEOS-11524] csw: default queryables mapping not generated

### DIFF
--- a/src/extension/csw/csw-iso/src/main/java/org/geoserver/csw/records/iso/QueryableMappingRecordDescriptor.java
+++ b/src/extension/csw/csw-iso/src/main/java/org/geoserver/csw/records/iso/QueryableMappingRecordDescriptor.java
@@ -165,7 +165,7 @@ public abstract class QueryableMappingRecordDescriptor extends AbstractRecordDes
                 Resource f = loader.get("csw").get(fileName);
 
                 if (!Resources.exists(f)) {
-                    if (mappingName == null) {
+                    if (Strings.isNullOrEmpty(mappingName)) {
                         IOUtils.copy(getClass().getResourceAsStream(fileName), f.out());
                     } else {
                         return null;

--- a/src/extension/csw/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/MetadataDescriptorTest.java
+++ b/src/extension/csw/csw-iso/src/test/java/org/geoserver/csw/store/internal/iso/MetadataDescriptorTest.java
@@ -1,0 +1,25 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.csw.store.internal.iso;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.geoserver.csw.records.QueryablesMapping;
+import org.geoserver.csw.records.iso.MetaDataDescriptor;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+
+public class MetadataDescriptorTest extends GeoServerSystemTestSupport {
+
+    @Test
+    public void testCreateDefaultQueryablesMapping() {
+        QueryablesMapping qMapping = MetaDataDescriptor.getInstance().getQueryablesMapping(null);
+        assertNotNull(qMapping);
+        assertEquals(
+                "identificationInfo.MD_DataIdentification.extent.EX_Extent.geographicElement.EX_GeographicBoundingBox",
+                qMapping.getBoundingBoxPropertyName());
+    }
+}


### PR DESCRIPTION
[![GEOS-11524](https://badgen.net/badge/JIRA/GEOS-11524/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11524) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->