### PR TITLE
[GEOS-11563] Allow configuring a DGGS resolution offset on a layer basis

### DIFF
--- a/src/community/ogcapi/dggs/dggs-core/src/test/java/org/geotools/dggs/gstore/DGGSResolutionCalculatorTest.java
+++ b/src/community/ogcapi/dggs/dggs-core/src/test/java/org/geotools/dggs/gstore/DGGSResolutionCalculatorTest.java
@@ -1,0 +1,109 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This file is hereby placed into the Public Domain. This means anyone is
+ *    free to do whatever they wish with this file. Use it well and enjoy!
+ */
+package org.geotools.dggs.gstore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.geotools.api.data.Query;
+import org.geotools.dggs.DGGSInstance;
+import org.geotools.dggs.h3.H3DGGSFactory;
+import org.geotools.filter.function.EnvFunction;
+import org.geotools.util.NumberRange;
+import org.geotools.util.factory.Hints;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DGGSResolutionCalculatorTest {
+
+    private DGGSInstance dggsInstance;
+    private DGGSResolutionCalculator calculator;
+
+    @Before
+    public void setUp() throws IOException {
+        dggsInstance = new H3DGGSFactory().createInstance(new HashMap<>());
+        calculator = new DGGSResolutionCalculator(dggsInstance);
+    }
+
+    @Test
+    public void testConstructor() {
+        assertNotNull(calculator);
+        assertEquals(16, calculator.levelThresholds.length);
+    }
+
+    @Test
+    public void testIsValid() {
+        for (int level = 0; level < 16; level++) {
+            assertTrue(calculator.isValid(level));
+        }
+        assertFalse(calculator.isValid(16));
+    }
+
+    @Test
+    public void testGetValidResolutions() {
+        NumberRange<Integer> range = calculator.getValidResolutions();
+        assertEquals(0, (int) range.getMinimum());
+        assertEquals(15, (int) range.getMaximum());
+    }
+
+    @Test
+    public void testGetTargetResolutionDistance() {
+        Query query = new Query("testLayer");
+        Hints hints = new Hints();
+        hints.put(Hints.GEOMETRY_DISTANCE, 10d); // 10 degrees
+        query.setHints(hints);
+
+        int resolution = calculator.getTargetResolution(query, 1);
+        assertEquals(0, resolution);
+    }
+
+    @Test
+    public void testGetTargetResolutionDistanceOffset() {
+        Query query = new Query("testLayer");
+        Hints hints = new Hints();
+        hints.put(Hints.GEOMETRY_DISTANCE, 10d); // 10 degrees
+        Hints.ConfigurationMetadataKey offsetKey =
+                Hints.ConfigurationMetadataKey.get(DGGSResolutionCalculator.CONFIGURED_OFFSET_KEY);
+        hints.put(offsetKey, 1);
+        query.setHints(hints);
+
+        int resolution = calculator.getTargetResolution(query, 1);
+        assertEquals(1, resolution);
+    }
+
+    @Test
+    public void testGetTargetResolutionExplicit() {
+        Query query = new Query("testLayer");
+        Hints hints = new Hints();
+        hints.put(Hints.VIRTUAL_TABLE_PARAMETERS, Map.of(DGGSStore.VP_RESOLUTION, 5));
+        query.setHints(hints);
+
+        int resolution = calculator.getTargetResolution(query, 1);
+        assertEquals(5, resolution);
+    }
+
+    @Test
+    public void testGetTargetResolutionWMSScale() {
+        EnvFunction.setLocalValues(
+                Map.of(DGGSResolutionCalculator.WMS_SCALE_DENOMINATOR, 10_000_000));
+        try {
+            Query query = new Query("testLayer");
+            int resolution = calculator.getTargetResolution(query, 1);
+            assertEquals(2, resolution);
+        } finally {
+            EnvFunction.clearLocalValues();
+        }
+    }
+}

