### PR TITLE
Run JUnit tests in all modules that received a JUnit 5 dependency

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1816,6 +1816,13 @@
       <!-- unit testing -->
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit4</artifactId>
+            <version>2.22.2</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <runOrder>alphabetical</runOrder>
           <includes>

--- a/src/web/core/src/test/java/org/geoserver/web/data/layergroup/LayerGroupEditPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/layergroup/LayerGroupEditPageTest.java
@@ -210,11 +210,11 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
         tester.assertNoErrorMessage();
         // Ensure that the Layer List page is rendered correctly
         tester.assertComponent(
-                "publishedinfo:tabs:panel:layers:popup:content:listContainer:items",
+                "publishedinfo:tabs:panel:layers:popup:modal:content:listContainer:items",
                 DataView.class);
         // Get the DataView containing the Layer List
         DataView<?> dataView =
-                (DataView<?>) page.lgEntryPanel.get("popup:content:listContainer:items");
+                (DataView<?>) page.lgEntryPanel.get("popup:modal:content:listContainer:items");
         // Ensure that the Row count is equal to the Layers in the Catalog
         Catalog catalog = getGeoServerApplication().getCatalog();
 
@@ -236,11 +236,11 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
         tester.assertNoErrorMessage();
         // Ensure that the Style Group List page is rendered correctly
         tester.assertComponent(
-                "publishedinfo:tabs:panel:layers:popup:content:listContainer:items",
+                "publishedinfo:tabs:panel:layers:popup:modal:content:listContainer:items",
                 DataView.class);
         // Get the DataView containing the Style Group List
         DataView<?> dataView =
-                (DataView<?>) page.lgEntryPanel.get("popup:content:listContainer:items");
+                (DataView<?>) page.lgEntryPanel.get("popup:modal:content:listContainer:items");
         // Ensure that the Row count is equal to the style in the Catalog
         Catalog catalog = getGeoServerApplication().getCatalog();
 
@@ -263,11 +263,11 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
         tester.assertNoErrorMessage();
         // Ensure that the Layer List page is rendered correctly
         tester.assertComponent(
-                "publishedinfo:tabs:panel:layers:popup:content:listContainer:items",
+                "publishedinfo:tabs:panel:layers:popup:modal:content:listContainer:items",
                 DataView.class);
         // Get the DataView containing the Layer List
         DataView<?> dataView =
-                (DataView<?>) page.lgEntryPanel.get("popup:content:listContainer:items");
+                (DataView<?>) page.lgEntryPanel.get("popup:modal:content:listContainer:items");
         // Ensure that the Row count is equal to the Layers in the Catalog
         Catalog catalog = getGeoServerApplication().getCatalog();
 
@@ -295,13 +295,14 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
         // Click on the link
         tester.clickLink("publishedinfo:tabs:panel:layers:addLayerGroup");
         tester.assertNoErrorMessage();
+
         // Ensure that the Layer List page is rendered correctly
         tester.assertComponent(
-                "publishedinfo:tabs:panel:layers:popup:content:listContainer:items",
+                "publishedinfo:tabs:panel:layers:popup:modal:content:listContainer:items",
                 DataView.class);
         // Get the DataView containing the Layer List
         DataView<?> dataView =
-                (DataView<?>) page.lgEntryPanel.get("popup:content:listContainer:items");
+                (DataView<?>) page.lgEntryPanel.get("popup:modal:content:listContainer:items");
         // Ensure that the Row count is equal to the Layers in the Catalog
         Catalog catalog = getGeoServerApplication().getCatalog();
 
@@ -720,7 +721,7 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
                     "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:addLayer",
                     "click");
             tester.executeAjaxEvent(
-                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:1:itemProperties:0:component:link",
+                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:modal:content:listContainer:items:1:itemProperties:0:component:link",
                     "click");
             tester.executeAjaxEvent(
                     "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:addLayerGroup",
@@ -773,14 +774,14 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
                     "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:addLayerGroup",
                     "click");
             tester.executeAjaxEvent(
-                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:3:itemProperties:0:component:link",
+                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:modal:content:listContainer:items:3:itemProperties:0:component:link",
                     "click");
 
             tester.executeAjaxEvent(
                     "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:addLayer",
                     "click");
             tester.executeAjaxEvent(
-                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:1:itemProperties:0:component:link",
+                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:modal:content:listContainer:items:1:itemProperties:0:component:link",
                     "click");
 
             FormTester ft = tester.newFormTester("publishedinfo");
