### PR TITLE
Add missing JARs to assembly.xml file for cog-s3 plugin

### DIFF
--- a/src/community/cog/cog-s3/src/assembly/assembly.xml
+++ b/src/community/cog/cog-s3/src/assembly/assembly.xml
@@ -27,6 +27,7 @@
         <include>imageio-ext-*rangereader*.jar</include>
         <include>jackson-datatype*.jar</include>
         <include>jackson-module*.jar</include>
+        <include>json-utils-2.*.jar</include>
         <include>kotlin-stdlib*.jar</include>
         <include>*netty*.jar</include>
         <include>okhttp*.jar</include>
@@ -35,6 +36,8 @@
         <include>protocol-core-2.*.jar</include>
         <include>reactive-streams*.jar</include>
         <include>regions-2.*.jar</include>
+        <include>retries-2.*.jar</include>
+        <include>retries-spi-2.*.jar</include>
         <include>rxjava*.jar</include>
         <include>s3-2.*.jar</include>
         <include>sdk-core-2.*.jar</include>
@@ -45,6 +48,7 @@
         <include>http-auth-*2*.jar</include>
         <include>identity-spi*.jar</include>
         <include>metrics-spi-2.*.jar</include>
+        <include>third-party-jackson-core-2.*.jar</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
The dependency `AWS SDK` of the `cog-s3` plugin requires additional libraries after it was upgraded from version 2.24.13 to 2.27.23.

This fixes the issue discussed in https://discourse.osgeo.org/t/missing-jars-for-cog-s3-plugin-in-assembly-xml/110332

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).