--- a/src/community/ogcapi/dggs/web-dggs/pom.xml
+++ b/src/community/ogcapi/dggs/web-dggs/pom.xml
@@ -59,6 +59,18 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-core</artifactId>
+      <version>${gs.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.html
+++ b/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.html
@@ -1,0 +1,20 @@
+<html xmlns:wicket="http://wicket.apache.org/">
+<head></head>
+<body>
+<form name="theForm">
+  <wicket:panel>
+
+    <fieldset>
+      <legend><span><wicket:message key="dggsSettings">DGGS Settings</wicket:message></span></legend>
+      <ul>
+        <li>
+          <label for="resolutionOffset"><wicket:message key="resolutionOffset">resOffset</wicket:message></label>
+          <input id="resolutionOffset" class="text" type="text" wicket:id="resolutionOffset"></input>
+        </li>
+      </ul>
+    </fieldset>
+
+  </wicket:panel>
+</form>
+</body>
+</html>

--- a/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.java
+++ b/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.java
@@ -1,0 +1,32 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.publish.dggs;
+
+import static org.geotools.dggs.gstore.DGGSResolutionCalculator.CONFIGURED_OFFSET_KEY;
+
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.PropertyModel;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.MetadataMap;
+import org.geoserver.web.publish.PublishedConfigurationPanel;
+import org.geoserver.web.util.MapModel;
+
+/** Configures a layer DGGS related attributes */
+public class DGGSConfigPanel extends PublishedConfigurationPanel<LayerInfo> {
+
+    private static final long serialVersionUID = 6469105227923320272L;
+
+    public DGGSConfigPanel(String id, IModel<LayerInfo> model) {
+        super(id, model);
+
+        PropertyModel<MetadataMap> metadata = new PropertyModel<>(model, "resource.metadata");
+        add(
+                new TextField<>(
+                        "resolutionOffset",
+                        new MapModel<>(metadata, CONFIGURED_OFFSET_KEY),
+                        Integer.class));
+    }
+}

--- a/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigurationPageInfo.java
+++ b/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigurationPageInfo.java
@@ -1,0 +1,38 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.publish.dggs;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.web.publish.LayerConfigurationPanelInfo;
+import org.geotools.dggs.gstore.DGGSStore;
+import org.geotools.util.logging.Logging;
+
+/**
+ * Configuration page for DGGS layers, makes sure the layer is a feature type and the store is a
+ * DGGS store.
+ */
+public class DGGSConfigurationPageInfo extends LayerConfigurationPanelInfo {
+    private static final Logger LOGGER = Logging.getLogger(DGGSConfigurationPageInfo.class);
+
+    @Override
+    public boolean canHandle(PublishedInfo published) {
+        if (!(published instanceof LayerInfo)) return false;
+        LayerInfo li = (LayerInfo) published;
+        if (!(li.getResource() instanceof FeatureTypeInfo)) return false;
+        FeatureTypeInfo fti = (FeatureTypeInfo) li.getResource();
+        try {
+            return fti.getStore().getDataStore(null) instanceof DGGSStore;
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to connect to store", e);
+        }
+
+        return false;
+    }
+}

--- a/src/community/ogcapi/dggs/web-dggs/src/main/resources/GeoServerApplication.properties
+++ b/src/community/ogcapi/dggs/web-dggs/src/main/resources/GeoServerApplication.properties
@@ -1,1 +1,3 @@
 DGGSGeometryStoreEditPanel.DGGSFactoryId=DGGS factory identifier
+DGGSConfigPanel.dggsSettings=DGGS Layer settings
+DGGSConfigPanel.resolutionOffset=DGGS zone resolution offset

--- a/src/community/ogcapi/dggs/web-dggs/src/main/resources/applicationContext.xml
+++ b/src/community/ogcapi/dggs/web-dggs/src/main/resources/applicationContext.xml
@@ -22,4 +22,10 @@
 
     <bean id="dggsServiceDescriptor" class="org.geoserver.web.data.store.dggs.DGGSServiceDescriptionProvider">
     </bean>
+
+    <bean id="dggsLayerConfig" class="org.geoserver.web.publish.dggs.DGGSConfigurationPageInfo">
+        <property name="id" value="dggsLayerConfig"/>
+        <property name="titleKey" value="publish.layer.config.dggs"/>
+        <property name="componentClass" value="org.geoserver.web.publish.dggs.DGGSConfigPanel"/>
+    </bean>
 </beans>


### PR DESCRIPTION
[![GEOS-11563](https://badgen.net/badge/JIRA/GEOS-11563/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11563) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->