@@ -860,7 +861,7 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
 
             // select the LayerGroupStyle.
             tester.executeAjaxEvent(
-                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:2:itemProperties:0:component:link",
+                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:modal:content:listContainer:items:2:itemProperties:0:component:link",
                     "click");
 
             // forces the model of the default style checkbox to be set to false


### PR DESCRIPTION
All the modules that received a junit-jupiter dependency during the Wicket 9 upgrade are not running their tests anymore:

```
community/monitor-kafka/pom.xml:      <artifactId>junit-jupiter-api</artifactId>
community/security/keycloak/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/css/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/csw/web-csw/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/geofence/geofence-server/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/geofence/geofence/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/geopkg-output/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/grib/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/gwc-s3/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/importer/web/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/inspire/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/mapml/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/mbstyle/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/metadata/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/netcdf-out/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/netcdf/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/params-extractor/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/rat/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/wcs2_0-eo/web/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/web-resource/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/wmts-multi-dimensional/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/wps-download/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/wps/web-wps/pom.xml:      <artifactId>junit-jupiter</artifactId>
pom.xml:        <artifactId>junit-jupiter</artifactId>
rest/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/core/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/demo/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/gwc/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/rest/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/security/core/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/security/jdbc/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/security/ldap/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/wcs/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/wfs/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/wms/pom.xml:      <artifactId>junit-jupiter</artifactId>
```

This draft PR tries to fix it, but it also shows many test failures that were not caught during the Wicket 9 upgrade (list collected running the build with -fn so that all modules are built despite test failures)

