### PR TITLE
Run JUnit tests in all modules that received a JUnit 5 dependency

### DIFF
--- a/src/community/ogcapi/web-ogcapi/src/test/java/org/geoserver/web/ogcapi/AbstractLinksEditorTest.java
+++ b/src/community/ogcapi/web-ogcapi/src/test/java/org/geoserver/web/ogcapi/AbstractLinksEditorTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractLinksEditorTest extends GeoServerWicketTestSupport
 
     @Test
     public void testDisplayLinks() throws Exception {
-        print(tester.getLastRenderedPage(), true, true);
+       // print(tester.getLastRenderedPage(), true, true);
 
         // check existing link
         tester.assertModelValue(EDITOR + ITEM1 + REL, link.getRel());
@@ -53,7 +53,7 @@ public abstract class AbstractLinksEditorTest extends GeoServerWicketTestSupport
         // (this generates a new set of ids for all link components, starting from 2)
         tester.clickLink(EDITOR + ":addLink");
 
-        print(tester.getLastRenderedPage(), true, true);
+        //print(tester.getLastRenderedPage(), true, true);
 
         // fill the links
         FormTester ft = tester.newFormTester(getFormName());

--- a/src/community/ogcapi/web-ogcapi/src/test/java/org/geoserver/web/ogcapi/AbstractLinksEditorTest.java
+++ b/src/community/ogcapi/web-ogcapi/src/test/java/org/geoserver/web/ogcapi/AbstractLinksEditorTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractLinksEditorTest extends GeoServerWicketTestSupport
 
     @Test
     public void testDisplayLinks() throws Exception {
-       // print(tester.getLastRenderedPage(), true, true);
+        // print(tester.getLastRenderedPage(), true, true);
 
         // check existing link
         tester.assertModelValue(EDITOR + ITEM1 + REL, link.getRel());
@@ -53,7 +53,7 @@ public abstract class AbstractLinksEditorTest extends GeoServerWicketTestSupport
         // (this generates a new set of ids for all link components, starting from 2)
         tester.clickLink(EDITOR + ":addLink");
 
-        //print(tester.getLastRenderedPage(), true, true);
+        // print(tester.getLastRenderedPage(), true, true);
 
         // fill the links
         FormTester ft = tester.newFormTester(getFormName());

--- a/src/community/proxy-base-ext/src/test/java/org/geoserver/proxybase/ext/web/ProxyBaseExtensionConfigPageTest.java
+++ b/src/community/proxy-base-ext/src/test/java/org/geoserver/proxybase/ext/web/ProxyBaseExtensionConfigPageTest.java
@@ -59,7 +59,7 @@ public class ProxyBaseExtensionConfigPageTest extends GeoServerWicketTestSupport
         tester.startPage(ProxyBaseExtensionConfigPage.class);
         tester.assertRenderedPage(ProxyBaseExtensionConfigPage.class);
 
-        print(tester.getLastRenderedPage(), true, true);
+        //print(tester.getLastRenderedPage(), true, true);
 
         // click the edit link of the first rule
         tester.clickLink("rulesPanel:listContainer:items:1:itemProperties:4:component:link");

--- a/src/community/proxy-base-ext/src/test/java/org/geoserver/proxybase/ext/web/ProxyBaseExtensionConfigPageTest.java
+++ b/src/community/proxy-base-ext/src/test/java/org/geoserver/proxybase/ext/web/ProxyBaseExtensionConfigPageTest.java
@@ -59,7 +59,7 @@ public class ProxyBaseExtensionConfigPageTest extends GeoServerWicketTestSupport
         tester.startPage(ProxyBaseExtensionConfigPage.class);
         tester.assertRenderedPage(ProxyBaseExtensionConfigPage.class);
 
-        //print(tester.getLastRenderedPage(), true, true);
+        // print(tester.getLastRenderedPage(), true, true);
 
         // click the edit link of the first rule
         tester.clickLink("rulesPanel:listContainer:items:1:itemProperties:4:component:link");

--- a/src/extension/importer/web/src/test/java/org/geoserver/importer/web/ImportTaskTableTest.java
+++ b/src/extension/importer/web/src/test/java/org/geoserver/importer/web/ImportTaskTableTest.java
@@ -64,14 +64,14 @@ public class ImportTaskTableTest extends GeoServerWicketTestSupport {
                 "taskTable:listContainer:items:1:itemProperties:2:component:form:crs:find", true);
         // Select the first CRS
         tester.clickLink(
-                "taskTable:listContainer:items:1:itemProperties:2:component:form:crs:popup:content:table:listContainer:items:1:itemProperties:0:component:link",
+                "taskTable:listContainer:items:1:itemProperties:2:component:form:crs:popup:modal:content:table:listContainer:items:1:itemProperties:0:component:link",
                 true);
         // Click the Find CRS button for the second layer to import
         tester.clickLink(
                 "taskTable:listContainer:items:2:itemProperties:2:component:form:crs:find", true);
         // Select the first CRS
         tester.clickLink(
-                "taskTable:listContainer:items:2:itemProperties:2:component:form:crs:popup:content:table:listContainer:items:2:itemProperties:0:component:link",
+                "taskTable:listContainer:items:2:itemProperties:2:component:form:crs:popup:modal:content:table:listContainer:items:2:itemProperties:0:component:link",
                 true);
 
         // The EPSG codes should be set

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/BulkOperationsPageTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/BulkOperationsPageTest.java
@@ -43,7 +43,7 @@ public class BulkOperationsPageTest extends AbstractWicketMetadataTest {
     public void testFixAll() {
         tester.clickLink("fix");
         tester.assertModelValue(
-                "dialog:dialog:content:form:userPanel",
+                "dialog:dialog:modal:content:form:userPanel",
                 "This will update 1 layers and might take a while.");
     }
 
@@ -58,7 +58,7 @@ public class BulkOperationsPageTest extends AbstractWicketMetadataTest {
 
         formTester.submit("import");
         tester.assertModelValue(
-                "dialog:dialog:content:form:userPanel",
+                "dialog:dialog:modal:content:form:userPanel",
                 "This will import 2 layers and might take a while. Existing data may be overwritten/removed.");
     }
 
@@ -73,7 +73,7 @@ public class BulkOperationsPageTest extends AbstractWicketMetadataTest {
 
         formTester.submit("custom");
         tester.assertModelValue(
-                "dialog:dialog:content:form:userPanel",
+                "dialog:dialog:modal:content:form:userPanel",
                 "This will process 2 layers and might take a while. Existing data may be overwritten/removed.");
     }
 
@@ -82,7 +82,7 @@ public class BulkOperationsPageTest extends AbstractWicketMetadataTest {
         FormTester formTester = tester.newFormTester("formClear");
         formTester.submit("clear");
         tester.assertModelValue(
-                "dialog:dialog:content:form:userPanel",
+                "dialog:dialog:modal:content:form:userPanel",
                 "This will update 1 layers and might take a while. Warning: ALL metadata will be removed and this cannot be undone!");
     }
 }

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/LayerMetadataTabTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/LayerMetadataTabTest.java
@@ -299,7 +299,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
         ((IModel<MetadataTemplateImpl>) selectTemplate.getDefaultModel()).setObject(template);
         tester.clickLink("publishedinfo:tabs:panel:importTemplatePanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:modal:content:form:submit");
         // test list of linked templates
         tester.assertLabel(
                 "publishedinfo:tabs:panel:importTemplatePanel:templatesPanel:listContainer:items:3:itemProperties:0:component",
@@ -349,7 +349,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
         ((IModel<MetadataTemplateImpl>) selectTemplate.getDefaultModel()).setObject(template);
         tester.clickLink("publishedinfo:tabs:panel:importTemplatePanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:modal:content:form:submit");
 
         tester.assertLabel(
                 "publishedinfo:tabs:panel:importTemplatePanel:templatesPanel:listContainer:items:7:itemProperties:0:component",
@@ -403,12 +403,12 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
         ((IModel<MetadataTemplateImpl>) selectTemplate.getDefaultModel()).setObject(template);
         tester.clickLink("publishedinfo:tabs:panel:importTemplatePanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:modal:content:form:submit");
         template = (MetadataTemplateImpl) selectTemplate.getChoices().get(0);
         ((IModel<MetadataTemplateImpl>) selectTemplate.getDefaultModel()).setObject(template);
         tester.clickLink("publishedinfo:tabs:panel:importTemplatePanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:modal:content:form:submit");
 
         // print(tester.getLastRenderedPage(), true, true);
         // check the link
@@ -477,7 +477,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
         ((IModel<MetadataTemplateImpl>) selectTemplate.getDefaultModel()).setObject(template);
         tester.clickLink("publishedinfo:tabs:panel:importTemplatePanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:modal:content:form:submit");
 
         tester.assertLabel(
                 "publishedinfo:tabs:panel:importTemplatePanel:templatesPanel:listContainer:items:3:itemProperties:0:component",
@@ -514,7 +514,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
         ((IModel<MetadataTemplateImpl>) selectTemplate.getDefaultModel()).setObject(template);
         tester.clickLink("publishedinfo:tabs:panel:importTemplatePanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:modal:content:form:submit");
 
         // print(tester.getLastRenderedPage(), true, true);
         tester.assertLabel(
@@ -579,7 +579,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
         ((IModel<MetadataTemplateImpl>) selectTemplate.getDefaultModel()).setObject(template);
         tester.clickLink("publishedinfo:tabs:panel:importTemplatePanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:modal:content:form:submit");
 
         // check table is visible
         Assert.assertNull(
@@ -602,7 +602,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
         ((IModel<MetadataTemplateImpl>) selectTemplate.getDefaultModel()).setObject(template);
         tester.clickLink("publishedinfo:tabs:panel:importTemplatePanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:modal:content:form:submit");
 
         selectTemplate =
                 (DropDownChoice<?>)
@@ -612,7 +612,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
         ((IModel<MetadataTemplateImpl>) selectTemplate.getDefaultModel()).setObject(template);
         tester.clickLink("publishedinfo:tabs:panel:importTemplatePanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:modal:content:form:submit");
 
         tester.assertLabel(
                 "publishedinfo:tabs:panel:importTemplatePanel:templatesPanel:listContainer:items:7:itemProperties:0:component",
@@ -648,7 +648,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
 
         tester.clickLink("publishedinfo:tabs:panel:geonetworkPanel:link");
         tester.clickLink(
-                "publishedinfo:tabs:panel:geonetworkPanel:importDialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:geonetworkPanel:importDialog:dialog:modal:content:form:submit");
 
         // print(tester.getLastRenderedPage(), true, true);
 
@@ -715,7 +715,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
                 GeoServerDialog.class);
 
         tester.clickLink(
-                "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items:13:itemProperties:1:component:attributesTablePanel:listContainer:items:2:itemProperties:1:component:dialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items:13:itemProperties:1:component:attributesTablePanel:listContainer:items:2:itemProperties:1:component:dialog:dialog:modal:content:form:submit");
 
         @SuppressWarnings("unchecked")
         GeoServerTablePanel<ComplexMetadataMap> panel =
@@ -741,7 +741,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
                 GeoServerDialog.class);
 
         tester.clickLink(
-                "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items:13:itemProperties:1:component:attributesTablePanel:listContainer:items:2:itemProperties:1:component:attributesTablePanel:listContainer:items:2:itemProperties:0:component:attributesTablePanel:listContainer:items:7:itemProperties:1:component:dialog:dialog:content:form:submit");
+                "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items:13:itemProperties:1:component:attributesTablePanel:listContainer:items:2:itemProperties:1:component:attributesTablePanel:listContainer:items:2:itemProperties:0:component:attributesTablePanel:listContainer:items:7:itemProperties:1:component:dialog:dialog:modal:content:form:submit");
 
         @SuppressWarnings("unchecked")
         GeoServerTablePanel<ComplexMetadataMap> panel2 =

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/TemplatesPageTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/TemplatesPageTest.java
@@ -142,8 +142,8 @@ public class TemplatesPageTest extends AbstractWicketMetadataTest {
         tester.clickLink("removeSelected");
 
         // print(tester.getLastRenderedPage(), true, true);
-        tester.assertComponent("dialog:dialog:content:form:userPanel", MultiLineLabel.class);
-        tester.clickLink("dialog:dialog:content:form:submit");
+        tester.assertComponent("dialog:dialog:modal:content:form:userPanel", MultiLineLabel.class);
+        tester.clickLink("dialog:dialog:modal:content:form:submit");
 
         // Check update content of the table)
         assertEquals(

--- a/src/extension/web-resource/src/test/java/org/geoserver/web/resources/PageResourceBrowserTest.java
+++ b/src/extension/web-resource/src/test/java/org/geoserver/web/resources/PageResourceBrowserTest.java
@@ -104,11 +104,13 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // paste in new directory
         tester.clickLink("paste");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", PanelPaste.class);
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        tester.assertComponent("dialog:dialog:modal:content:form:userPanel", PanelPaste.class);
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.setValue("userPanel:directory", "temp/new_dir");
         formTester.submit("submit");
-        assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
+        assertNull(
+                tester.getComponentFromLastRenderedPage(
+                        "dialog:dialog:modal:content:form:userPanel"));
         assertFalse(Resources.exists(resourceBrowser.store().get(PATH_RES)));
         assertTrue(Resources.exists(resourceBrowser.store().get("temp/new_dir")));
         assertTrue(Resources.exists(resourceBrowser.store().get("temp/new_dir/dir/something")));
@@ -163,10 +165,12 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // paste in same directory
         tester.clickLink("paste");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", PanelPaste.class);
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        tester.assertComponent("dialog:dialog:modal:content:form:userPanel", PanelPaste.class);
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.submit("submit");
-        assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
+        assertNull(
+                tester.getComponentFromLastRenderedPage(
+                        "dialog:dialog:modal:content:form:userPanel"));
 
         tester.assertComponent(
                 "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/something.1",
@@ -225,10 +229,12 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // delete resource
         tester.clickLink("delete");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", Label.class);
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        tester.assertComponent("dialog:dialog:modal:content:form:userPanel", Label.class);
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.submit("submit");
-        assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
+        assertNull(
+                tester.getComponentFromLastRenderedPage(
+                        "dialog:dialog:modal:content:form:userPanel"));
 
         assertFalse(Resources.exists(resourceBrowser.store().get(PATH_RES)));
         assertFalse(Resources.exists(resourceBrowser.store().get(PATH_RES2)));
@@ -248,11 +254,13 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // rename resource
         tester.clickLink("rename");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", PanelRename.class);
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        tester.assertComponent("dialog:dialog:modal:content:form:userPanel", PanelRename.class);
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.setValue("userPanel:name", "anotherthing");
         formTester.submit("submit");
-        assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
+        assertNull(
+                tester.getComponentFromLastRenderedPage(
+                        "dialog:dialog:modal:content:form:userPanel"));
 
         assertFalse(Resources.exists(resourceBrowser.store().get(PATH_RES)));
         tester.assertContainsNot(
@@ -312,12 +320,14 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // upload file
         tester.clickLink("upload");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", PanelUpload.class);
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        tester.assertComponent("dialog:dialog:modal:content:form:userPanel", PanelUpload.class);
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.setFile(
                 "userPanel:file", new org.apache.wicket.util.file.File(file), "text/plain");
         formTester.submit("submit");
-        assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
+        assertNull(
+                tester.getComponentFromLastRenderedPage(
+                        "dialog:dialog:modal:content:form:userPanel"));
 
         tester.assertComponent(
                 "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/anewthing",
@@ -350,12 +360,14 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // new file
         tester.clickLink("new");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", PanelEdit.class);
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        tester.assertComponent("dialog:dialog:modal:content:form:userPanel", PanelEdit.class);
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.setValue("userPanel:resource", "temp/dir/anewthing");
         formTester.setValue("userPanel:contents", DATA2);
         formTester.submit("submit");
-        assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
+        assertNull(
+                tester.getComponentFromLastRenderedPage(
+                        "dialog:dialog:modal:content:form:userPanel"));
 
         tester.assertComponent(
                 "treeview:rootView:/:children:temp:children:temp/dir:children:temp/dir/anewthing",
@@ -389,12 +401,14 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
 
         // new file
         tester.clickLink("edit");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", PanelEdit.class);
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        tester.assertComponent("dialog:dialog:modal:content:form:userPanel", PanelEdit.class);
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         assertEquals(DATA, formTester.getTextComponentValue("userPanel:contents"));
         formTester.setValue("userPanel:contents", DATA2);
         formTester.submit("submit");
-        assertNull(tester.getComponentFromLastRenderedPage("dialog:dialog:content:form:userPanel"));
+        assertNull(
+                tester.getComponentFromLastRenderedPage(
+                        "dialog:dialog:modal:content:form:userPanel"));
 
         try (InputStream is = resourceBrowser.store().get(PATH_RES).in()) {
             assertEquals(

--- a/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/ProcessStatusPageTest.java
+++ b/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/ProcessStatusPageTest.java
@@ -95,7 +95,7 @@ public class ProcessStatusPageTest extends WPSPagesTestSupport {
         tester.getComponentFromLastRenderedPage("headerPanel:dismissSelected").setEnabled(true);
         tester.clickLink("headerPanel:dismissSelected");
         // this submits the dialog
-        tester.clickLink("dialog:dialog:content:form:submit", true);
+        tester.clickLink("dialog:dialog:modal:content:form:submit", true);
         // this makes the dialog actually close
         tester.getComponentFromLastRenderedPage("dialog:dialog")
                 .getBehaviors()

--- a/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/ProcessStatusPageTest.java
+++ b/src/extension/wps/web-wps/src/test/java/org/geoserver/wps/web/ProcessStatusPageTest.java
@@ -97,7 +97,7 @@ public class ProcessStatusPageTest extends WPSPagesTestSupport {
         // this submits the dialog
         tester.clickLink("dialog:dialog:modal:content:form:submit", true);
         // this makes the dialog actually close
-        tester.getComponentFromLastRenderedPage("dialog:dialog")
+        tester.getComponentFromLastRenderedPage("dialog:dialog:modal")
                 .getBehaviors()
                 .forEach(
                         b -> {

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1816,6 +1816,13 @@
       <!-- unit testing -->
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit4</artifactId>
+            <version>2.22.2</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <runOrder>alphabetical</runOrder>
           <includes>

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerWicketTestSupport.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerWicketTestSupport.java
@@ -38,7 +38,7 @@ public abstract class GeoServerWicketTestSupport extends GeoServerSecurityTestSu
     }
 
     @AfterClass
-    public  static void cleanupWicketConfiguration() throws Exception {
+    public static void cleanupWicketConfiguration() throws Exception {
         System.clearProperty("wicket.configuration");
     }
 

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerWicketTestSupport.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerWicketTestSupport.java
@@ -25,6 +25,7 @@ import org.geoserver.data.test.SystemTestData;
 import org.geoserver.security.GeoServerSecurityTestSupport;
 import org.geoserver.web.wicket.WicketHierarchyPrinter;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 public abstract class GeoServerWicketTestSupport extends GeoServerSecurityTestSupport {
@@ -34,6 +35,11 @@ public abstract class GeoServerWicketTestSupport extends GeoServerSecurityTestSu
     public static void disableBrowserDetection() {
         // disable browser detection, makes testing harder for nothing
         GeoServerApplication.DETECT_BROWSER = false;
+    }
+
+    @AfterClass
+    public  static void cleanupWicketConfiguration() throws Exception {
+        System.clearProperty("wicket.configuration");
     }
 
     @Override

--- a/src/web/core/src/test/java/org/geoserver/web/data/layergroup/LayerGroupEditPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/layergroup/LayerGroupEditPageTest.java
@@ -210,11 +210,11 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
         tester.assertNoErrorMessage();
         // Ensure that the Layer List page is rendered correctly
         tester.assertComponent(
-                "publishedinfo:tabs:panel:layers:popup:content:listContainer:items",
+                "publishedinfo:tabs:panel:layers:popup:modal:content:listContainer:items",
                 DataView.class);
         // Get the DataView containing the Layer List
         DataView<?> dataView =
-                (DataView<?>) page.lgEntryPanel.get("popup:content:listContainer:items");
+                (DataView<?>) page.lgEntryPanel.get("popup:modal:content:listContainer:items");
         // Ensure that the Row count is equal to the Layers in the Catalog
         Catalog catalog = getGeoServerApplication().getCatalog();
 
@@ -236,11 +236,11 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
         tester.assertNoErrorMessage();
         // Ensure that the Style Group List page is rendered correctly
         tester.assertComponent(
-                "publishedinfo:tabs:panel:layers:popup:content:listContainer:items",
+                "publishedinfo:tabs:panel:layers:popup:modal:content:listContainer:items",
                 DataView.class);
         // Get the DataView containing the Style Group List
         DataView<?> dataView =
-                (DataView<?>) page.lgEntryPanel.get("popup:content:listContainer:items");
+                (DataView<?>) page.lgEntryPanel.get("popup:modal:content:listContainer:items");
         // Ensure that the Row count is equal to the style in the Catalog
         Catalog catalog = getGeoServerApplication().getCatalog();
 
@@ -263,11 +263,11 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
         tester.assertNoErrorMessage();
         // Ensure that the Layer List page is rendered correctly
         tester.assertComponent(
-                "publishedinfo:tabs:panel:layers:popup:content:listContainer:items",
+                "publishedinfo:tabs:panel:layers:popup:modal:content:listContainer:items",
                 DataView.class);
         // Get the DataView containing the Layer List
         DataView<?> dataView =
-                (DataView<?>) page.lgEntryPanel.get("popup:content:listContainer:items");
+                (DataView<?>) page.lgEntryPanel.get("popup:modal:content:listContainer:items");
         // Ensure that the Row count is equal to the Layers in the Catalog
         Catalog catalog = getGeoServerApplication().getCatalog();
 
@@ -295,13 +295,14 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
         // Click on the link
         tester.clickLink("publishedinfo:tabs:panel:layers:addLayerGroup");
         tester.assertNoErrorMessage();
+
         // Ensure that the Layer List page is rendered correctly
         tester.assertComponent(
-                "publishedinfo:tabs:panel:layers:popup:content:listContainer:items",
+                "publishedinfo:tabs:panel:layers:popup:modal:content:listContainer:items",
                 DataView.class);
         // Get the DataView containing the Layer List
         DataView<?> dataView =
-                (DataView<?>) page.lgEntryPanel.get("popup:content:listContainer:items");
+                (DataView<?>) page.lgEntryPanel.get("popup:modal:content:listContainer:items");
         // Ensure that the Row count is equal to the Layers in the Catalog
         Catalog catalog = getGeoServerApplication().getCatalog();
 
@@ -720,7 +721,7 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
                     "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:addLayer",
                     "click");
             tester.executeAjaxEvent(
-                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:1:itemProperties:0:component:link",
+                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:modal:content:listContainer:items:1:itemProperties:0:component:link",
                     "click");
             tester.executeAjaxEvent(
                     "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:addLayerGroup",
@@ -773,14 +774,14 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
                     "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:addLayerGroup",
                     "click");
             tester.executeAjaxEvent(
-                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:3:itemProperties:0:component:link",
+                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:modal:content:listContainer:items:3:itemProperties:0:component:link",
                     "click");
 
             tester.executeAjaxEvent(
                     "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:addLayer",
                     "click");
             tester.executeAjaxEvent(
-                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:1:itemProperties:0:component:link",
+                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:modal:content:listContainer:items:1:itemProperties:0:component:link",
                     "click");
 
             FormTester ft = tester.newFormTester("publishedinfo");
@@ -860,7 +861,7 @@ public class LayerGroupEditPageTest extends LayerGroupBaseTest {
 
             // select the LayerGroupStyle.
             tester.executeAjaxEvent(
-                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:2:itemProperties:0:component:link",
+                    "publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:modal:content:listContainer:items:2:itemProperties:0:component:link",
                     "click");
 
             // forces the model of the default style checkbox to be set to false

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/ResourceConfigurationPageTest.java
@@ -465,7 +465,7 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
 
         // click first item in SRS (urn:ogc:def:crs:EPSG::4326)
         tester.clickLink(
-                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link",
+                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:modal:content:table:listContainer:items:1:itemProperties:0:component:link",
                 true);
 
         // assert that native SRS has changed from EPSG:26713 to urn:ogc:def:crs:EPSG::4326
@@ -582,7 +582,7 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
 
         // click first item in SRS
         tester.clickLink(
-                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link",
+                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:modal:content:table:listContainer:items:1:itemProperties:0:component:link",
                 true);
 
         // assert that native SRS has changed
@@ -620,20 +620,20 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
         DataView epsgContainer =
                 (DataView)
                         tester.getComponentFromLastRenderedPage(
-                                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items");
+                                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:modal:content:table:listContainer:items");
 
         // we got two epsg in the otherSrs container
         assertEquals(3, epsgContainer.size());
 
         Component epsgComponent1 =
                 tester.getComponentFromLastRenderedPage(
-                        "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link:label");
+                        "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:modal:content:table:listContainer:items:1:itemProperties:0:component:link:label");
         Component epsgComponent2 =
                 tester.getComponentFromLastRenderedPage(
-                        "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:2:itemProperties:0:component:link:label");
+                        "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:modal:content:table:listContainer:items:2:itemProperties:0:component:link:label");
         Component epsgComponent3 =
                 tester.getComponentFromLastRenderedPage(
-                        "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:3:itemProperties:0:component:link:label");
+                        "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:modal:content:table:listContainer:items:3:itemProperties:0:component:link:label");
 
         // checks that they have been properly displayed with not urn format being cut
         assertEquals("urn:ogc:def:crs:EPSG::3006", epsgComponent1.getDefaultModel().getObject());
@@ -832,7 +832,7 @@ public class ResourceConfigurationPageTest extends GeoServerWicketTestSupport {
 
         // click first item in SRS
         tester.clickLink(
-                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link",
+                "publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:modal:content:table:listContainer:items:1:itemProperties:0:component:link",
                 true);
         tester.clickLink(
                 "publishedinfo:tabs:panel:theList:0:content:referencingForm:computeNative", true);

--- a/src/web/core/src/test/java/org/geoserver/web/wicket/CRSPanelTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/wicket/CRSPanelTest.java
@@ -66,7 +66,7 @@ public class CRSPanelTest extends GeoServerWicketTestSupport {
         tester.clickLink("form:crs:wkt", true);
         assertTrue(window.isShown());
 
-        tester.assertModelValue("form:crs:popup:content:wkt", crs.toWKT());
+        tester.assertModelValue("form:crs:popup:modal:content:wkt", crs.toWKT());
     }
 
     @Test
@@ -224,7 +224,7 @@ public class CRSPanelTest extends GeoServerWicketTestSupport {
         tester.clickLink("form:crs:wkt", true);
         assertTrue(window.isShown());
 
-        tester.assertModelValue("form:crs:popup:content:wkt", crs.toWKT());
+        tester.assertModelValue("form:crs:popup:modal:content:wkt", crs.toWKT());
     }
 
     @Test
@@ -242,8 +242,8 @@ public class CRSPanelTest extends GeoServerWicketTestSupport {
 
         // filter by name
         FormTester ft = tester.newFormTester("form");
-        ft.setValue("crs:popup:content:table:filterForm:filter", "IAU:30115");
-        ft.submit("crs:popup:content:table:filterForm:submit");
+        ft.setValue("crs:popup:modal:content:table:filterForm:filter", "IAU:30115");
+        ft.submit("crs:popup:modal:content:table:filterForm:submit");
 
         // find and click the link with the 30115 code
         tester.getLastRenderedPage()

--- a/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.java
+++ b/src/web/demo/src/main/java/org/geoserver/web/demo/MapPreviewPage.java
@@ -301,7 +301,7 @@ public class MapPreviewPage extends GeoServerBasePage {
         // onChange event handled by JS (see renderHeader)
         // we need 2 things;
         // 1. wmsLink
-        // 2. wmsLink
+        // 2. wfsLink
 
         menu.add(new AttributeAppender("wmsLink", new Model<>(layer.getWmsLink()), ";"));
         menu.add(new AttributeAppender("wfsLink", new Model<>(layer.buildWfsLink()), ";"));

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayersPageTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/CachedLayersPageTest.java
@@ -220,7 +220,7 @@ public class CachedLayersPageTest extends GeoServerWicketTestSupport {
         tester.assertVisible("dialog");
 
         // click submit
-        tester.clickLink("dialog:dialog:content:form:submit", true);
+        tester.clickLink("dialog:dialog:modal:content:form:submit", true);
 
         tester.assertNoErrorMessage();
     }

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/user/AbstractUserPage.java
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/user/AbstractUserPage.java
@@ -18,6 +18,7 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.FormComponent;
+import org.apache.wicket.markup.html.form.IFormSubmittingComponent;
 import org.apache.wicket.markup.html.form.PasswordTextField;
 import org.apache.wicket.markup.html.form.SubmitLink;
 import org.apache.wicket.markup.html.form.TextField;
@@ -234,7 +235,8 @@ public abstract class AbstractUserPage extends AbstractSecurityPage {
         if (form == null) {
             return false;
         }
-        return form.findSubmitter().getInputName().equals("save");
+        IFormSubmittingComponent submitter = form.findSubmitter();
+        return submitter != null && submitter.getInputName().equals("save");
     }
 
     void updateCalculatedRoles(AjaxRequestTarget target) {

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/AbstractSecurityNamedServicePanelTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/AbstractSecurityNamedServicePanelTest.java
@@ -206,7 +206,6 @@ public abstract class AbstractSecurityNamedServicePanelTest
         return formTester.getForm().get("config.className").getDefaultModelObjectAsString();
     }
 
-    // TODO: WICKET 9 fix this
     @SuppressWarnings("unchecked")
     protected <T extends SecurityNamedServicePanelInfo> void setSecurityConfigClassName(
             Class<T> clazz) throws Exception {
@@ -215,15 +214,17 @@ public abstract class AbstractSecurityNamedServicePanelTest
                 i -> {
                     if (i instanceof ListItem) {
                         ListItem<? extends Object> listItem = (ListItem<? extends Object>) i;
-                        listItem.forEach(
-                                action -> {
-                                    if (action instanceof AjaxLink) {
-                                        AjaxLink link = (AjaxLink) action;
-                                        if (link.isEnabled()) {
-                                            tester.executeAjaxEvent(link, "click");
+                        if (clazz.isInstance(listItem.getModelObject())) {
+                            listItem.forEach(
+                                    action -> {
+                                        if (action instanceof AjaxLink) {
+                                            AjaxLink link = (AjaxLink) action;
+                                            if (link.isEnabled()) {
+                                                tester.executeAjaxEvent(link, "click");
+                                            }
                                         }
-                                    }
-                                });
+                                    });
+                        }
                     }
                 });
     }

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/url/URLChecksPageTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/url/URLChecksPageTest.java
@@ -100,7 +100,7 @@ public class URLChecksPageTest extends GeoServerWicketTestSupport {
         // click remove link
         tester.clickLink("removeSelected", true);
         // confirm on dialog
-        tester.clickLink("dialog:dialog:content:form:submit");
+        tester.clickLink("dialog:dialog:modal:content:form:submit");
 
         assertThat(getDao().getChecks(), empty());
     }

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleEditPageTest.java
@@ -264,25 +264,27 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
         tester.assertComponent(
                 "styleForm:styleEditor:editorContainer:toolbar:custom-buttons:1", AjaxLink.class);
         tester.clickLink("styleForm:styleEditor:editorContainer:toolbar:custom-buttons:1");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", ChooseImagePanel.class);
-        tester.assertComponent("dialog:dialog:content:form:userPanel:image", DropDownChoice.class);
-        tester.assertInvisible("dialog:dialog:content:form:userPanel:display");
+        tester.assertComponent(
+                "dialog:dialog:modal:content:form:userPanel", ChooseImagePanel.class);
+        tester.assertComponent(
+                "dialog:dialog:modal:content:form:userPanel:image", DropDownChoice.class);
+        tester.assertInvisible("dialog:dialog:modal:content:form:userPanel:display");
         @SuppressWarnings("unchecked")
         List<? extends String> choices =
                 ((DropDownChoice<String>)
                                 tester.getComponentFromLastRenderedPage(
-                                        "dialog:dialog:content:form:userPanel:image"))
+                                        "dialog:dialog:modal:content:form:userPanel:image"))
                         .getChoices();
         assertEquals(3, choices.size());
         assertEquals("otherpicture.jpg", choices.get(0));
         assertEquals("somepicture.png", choices.get(1));
         assertEquals("vector.svg", choices.get(2));
 
-        FormTester formTester = tester.newFormTester("dialog:dialog:content:form");
+        FormTester formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.select("userPanel:image", 1);
 
-        tester.executeAjaxEvent("dialog:dialog:content:form:userPanel:image", "change");
-        tester.assertVisible("dialog:dialog:content:form:userPanel:display");
+        tester.executeAjaxEvent("dialog:dialog:modal:content:form:userPanel:image", "change");
+        tester.assertVisible("dialog:dialog:modal:content:form:userPanel:display");
 
         formTester.submit("submit");
 
@@ -294,8 +296,8 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
                                 + "xmlns:xlink=\"http://www.w3.org/1999/xlink\">\\\\n"
                                 + "<OnlineResource xlink:type=\"simple\" xlink:href=\""
                                 + "(.*)\" />\\\\n"
-                                + "<Format>(.*)</Format>\\\\n"
-                                + "</ExternalGraphic>\\\\n'\\)");
+                                + "<Format>([^<]+)<..Format>\\\\n"
+                                + "<..ExternalGraphic>\\\\n'\\)");
         Matcher matcher = pattern.matcher(tester.getLastResponse().getDocument());
         assertTrue(matcher.find());
         assertEquals("somepicture.png", matcher.group(1));
@@ -303,7 +305,7 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
 
         // test uploading
         tester.clickLink("styleForm:styleEditor:editorContainer:toolbar:custom-buttons:1");
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         org.apache.wicket.util.file.File file =
                 new org.apache.wicket.util.file.File(
                         URLs.urlToFile(getClass().getResource("GeoServer_75.png")));
@@ -363,10 +365,12 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
         tester.assertComponent(
                 "styleForm:styleEditor:editorContainer:toolbar:custom-buttons:1", AjaxLink.class);
         tester.clickLink("styleForm:styleEditor:editorContainer:toolbar:custom-buttons:1");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", ChooseImagePanel.class);
-        tester.assertComponent("dialog:dialog:content:form:userPanel:image", DropDownChoice.class);
+        tester.assertComponent(
+                "dialog:dialog:modal:content:form:userPanel", ChooseImagePanel.class);
+        tester.assertComponent(
+                "dialog:dialog:modal:content:form:userPanel:image", DropDownChoice.class);
 
-        FormTester formTester = tester.newFormTester("dialog:dialog:content:form");
+        FormTester formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.select("userPanel:image", 0);
         formTester.submit("submit");
 
@@ -378,8 +382,8 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
                                 + "xmlns:xlink=\"http://www.w3.org/1999/xlink\">\\\\n"
                                 + "<OnlineResource xlink:type=\"simple\" xlink:href=\""
                                 + "(.*)\" />\\\\n"
-                                + "<Format>(.*)</Format>\\\\n"
-                                + "</ExternalGraphic>\\\\n'\\)");
+                                + "<Format>(.*)<..Format>\\\\n"
+                                + "<..ExternalGraphic>\\\\n'\\)");
         Matcher matcher = pattern.matcher(tester.getLastResponse().getDocument());
         assertTrue(matcher.find());
         assertEquals("somepicture.png", matcher.group(1));
@@ -440,14 +444,16 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
     public void testLayerAttributesUnreachableLayer() throws Exception {
         tester.executeAjaxEvent("styleForm:context:tabs-container:tabs:3:link", "click");
         tester.executeAjaxEvent("styleForm:context:panel:changeLayer:link", "click");
-        tester.assertComponent("styleForm:popup:content:layer.table", GeoServerTablePanel.class);
+        tester.assertComponent(
+                "styleForm:popup:modal:content:layer.table", GeoServerTablePanel.class);
         tester.executeAjaxEvent(
-                "styleForm:popup:content:layer.table:navigatorBottom:navigator:last", "click");
+                "styleForm:popup:modal:content:layer.table:navigatorBottom:navigator:last",
+                "click");
         tester.assertLabel(
-                "styleForm:popup:content:layer.table:listContainer:items:30:itemProperties:2:component:link:layer.name",
+                "styleForm:popup:modal:content:layer.table:listContainer:items:30:itemProperties:2:component:link:layer.name",
                 "unlayer");
         tester.executeAjaxEvent(
-                "styleForm:popup:content:layer.table:listContainer:items:30:itemProperties:2:component:link",
+                "styleForm:popup:modal:content:layer.table:listContainer:items:30:itemProperties:2:component:link",
                 "click");
         tester.assertContains("Failed to load attribute list, internal error is:");
     }
@@ -456,12 +462,14 @@ public class StyleEditPageTest extends GeoServerWicketTestSupport {
     public void testLayerAttributesTabWMS() {
         tester.executeAjaxEvent("styleForm:context:tabs-container:tabs:3:link", "click");
         tester.executeAjaxEvent("styleForm:context:panel:changeLayer:link", "click");
-        tester.assertComponent("styleForm:popup:content:layer.table", GeoServerTablePanel.class);
+        tester.assertComponent(
+                "styleForm:popup:modal:content:layer.table", GeoServerTablePanel.class);
 
         // 31 layers total, 25 layers per page; foo should not appear on page 1 or 2.
         tester.assertContainsNot("wmsstore");
         tester.executeAjaxEvent(
-                "styleForm:popup:content:layer.table:navigatorBottom:navigator:last", "click");
+                "styleForm:popup:modal:content:layer.table:navigatorBottom:navigator:last",
+                "click");
         tester.assertContainsNot("wmsstore");
     }
 

--- a/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleNewPageTest.java
+++ b/src/web/wms/src/test/java/org/geoserver/wms/web/data/StyleNewPageTest.java
@@ -490,25 +490,27 @@ public class StyleNewPageTest extends GeoServerWicketTestSupport {
         tester.assertComponent(
                 "styleForm:styleEditor:editorContainer:toolbar:custom-buttons:1", AjaxLink.class);
         tester.clickLink("styleForm:styleEditor:editorContainer:toolbar:custom-buttons:1");
-        tester.assertComponent("dialog:dialog:content:form:userPanel", ChooseImagePanel.class);
-        tester.assertComponent("dialog:dialog:content:form:userPanel:image", DropDownChoice.class);
-        tester.assertInvisible("dialog:dialog:content:form:userPanel:display");
+        tester.assertComponent(
+                "dialog:dialog:modal:content:form:userPanel", ChooseImagePanel.class);
+        tester.assertComponent(
+                "dialog:dialog:modal:content:form:userPanel:image", DropDownChoice.class);
+        tester.assertInvisible("dialog:dialog:modal:content:form:userPanel:display");
         @SuppressWarnings("unchecked")
         List<? extends String> choices =
                 ((DropDownChoice<String>)
                                 tester.getComponentFromLastRenderedPage(
-                                        "dialog:dialog:content:form:userPanel:image"))
+                                        "dialog:dialog:modal:content:form:userPanel:image"))
                         .getChoices();
         assertEquals(4, choices.size());
         assertEquals("otherpicture.jpg", choices.get(1));
         assertEquals("somepicture.png", choices.get(2));
         assertEquals("vector.svg", choices.get(3));
 
-        FormTester formTester = tester.newFormTester("dialog:dialog:content:form");
+        FormTester formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.select("userPanel:image", 2);
 
-        tester.executeAjaxEvent("dialog:dialog:content:form:userPanel:image", "change");
-        tester.assertVisible("dialog:dialog:content:form:userPanel:display");
+        tester.executeAjaxEvent("dialog:dialog:modal:content:form:userPanel:image", "change");
+        tester.assertVisible("dialog:dialog:modal:content:form:userPanel:display");
 
         formTester.submit("submit");
 
@@ -520,8 +522,8 @@ public class StyleNewPageTest extends GeoServerWicketTestSupport {
                                 + "xmlns:xlink=\"http://www.w3.org/1999/xlink\">\\\\n"
                                 + "<OnlineResource xlink:type=\"simple\" xlink:href=\""
                                 + "(.*)\" />\\\\n"
-                                + "<Format>(.*)</Format>\\\\n"
-                                + "</ExternalGraphic>\\\\n'\\)");
+                                + "<Format>(.*)<..Format>\\\\n"
+                                + "<..ExternalGraphic>\\\\n'\\)");
         Matcher matcher = pattern.matcher(tester.getLastResponse().getDocument());
         assertTrue(matcher.find());
         assertEquals("somepicture.png", matcher.group(1));
@@ -529,7 +531,7 @@ public class StyleNewPageTest extends GeoServerWicketTestSupport {
 
         // test uploading
         tester.clickLink("styleForm:styleEditor:editorContainer:toolbar:custom-buttons:1");
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         org.apache.wicket.util.file.File file =
                 new org.apache.wicket.util.file.File(
                         getClass().getResource("GeoServer_75.png").getFile());
@@ -561,7 +563,7 @@ public class StyleNewPageTest extends GeoServerWicketTestSupport {
 
         // test uploading
         tester.clickLink("styleForm:styleEditor:editorContainer:toolbar:custom-buttons:1");
-        FormTester formTester = tester.newFormTester("dialog:dialog:content:form");
+        FormTester formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         org.apache.wicket.util.file.File file =
                 new org.apache.wicket.util.file.File(
                         dd.getStyles().get("');foo('.png").file().getPath());
@@ -597,24 +599,26 @@ public class StyleNewPageTest extends GeoServerWicketTestSupport {
                 "styleForm:context:panel:legendPanel:externalGraphicContainer:list:chooseImage",
                 "click");
 
-        tester.assertComponent("dialog:dialog:content:form:userPanel", ChooseImagePanel.class);
-        tester.assertComponent("dialog:dialog:content:form:userPanel:image", DropDownChoice.class);
-        tester.assertInvisible("dialog:dialog:content:form:userPanel:display");
+        tester.assertComponent(
+                "dialog:dialog:modal:content:form:userPanel", ChooseImagePanel.class);
+        tester.assertComponent(
+                "dialog:dialog:modal:content:form:userPanel:image", DropDownChoice.class);
+        tester.assertInvisible("dialog:dialog:modal:content:form:userPanel:display");
         @SuppressWarnings("unchecked")
         List<? extends String> choices =
                 ((DropDownChoice<String>)
                                 tester.getComponentFromLastRenderedPage(
-                                        "dialog:dialog:content:form:userPanel:image"))
+                                        "dialog:dialog:modal:content:form:userPanel:image"))
                         .getChoices();
         assertEquals(3, choices.size());
         assertEquals("otherpicture.jpg", choices.get(1));
         assertEquals("somepicture.png", choices.get(2));
 
-        FormTester formTester = tester.newFormTester("dialog:dialog:content:form");
+        FormTester formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         formTester.select("userPanel:image", 2);
 
-        tester.executeAjaxEvent("dialog:dialog:content:form:userPanel:image", "change");
-        tester.assertVisible("dialog:dialog:content:form:userPanel:display");
+        tester.executeAjaxEvent("dialog:dialog:modal:content:form:userPanel:image", "change");
+        tester.assertVisible("dialog:dialog:modal:content:form:userPanel:display");
 
         formTester.submit("submit");
 
@@ -626,7 +630,7 @@ public class StyleNewPageTest extends GeoServerWicketTestSupport {
         tester.executeAjaxEvent(
                 "styleForm:context:panel:legendPanel:externalGraphicContainer:list:chooseImage",
                 "click");
-        formTester = tester.newFormTester("dialog:dialog:content:form");
+        formTester = tester.newFormTester("dialog:dialog:modal:content:form");
         org.apache.wicket.util.file.File file =
                 new org.apache.wicket.util.file.File(
                         getClass().getResource("GeoServer_75.png").getFile());


### PR DESCRIPTION
All the modules that received a junit-jupiter dependency during the Wicket 9 upgrade are not running their tests anymore:

```
community/monitor-kafka/pom.xml:      <artifactId>junit-jupiter-api</artifactId>
community/security/keycloak/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/css/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/csw/web-csw/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/geofence/geofence-server/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/geofence/geofence/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/geopkg-output/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/grib/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/gwc-s3/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/importer/web/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/inspire/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/mapml/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/mbstyle/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/metadata/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/netcdf-out/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/netcdf/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/params-extractor/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/rat/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/wcs2_0-eo/web/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/web-resource/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/wmts-multi-dimensional/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/wps-download/pom.xml:      <artifactId>junit-jupiter</artifactId>
extension/wps/web-wps/pom.xml:      <artifactId>junit-jupiter</artifactId>
pom.xml:        <artifactId>junit-jupiter</artifactId>
rest/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/core/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/demo/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/gwc/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/rest/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/security/core/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/security/jdbc/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/security/ldap/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/wcs/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/wfs/pom.xml:      <artifactId>junit-jupiter</artifactId>
web/wms/pom.xml:      <artifactId>junit-jupiter</artifactId>
```

This draft PR tries to fix it, but it also shows many test failures that were not caught during the Wicket 9 upgrade (list collected running the build with -fn so that all modules are built despite test failures)

```
[ERROR]   LayerGroupEditPageTest.testLayerGroupLinkWithWorkspace:299 path: 'publishedinfo:tabs:panel:layers:popup:content:listContainer:items' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerGroupStyle:722 path: 'publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:1:itemProperties:0:component:link' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerGroupStyle2:775 path: 'publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:3:itemProperties:0:component:link' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerGroupStyleSelection:862 path: 'publishedinfo:tabs:panel:layerGroupStyles:listContainer:styleList:0:layerGroupStylePanel:layerGroupEntryPanel:popup:content:listContainer:items:2:itemProperties:0:component:link' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerLink:212 path: 'publishedinfo:tabs:panel:layers:popup:content:listContainer:items' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testLayerLinkWithWorkspace:265 path: 'publishedinfo:tabs:panel:layers:popup:content:listContainer:items' does not exist for page: LayerGroupEditPage
[ERROR]   LayerGroupEditPageTest.testStyleGroupLink:238 path: 'publishedinfo:tabs:panel:layers:popup:content:listContainer:items' does not exist for page: LayerGroupEditPage
[ERROR]   ResourceConfigurationPageTest.testConsistentUpdateWMTSBbox:834 path: 'publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link' does not exist for page: ResourceConfigurationPage
[ERROR]   ResourceConfigurationPageTest.testWFSDataStoreResource:467 path: 'publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link' does not exist for page: ResourceConfigurationPage
[ERROR]   ResourceConfigurationPageTest.testWMTSOtherCRS:584 path: 'publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items:1:itemProperties:0:component:link' does not exist for page: ResourceConfigurationPage
[ERROR]   ResourceConfigurationPageTest.testWMTSOtherCRSUrnFormat:622 path: 'publishedinfo:tabs:panel:theList:0:content:referencingForm:nativeSRS:popup:content:table:listContainer:items' does not exist for page: ResourceConfigurationPage
[ERROR]   CRSPanelTest.testPlanetaryList:245 Unable to set value. Couldn't find component with name: crs:popup:content:table:filterForm:filter ==> expected: not <null>
[ERROR]   CRSPanelTest.testPlanetaryPopupWindow:227 path: 'form:crs:popup:content:wkt' does not exist for page: CRSPanelTestPage
[ERROR]   CRSPanelTest.testPopupWindow:69 path: 'form:crs:popup:content:wkt' does not exist for page: CRSPanelTestPage
[ERROR]   GeoServerAboutPageTest.testHideSensitiveInfo:40 » WicketRuntime The component(...
[ERROR]   GeoServerAboutPageTest.testLoginFormAction:21 » WicketRuntime The component(s)...
[ERROR]   PageResourceBrowserTest.testCopyPaste:166 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testCutPaste:107 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testDelete:228 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testEdit:392 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testNew:353 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testRename:251 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   PageResourceBrowserTest.testUpload:315 path: 'dialog:dialog:content:form:userPanel' does not exist for page: PageResourceBrowser
[ERROR]   XMLRoleConfigDetailsPanelTest.testAddModifyRemove:129->setFileName:66 Unable to set value. Couldn't find component with name: panel:content:fileName ==> expected: not <null>
[ERROR]   URLChecksPageTest.testDeleteRule:103 path: 'dialog:dialog:content:form:submit' does not exist for page: URLChecksPage
[ERROR]   XMLUserGroupConfigDetailsPanelTest.testAddModify:130->setFileName:77 Unable to set value. Couldn't find component with name: panel:content:fileName ==> expected: not <null>
[ERROR]   EditUserPageTest.testFill:39->doTestFill:79->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   EditUserPageTest.testReadOnlyUserGroupService:116->doTestReadOnlyUserGroupService:141->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   NewUserPageTest.testFill:50->doTestFill:75->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   NewUserPageTest.testFill2:158->doTestFill2:177->AbstractUserPageTest.assignGroup:86 » NullPointer
[ERROR]   NewUserPageTest.testFill3:111->doTestFill3:129->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   JDBCEditUserPageTest.testFill:23->EditUserPageTest.doTestFill:79->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   JDBCEditUserPageTest.testReadOnlyUserGroupService:29->EditUserPageTest.doTestReadOnlyUserGroupService:141->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   JDBCNewUserPageTest.testFill:23->NewUserPageTest.doTestFill:75->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   JDBCNewUserPageTest.testFill2:35->NewUserPageTest.doTestFill2:177->AbstractUserPageTest.assignGroup:86 » NullPointer
[ERROR]   JDBCNewUserPageTest.testFill3:29->NewUserPageTest.doTestFill3:129->AbstractUserPageTest.assignRole:77 » NullPointer
[ERROR]   BulkOperationsPageTest.testClearAll:84 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataBulkOperationsPage
[ERROR]   BulkOperationsPageTest.testFixAll:45 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataBulkOperationsPage
[ERROR]   BulkOperationsPageTest.testImport:60 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataBulkOperationsPage
[ERROR]   BulkOperationsPageTest.testNativeToCustom:75 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataBulkOperationsPage
[ERROR]   LayerMetadataTabTest.testGenerateFeatureCatalogueAndDomain:717 path: 'publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items:13:itemProperties:1:component:attributesTablePanel:listContainer:items:2:itemProperties:1:component:dialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testImportFromGeonetwork:650 path: 'publishedinfo:tabs:panel:geonetworkPanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testLinkAndUnlinkDeleteRowTemplatesBug:479 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testLinkRowTemplatesBug:581 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testLinkWithSimpleAndListTemplates:301 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testTemplatesRemainInPriorityOrder:604 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   LayerMetadataTabTest.testUnlinkFromSimpleAndListTemplates:405 path: 'publishedinfo:tabs:panel:importTemplatePanel:importDialog:dialog:content:form:submit' does not exist for page: ResourceConfigurationPage
[ERROR]   TemplatesPageTest.testDelete:145 path: 'dialog:dialog:content:form:userPanel' does not exist for page: MetadataTemplatesPage
[ERROR]   MapPreviewPageTest.testMaxNumberOfFeaturesForPreview:141->assertMaxFeaturesInData:189
[ERROR]   MapPreviewPageTest.testNameURLEncoding:279 
[ERROR]   StyleEditPageTest.testInsertImage:267 path: 'dialog:dialog:content:form:userPanel' does not exist for page: StyleEditPage
[ERROR]   StyleEditPageTest.testInsertImageSLD11:366 path: 'dialog:dialog:content:form:userPanel' does not exist for page: StyleEditPage
[ERROR]   StyleEditPageTest.testLayerAttributesTabWMS:459 path: 'styleForm:popup:content:layer.table' does not exist for page: StyleEditPage
[ERROR]   StyleEditPageTest.testLayerAttributesUnreachableLayer:443 path: 'styleForm:popup:content:layer.table' does not exist for page: StyleEditPage
[ERROR]   StyleNewPageTest.testInsertImage:493 path: 'dialog:dialog:content:form:userPanel' does not exist for page: StyleNewPage
[ERROR]   StyleNewPageTest.testInsertImageEscaped:564 path: 'dialog:dialog:content:form' does not exist for page: StyleNewPage
[ERROR]   StyleNewPageTest.testLegendChooseImage:600 path: 'dialog:dialog:content:form:userPanel' does not exist for page: StyleNewPage
[ERROR]   ProcessStatusPageTest.test:98 path: 'dialog:dialog:content:form:submit' does not exist for page: ProcessStatusPage
[ERROR]   ImportTaskTableTest.testTwoCRSSetByFindThenApply:66 path: 'taskTable:listContainer:items:1:itemProperties:2:component:form:crs:popup:content:table:listContainer:items:1:itemProperties:0:component:link' does not exist for page: StartComponentInPage
[ERROR]   CachedLayersPageTest.testGWCClean:223 path: 'dialog:dialog:content:form:submit' does not exist for page: CachedLayersPage
```


# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->