### PR TITLE
[GEOS-11565] Allow configuring the minimum and maximum resolution for a layer

### DIFF
--- a/src/community/ogcapi/dggs/dggs-core/src/main/java/org/geotools/dggs/gstore/DGGSResolutionCalculator.java
+++ b/src/community/ogcapi/dggs/dggs-core/src/main/java/org/geotools/dggs/gstore/DGGSResolutionCalculator.java
@@ -16,6 +16,9 @@
  */
 package org.geotools.dggs.gstore;
 
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static org.geotools.dggs.gstore.DGGSStore.VP_RESOLUTION;
 import static org.geotools.dggs.gstore.DGGSStore.VP_RESOLUTION_DELTA;
 
@@ -44,7 +47,23 @@ public class DGGSResolutionCalculator {
 
     private static final double DISTANCE_SCALE_FACTOR = 0.0254 / (25.4 / 0.28);
 
+    /** The key used to store the resolution offset in the layer metadata */
     public static final String CONFIGURED_OFFSET_KEY = "dggs.resOffset";
+
+    static final Hints.ConfigurationMetadataKey OFFSET_HINTS_KEY =
+            Hints.ConfigurationMetadataKey.get(CONFIGURED_OFFSET_KEY);
+
+    /** The key used to store the minimum resolution in the layer metadata */
+    public static final String CONFIGURED_MINRES_KEY = "dggs.minResolution";
+
+    static final Hints.ConfigurationMetadataKey MINRES_HINTS_KEY =
+            Hints.ConfigurationMetadataKey.get(CONFIGURED_MINRES_KEY);
+
+    /** The key used to store the maximum resolution in the layer metadata */
+    public static final String CONFIGURED_MAXRES_KEY = "dggs.maxResolution";
+
+    static final Hints.ConfigurationMetadataKey MAXRES_HINTS_KEY =
+            Hints.ConfigurationMetadataKey.get(CONFIGURED_MAXRES_KEY);
 
     double[] levelThresholds;
 
@@ -98,17 +117,30 @@ public class DGGSResolutionCalculator {
                         .map(n -> safeConvert(n, Integer.class));
         // if not available through the request, try the values coming from the configuration
         if (!resolutionDelta.isPresent()) {
-            Hints.ConfigurationMetadataKey offsetKey =
-                    Hints.ConfigurationMetadataKey.get(CONFIGURED_OFFSET_KEY);
-            resolutionDelta =
-                    Optional.ofNullable(hints.get(offsetKey))
-                            .map(n -> safeConvert(n, Integer.class));
+            resolutionDelta = getIntegerHint(hints, OFFSET_HINTS_KEY);
         }
         int resOffset = resolutionDelta.orElse(0);
 
         // compute resolution and eventually apply delta
-        return distance.map(n -> getResolutionFromThresholds(n.doubleValue()) + resOffset)
-                .orElse(defaultResolution);
+        int resolution =
+                distance.map(n -> getResolutionFromThresholds(n.doubleValue()) + resOffset)
+                        .orElse(defaultResolution);
+
+        // see if there is a min/max resolution set, if so, use it (don't limit to 0 on purpose,
+        // if a resolution has been forced to an invalid value, it should not return zones)
+        resolution = max(getIntegerHint(hints, MINRES_HINTS_KEY).orElse(-MAX_VALUE), resolution);
+        resolution = min(getIntegerHint(hints, MAXRES_HINTS_KEY).orElse(MAX_VALUE), resolution);
+
+        return resolution;
+    }
+
+    /**
+     * Given the hints and a key, returns the integer value associated with the key, as an {@link
+     * Optional}.
+     */
+    private Optional<Integer> getIntegerHint(Hints hints, Object key) {
+        return Optional.ofNullable((Integer) hints.get(key))
+                .map(n -> safeConvert(n, Integer.class));
     }
 
     /**

--- a/src/community/ogcapi/dggs/dggs-core/src/test/java/org/geotools/dggs/gstore/DGGSResolutionCalculatorTest.java
+++ b/src/community/ogcapi/dggs/dggs-core/src/test/java/org/geotools/dggs/gstore/DGGSResolutionCalculatorTest.java
@@ -59,10 +59,10 @@ public class DGGSResolutionCalculatorTest {
     }
 
     @Test
-    public void testGetTargetResolutionDistance() {
+    public void testGetTargetResolutionDistanceLarge() {
         Query query = new Query("testLayer");
         Hints hints = new Hints();
-        hints.put(Hints.GEOMETRY_DISTANCE, 10d); // 10 degrees
+        hints.put(Hints.GEOMETRY_DISTANCE, 10d); // degrees
         query.setHints(hints);
 
         int resolution = calculator.getTargetResolution(query, 1);
@@ -70,13 +70,46 @@ public class DGGSResolutionCalculatorTest {
     }
 
     @Test
+    public void testGetResolutionMin() {
+        Query query = new Query("testLayer");
+        Hints hints = new Hints();
+        hints.put(Hints.GEOMETRY_DISTANCE, 10d); // 10 degrees
+        hints.put(DGGSResolutionCalculator.MINRES_HINTS_KEY, 5); // min resolution is 5
+        query.setHints(hints);
+
+        int resolution = calculator.getTargetResolution(query, 1);
+        assertEquals(5, resolution);
+    }
+
+    @Test
+    public void testGetTargetResolutionDistanceSmall() {
+        Query query = new Query("testLayer");
+        Hints hints = new Hints();
+        hints.put(Hints.GEOMETRY_DISTANCE, 0.001d); // degrees
+        query.setHints(hints);
+
+        int resolution = calculator.getTargetResolution(query, 1);
+        assertEquals(5, resolution);
+    }
+
+    @Test
+    public void testGetResolutionMax() {
+        Query query = new Query("testLayer");
+        Hints hints = new Hints();
+        hints.put(Hints.GEOMETRY_DISTANCE, 0.001); // in degrees
+        hints.put(DGGSResolutionCalculator.MAXRES_HINTS_KEY, 2);
+        query.setHints(hints);
+
+        int resolution = calculator.getTargetResolution(query, 1);
+        assertEquals(2, resolution);
+    }
+
+    @Test
     public void testGetTargetResolutionDistanceOffset() {
         Query query = new Query("testLayer");
         Hints hints = new Hints();
         hints.put(Hints.GEOMETRY_DISTANCE, 10d); // 10 degrees
-        Hints.ConfigurationMetadataKey offsetKey =
-                Hints.ConfigurationMetadataKey.get(DGGSResolutionCalculator.CONFIGURED_OFFSET_KEY);
-        hints.put(offsetKey, 1);
+        hints.put(DGGSResolutionCalculator.OFFSET_HINTS_KEY, 1);
         query.setHints(hints);
 
         int resolution = calculator.getTargetResolution(query, 1);

--- a/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.html
+++ b/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.html
@@ -8,6 +8,14 @@
       <legend><span><wicket:message key="dggsSettings">DGGS Settings</wicket:message></span></legend>
       <ul>
         <li>
+          <label for="minResolution"><wicket:message key="minResolution">minResolution</wicket:message></label>
+          <input id="minResolution" class="text" type="text" wicket:id="minResolution"></input>
+        </li>
+        <li>
+          <label for="maxResolution"><wicket:message key="minResolution">maxResolution</wicket:message></label>
+          <input id="maxResolution" class="text" type="text" wicket:id="maxResolution"></input>
+        </li>
+        <li>
           <label for="resolutionOffset"><wicket:message key="resolutionOffset">resOffset</wicket:message></label>
           <input id="resolutionOffset" class="text" type="text" wicket:id="resolutionOffset"></input>
         </li>

--- a/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.java
+++ b/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.java
@@ -4,29 +4,118 @@
  */
 package org.geoserver.web.publish.dggs;
 
+import static org.geotools.dggs.gstore.DGGSResolutionCalculator.CONFIGURED_MAXRES_KEY;
+import static org.geotools.dggs.gstore.DGGSResolutionCalculator.CONFIGURED_MINRES_KEY;
 import static org.geotools.dggs.gstore.DGGSResolutionCalculator.CONFIGURED_OFFSET_KEY;
 
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.form.validation.IFormValidator;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.validation.ValidationError;
+import org.apache.wicket.validation.validator.RangeValidator;
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.MetadataMap;
 import org.geoserver.web.publish.PublishedConfigurationPanel;
 import org.geoserver.web.util.MapModel;
+import org.geoserver.web.wicket.ParamResourceModel;
+import org.geotools.api.data.FeatureSource;
+import org.geotools.dggs.DGGSInstance;
+import org.geotools.dggs.gstore.DGGSFeatureSource;
+import org.geotools.util.decorate.Wrapper;
 
 /** Configures a layer DGGS related attributes */
 public class DGGSConfigPanel extends PublishedConfigurationPanel<LayerInfo> {
 
     private static final long serialVersionUID = 6469105227923320272L;
+    private final TextField<Integer> minResolution;
+    private final TextField<Integer> maxResolution;
 
-    public DGGSConfigPanel(String id, IModel<LayerInfo> model) {
+    public DGGSConfigPanel(String id, IModel<LayerInfo> model) throws IOException {
         super(id, model);
 
+        // adding the resolution offset editor
         PropertyModel<MetadataMap> metadata = new PropertyModel<>(model, "resource.metadata");
-        add(
-                new TextField<>(
-                        "resolutionOffset",
-                        new MapModel<>(metadata, CONFIGURED_OFFSET_KEY),
-                        Integer.class));
+        add(metadataIntegerEditor("resolutionOffset", metadata, CONFIGURED_OFFSET_KEY));
+
+        // Adding the min and max resolution editors
+        @SuppressWarnings("PMD.CloseResource") // owned by the store
+        DGGSInstance dggs = getDGGS(model);
+        int[] resolutions = dggs.getResolutions();
+        int minDggsRes = Arrays.stream(resolutions).min().orElse(0);
+        int maxDggsRes = Arrays.stream(resolutions).max().orElse(Integer.MAX_VALUE);
+
+        minResolution = metadataIntegerEditor("minResolution", metadata, CONFIGURED_MINRES_KEY);
+        add(minResolution);
+        minResolution.add(RangeValidator.minimum(minDggsRes));
+        maxResolution = metadataIntegerEditor("maxResolution", metadata, CONFIGURED_MAXRES_KEY);
+        add(maxResolution);
+        maxResolution.add(RangeValidator.maximum(maxDggsRes));
+    }
+
+    /**
+     * Returns a {@link TextField} for editing an integer value stored in the metadata map
+     *
+     * @param fieldName
+     * @param metadata
+     * @param metadataMapKey
+     */
+    private static TextField<Integer> metadataIntegerEditor(
+            String fieldName, PropertyModel<MetadataMap> metadata, String metadataMapKey) {
+        return new TextField<>(fieldName, new MapModel<>(metadata, metadataMapKey), Integer.class);
+    }
+
+    @Override
+    /**
+     * Check the min/max values are consistent, need the panel to included in the hierarchy to find
+     * the /form
+     */
+    protected void onInitialize() {
+        super.onInitialize();
+
+        minResolution.getForm().add(new MinMaxValidator(minResolution, maxResolution));
+    }
+
+    private static DGGSInstance getDGGS(IModel<LayerInfo> model) throws IOException {
+        FeatureTypeInfo fti = (FeatureTypeInfo) model.getObject().getResource();
+        FeatureSource fs = fti.getFeatureSource(null, null);
+        if (fs instanceof Wrapper) {
+            fs = ((Wrapper) fs).unwrap(DGGSFeatureSource.class);
+        }
+        return ((DGGSFeatureSource) fs).getDGGS();
+    }
+
+    public class MinMaxValidator implements IFormValidator {
+
+        private final TextField<Integer> minField;
+        private final TextField<Integer> maxField;
+
+        public MinMaxValidator(TextField<Integer> minField, TextField<Integer> maxField) {
+            this.minField = minField;
+            this.maxField = maxField;
+        }
+
+        @Override
+        public FormComponent<?>[] getDependentFormComponents() {
+            return new FormComponent<?>[] {minField, maxField};
+        }
+
+        @Override
+        public void validate(Form<?> form) {
+            Integer minValue = minField.getConvertedInput();
+            Integer maxValue = maxField.getConvertedInput();
+
+            if (minValue != null && maxValue != null && minValue > maxValue) {
+                ValidationError error = new ValidationError();
+                error.setMessage(
+                        new ParamResourceModel("minMaxError", DGGSConfigPanel.this).getObject());
+                minField.error(error);
+            }
+        }
     }
 }

--- a/src/community/ogcapi/dggs/web-dggs/src/main/resources/GeoServerApplication.properties
+++ b/src/community/ogcapi/dggs/web-dggs/src/main/resources/GeoServerApplication.properties
@@ -1,3 +1,6 @@
 DGGSGeometryStoreEditPanel.DGGSFactoryId=DGGS factory identifier
 DGGSConfigPanel.dggsSettings=DGGS Layer settings
 DGGSConfigPanel.resolutionOffset=DGGS zone resolution offset
+DGGSConfigPanel.minResolution=Minimum resolution in layer
+DGGSConfigPanel.maxResolution=Maximum resolution in layer
+DGGSConfigPanel.minMaxError=DGGS minimum layer resolution but be less or equal than the maximum resolution.

--- a/src/main/src/main/java/org/vfny/geoserver/global/GeoServerFeatureSource.java
+++ b/src/main/src/main/java/org/vfny/geoserver/global/GeoServerFeatureSource.java
@@ -54,6 +54,7 @@ import org.geotools.filter.spatial.ReprojectingFilterVisitor;
 import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
+import org.geotools.util.decorate.AbstractDecorator;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.factory.Hints.ConfigurationMetadataKey;
 
@@ -69,7 +70,8 @@ import org.geotools.util.factory.Hints.ConfigurationMetadataKey;
  * @author Gabriel Roldan
  * @version $Id$
  */
-public class GeoServerFeatureSource implements SimpleFeatureSource {
+public class GeoServerFeatureSource extends AbstractDecorator<SimpleFeatureSource>
+        implements SimpleFeatureSource {
     /** Shared package logger */
     private static final Logger LOGGER =
             org.geotools.util.logging.Logging.getLogger("org.vfny.geoserver.global");
@@ -143,6 +145,7 @@ public class GeoServerFeatureSource implements SimpleFeatureSource {
      */
     GeoServerFeatureSource(
             FeatureSource<SimpleFeatureType, SimpleFeature> source, Settings settings) {
+        super(DataUtilities.simple(source));
         this.source = DataUtilities.simple(source);
         this.schema = settings.schema;
         this.definitionQuery = settings.definitionQuery;


### PR DESCRIPTION
[![GEOS-11565](https://badgen.net/badge/JIRA/GEOS-11565/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11565) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->