```
[ERROR]   LayerGroupEditPageTest.testLayerGroupLinkWithWorkspace:299 path: 'publishedinfo:tabs:panel:layers:popup:content:listContainer:items' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerGroupStyle:722 path: 'publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:1:itemProperties:0:component:link' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerGroupStyle2:775 path: 'publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:3:itemProperties:0:component:link' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerGroupStyleSelection:862 path: 'publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:2:itemProperties:0:component:link' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerLink:212 path: 'publishedinfo:tabs:panel:layers:popup:content:listContainer:items' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerLinkWithWorkspace:265 path: 'publishedinfo:tabs:panel:layers:popup:content:listContainer:items' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testStyleGroupLink:238 path: 'publishedinfo:tabs:panel:layers:popup:content:listContainer:items' does not exist for page: LayerGroupEditPage
[ERROR]   ResourceConfigurationPageTest.testConsistentUpdateWMTSBbox:834 path: 'publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link' does not exist for page: ResourceConfigurationPage
[ERROR]   ResourceConfigurationPageTest.testWFSDataStoreResource:467 path: 'publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link' does not exist for page: ResourceConfigurationPage
[ERROR]   ResourceConfigurationPageTest.testWMTSOtherCRS:584 path: 'publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link' does not exist for page: ResourceConfigurationPage
[ERROR]   ResourceConfigurationPageTest.testWMTSOtherCRSUrnFormat:622 path: 'publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items' does not exist for page: ResourceConfigurationPage
[ERROR]   CRSPanelTest.testPlanetaryList:245 Unable to set value. Couldn't find component with name: crs:popup:content:table:filterForm:filter ==> expected: not <null>
[ERROR]   CRSPanelTest.testPlanetaryPopupWindow:227 path: 'form:crs:popup:content:wkt' does not exist for page: CRSPanelTestPage
[ERROR]   CRSPanelTest.testPopupWindow:69 path: 'form:crs:popup:content:wkt' does not exist for page: CRSPanelTestPage
[ERROR]   GeoServerAboutPageTest.testHideSensitiveInfo:40 » WicketRuntime The component(...
[ERROR]   GeoServerAboutPageTest.testLoginFormAction:21 » WicketRuntime The component(s)...
[ERROR]   PageResourceBrowserTest.testCopyPaste:166 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testCutPaste:107 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testDelete:228 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testEdit:392 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testNew:353 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testRename:251 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testUpload:315 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   XMLRoleConfigDetailsPanelTest.testAddModifyRemove:129->setFileName:66 Unable to set value. Couldn't find component with name: panel:content:fileName ==> expected: not <null>
[ERROR]   URLChecksPageTest.testDeleteRule:103 path: 'dialog:dialog:content:form:submit' does not exist for page: URLChecksPage
[ERROR]   XMLUserGroupConfigDetailsPanelTest.testAddModify:130->setFileName:77 Unable to set value. Couldn't find component with name: panel:content:fileName ==> expected: not <null>
[ERROR]   EditUserPageTest.testFill:39->doTestFill:79->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   EditUserPageTest.testReadOnlyUserGroupService:116->doTestReadOnlyUserGroupService:141->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   NewUserPageTest.testFill:50->doTestFill:75->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   NewUserPageTest.testFill2:158->doTestFill2:177->AbstractUserPageTest.assignGroup:86 » NullPointer
[ERROR]   NewUserPageTest.testFill3:111->doTestFill3:129->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   JDBCEditUserPageTest.testFill:23->EditUserPageTest.doTestFill:79->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   JDBCEditUserPageTest.testReadOnlyUserGroupService:29->EditUserPageTest.doTestReadOnlyUserGroupService:141->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   JDBCNewUserPageTest.testFill:23->NewUserPageTest.doTestFill:75->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   JDBCNewUserPageTest.testFill2:35->NewUserPageTest.doTestFill2:177->AbstractUserPageTest.assignGroup:86 » NullPointer
[ERROR]   JDBCNewUserPageTest.testFill3:29->NewUserPageTest.doTestFill3:129->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   BulkOperationsPageTest.testClearAll:84 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataBulkOperationsPage
[ERROR]   BulkOperationsPageTest.testFixAll:45 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataBulkOperationsPage
[ERROR]   BulkOperationsPageTest.testImport:60 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataBulkOperationsPage
[ERROR]   BulkOperationsPageTest.testNativeToCustom:75 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataBulkOperationsPage
[ERROR]   LayerMetadataTabTest.testGenerateFeatureCatalogueAndDomain:717 path: 'publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items:13:itemProperties:1:component:attributesTablePanel:listContainer:items:2:itemProperties:1:component:dialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testImportFromGeonetwork:650 path: 'publishedinfo:tabs:panel:geonetworkPanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testLinkAndUnlinkDeleteRowTemplatesBug:479 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testLinkRowTemplatesBug:581 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testLinkWithSimpleAndListTemplates:301 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testTemplatesRemainInPriorityOrder:604 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testUnlinkFromSimpleAndListTemplates:405 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   TemplatesPageTest.testDelete:145 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataTemplatesPage
[ERROR]   MapPreviewPageTest.testMaxNumberOfFeaturesForPreview:141->assertMaxFeaturesInData:189
[ERROR]   MapPreviewPageTest.testNameURLEncoding:279 
[ERROR]   StyleEditPageTest.testInsertImage:267 path: 'dialog:dialog:content:form:userPanel' does not exist for page: StyleEditPage
[ERROR]   StyleEditPageTest.testInsertImageSLD11:366 path: 'dialog:dialog:content:form:userPanel' does not exist for page: StyleEditPage
[ERROR]   StyleEditPageTest.testLayerAttributesTabWMS:459 path: 'styleForm:popup:content:layer.table' does not exist for page: StyleEditPage
[ERROR]   StyleEditPageTest.testLayerAttributesUnreachableLayer:443 path: 'styleForm:popup:content:layer.table' does not exist for page: StyleEditPage
[ERROR]   StyleNewPageTest.testInsertImage:493 path: 'dialog:dialog:content:form:userPanel' does not exist for page: StyleNewPage
[ERROR]   StyleNewPageTest.testInsertImageEscaped:564 path: 'dialog:dialog:content:form' does not exist for page: StyleNewPage
[ERROR]   StyleNewPageTest.testLegendChooseImage:600 path: 'dialog:dialog:content:form:userPanel' does not exist for page: StyleNewPage
[ERROR]   ProcessStatusPageTest.test:98 path: 'dialog:dialog:content:form:submit' does not exist for page: ProcessStatusPage
[ERROR]   ImportTaskTableTest.testTwoCRSSetByFindThenApply:66 path: 'taskTable:listContainer:items:1:itemProperties:2:component:form:crs:popup:content:table:listContainer:items:1:itemProperties:0:component:link' does not exist for page: StartComponentInPage
[ERROR]   CachedLayersPageTest.testGWCClean:223 path: 'dialog:dialog:content:form:submit' does not exist for page: CachedLayersPage
```


# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->