### PR TITLE
Fixed some Wicket CSP violations

### DIFF
--- a/src/extension/monitor/core/src/main/java/org/geoserver/monitor/web/ActivityChartBasePanel.html
+++ b/src/extension/monitor/core/src/main/java/org/geoserver/monitor/web/ActivityChartBasePanel.html
@@ -1,22 +1,14 @@
 <html xmlns:wicket="http://wicket.apache.org/">
 <head>
 <title><wicket:message key="title">Activity</wicket:message></title>
-<wicket:head>
-  <style type="text/css">
-   form label {
-      display: inline;
-   }
-  </style>
-</wicket:head>
-
 </head>
 <body>
 <wicket:panel>
      <form wicket:id="form" class="pb-1 ps-5">
-        <label for="from">From</label>
+        <label for="from" class="inline">From</label>
         <input type="text" wicket:id="from" id="start" class="pe-4 d-inline"></input>
         
-        <label for="to">To</label>
+        <label for="to" class="inline">To</label>
         <input type="text" wicket:id="to" id="end" class="d-inline"></input>
         
         <a href="#" wicket:id="refresh" class="refresh-link">Refresh</a>

--- a/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSAccessRulePage.html
+++ b/src/extension/wps/web-wps/src/main/java/org/geoserver/wps/web/WPSAccessRulePage.html
@@ -3,23 +3,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:wicket="http://wicket.apache.org/">
 <wicket:head>
-    <style type="text/css">
-       #processAccessMode {
-         display:block;
-         padding-top: 0.5em;
-       }
-       #processAccessMode input {
-          display: block;
-          float: left;
-          clear:left;
-          padding-top:0.5em;
-          margin-bottom: 0.5em;
-       }
-       #processAccessMode label {
-          clear:right;
-          margin-bottom: 0.5em;
-       }
-     </style>
      <title><wicket:message key="title">WPS security</wicket:message></title>
 </wicket:head>
 <body>

--- a/src/main/src/main/java/org/geoserver/GeoServerNodeData.java
+++ b/src/main/src/main/java/org/geoserver/GeoServerNodeData.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -37,15 +38,12 @@ public class GeoServerNodeData {
     /** System property, environment variable, etc... used to specify the node id. */
     public static final String GEOSERVER_NODE_OPTS = "GEOSERVER_NODE_OPTS";
 
-    static final String DEFAULT_NODE_ID_TEMPLATE =
-            "position:absolute; top:12px; left:12px; right:28px; width:auto; background:$background; padding: 1px; border: 1px solid #0076a1; color:$color; font-weight:bold";
-
     static final Logger LOGGER = Logging.getLogger(GeoServerNodeData.class);
 
     final String nodeId;
-    final String nodeIdStyle;
+    final Map<String, String> nodeIdStyle;
 
-    public GeoServerNodeData(String nodeId, String nodeIdStyle) {
+    public GeoServerNodeData(String nodeId, Map<String, String> nodeIdStyle) {
         this.nodeId = nodeId;
         this.nodeIdStyle = nodeIdStyle;
     }
@@ -83,12 +81,9 @@ public class GeoServerNodeData {
     /** Creates a node data from a format-options style string. */
     public static GeoServerNodeData createFromString(String nodeOpts) {
         String nodeId = null;
-        String nodeIdStyle = null;
+        Map<String, String> nodeIdStyle = new LinkedHashMap<>();
 
-        if (nodeOpts == null) {
-            nodeId = null;
-            nodeIdStyle = null;
-        } else {
+        if (nodeOpts != null) {
             try {
                 Map<String, String> options = parseProperties(nodeOpts);
                 String id = options.get("id");
@@ -106,15 +101,13 @@ public class GeoServerNodeData {
 
                 nodeId = id;
                 String bgcolor = options.get("background");
-                if (bgcolor == null) {
-                    bgcolor = "#dadada";
+                if (bgcolor != null) {
+                    nodeIdStyle.put("backgroundColor", bgcolor);
                 }
-                String style = DEFAULT_NODE_ID_TEMPLATE.replace("$background", bgcolor);
                 String color = options.get("color");
-                if (color == null) {
-                    color = "#0076a1";
+                if (color != null) {
+                    nodeIdStyle.put("color", color);
                 }
-                nodeIdStyle = style.replace("$color", color);
             } catch (Exception e) {
                 LOGGER.log(
                         Level.SEVERE,
@@ -122,7 +115,7 @@ public class GeoServerNodeData {
                                 + nodeOpts
                                 + " instead. Disabling NODE_ID GUI element");
                 nodeId = null;
-                nodeIdStyle = null;
+                nodeIdStyle.clear();
             }
         }
 
@@ -214,7 +207,7 @@ public class GeoServerNodeData {
     }
 
     /** The node id styling. */
-    public String getIdStyle() {
+    public Map<String, String> getIdStyle() {
         return nodeIdStyle;
     }
 }

--- a/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
+++ b/src/web/core/src/main/java/org/geoserver/web/css/geoserver.css
@@ -240,63 +240,63 @@ Utility Classes
   width: 95% !important;
 }
 
-w-1pct {
+.w-1pct {
     width: 1%;
 }
 
-w-90pct {
+.w-90pct {
     width: 90%;
 }
 
-w-99pct {
+.w-99pct {
     width: 99%;
 }
 
-w-100pct {
+.w-100pct {
     width: 100%;
 }
 
-w-30px {
+.w-30px {
     width: 30px;
 }
 
-w-50px {
+.w-50px {
     width: 50px;
 }
 
-w-80px {
+.w-80px {
     width: 80px;
 }
 
-w-120px {
+.w-120px {
     width: 120px;
 }
 
-w-200px {
+.w-200px {
     width: 200px;
 }
 
-w-240px {
+.w-240px {
     width: 240px;
 }
 
-w-260px {
+.w-260px {
     width: 260px;
 }
 
-w-300px {
+.w-300px {
     width: 300px;
 }
 
-w-600px {
+.w-600px {
     width: 600px;
 }
 
-min-w-200px {
+.min-w-200px {
     min-width: 200px;
 }
 
-max-w-100pct {
+.max-w-100pct {
     max-width: 100%;
 }
 
@@ -326,29 +326,29 @@ max-w-100pct {
   height: 100em !important;
 }
 
-h-50px {
+.h-50px {
     height: 50px;
 }
 
-h-100px {
+.h-100px {
     height: 100px;
 }
 
-h-100pct {
+.h-100pct {
     height: 100%;
 }
 
 /* more migration utils */
 
-margin-left-5pct {
+.margin-left-5pct {
     margin-left: 5%;
 }
 
-visibility-hidden {
+.visibility-hidden {
     visibility: hidden;
 }
 
-visibility-visible {
+.visibility-visible {
     visibility: visible;
 }
 
@@ -1740,59 +1740,98 @@ li.select2-results__option {
    margin: 0px 0.2em;
 }
 
-traceback {
+.traceback {
     padding-top: 16px;
     white-space: pre;
     font-family: monospace;
 }
 
-gwc-remove-link {
+.overflowAuto {
+    overflow: auto;
+}
+
+.default-node-info {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    right: 28px;
+    width: auto;
+    padding: 1px;
+    border: 1px solid #0076a1;
+    font-weight: bold;
+    background-color: #dadada;
+    color: #0076a1;
+}
+
+.sec-removal-dialog {
+   padding: 2em;
+}
+
+.sec-removal-dialog h3 {
+   margin-left: auto;
+   max-width: 90%;
+}
+
+.sec-removal-dialog span {
+   color: #000;
+}
+
+.sec-removal-dialog ul ul {
+   padding-left: 0.75em;
+}
+
+.gwc-missing-gridset {
+    color: red;
+    text-decoration: line-through;
+}
+
+.gwc-remove-link {
     position:absolute;
     right:0;
     text-align:right;
 }
 
-codemirror {
+.codemirror {
     border: 1px solid black;
     padding-bottom: 3px;
 }
 
-italic {
+.italic {
     font-style: italic;
 }
 
-padding-1em {
+.padding-1em {
     padding: 1em;
 }
 
-padding-right-25pct {
+.padding-right-25pct {
     padding-right: 25%;
 }
 
-bottom-margin-1em {
+.bottom-margin-1em {
     margin-bottom: 1em;
 }
 
-bottom-padding-0pt5em {
+.bottom-padding-0pt5em {
     padding-bottom: 0.5em;
 }
 
-bottom-padding-2em {
+.bottom-padding-2em {
     padding-bottom: 2em;
 }
 
-srs-demo-map-container {
+.srs-demo-map-container {
     width:512px;
     height:256px;
     background-color:white;
 }
 
-reproj-console-geom {
+.reproj-console-geom {
     height: 2em;
     width: 55em;
 }
 
-image-chooser-img {
+.image-chooser-img {
     display: block;
     float:right;
     max-width: 35px;
@@ -1801,4 +1840,26 @@ image-chooser-img {
 
 .hidden {
     display: none;
+}
+
+.inline {
+    display: inline;
+}
+
+#processAccessMode {
+    display: block;
+    padding-top: 0.5em;
+}
+
+#processAccessMode input {
+    display: block;
+    float: left;
+    clear: left;
+    padding-top :0.5em;
+    margin-bottom: 0.5em;
+}
+
+#processAccessMode label {
+    clear: right;
+    margin-bottom: 0.5em;
 }

--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/DimensionEditorBase.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/DimensionEditorBase.java
@@ -265,12 +265,10 @@ public abstract class DimensionEditorBase<T extends DimensionInfo> extends FormC
 
                         boolean listSelected =
                                 presentation.getModelObject() == DimensionPresentation.LIST;
-                        String containerVisible = listSelected ? "none" : "initial";
+                        String containerVisible = listSelected ? "hidden" : "";
                         startField
                                 .getParent()
-                                .add(
-                                        new AttributeModifier(
-                                                "style", "display:" + containerVisible + ";"));
+                                .add(AttributeModifier.replace("class", containerVisible));
                         if (listSelected) {
                             startField.setModelValue(new String[0]);
                             startField.setRequired(false);
@@ -470,9 +468,8 @@ public abstract class DimensionEditorBase<T extends DimensionInfo> extends FormC
         final WebMarkupContainer startEndContainer = new WebMarkupContainer("startEndContainer");
         startEndContainer.setOutputMarkupId(true);
         String containerVisibility =
-                presentation.getModelObject() == DimensionPresentation.LIST ? "none" : "initial";
-        startEndContainer.add(
-                new AttributeModifier("style", "display:" + containerVisibility + ";"));
+                presentation.getModelObject() == DimensionPresentation.LIST ? "hidden" : "";
+        startEndContainer.add(AttributeModifier.replace("class", containerVisibility));
         configs.add(startEndContainer);
 
         IModel<String> sfModel = new PropertyModel<>(model, "startValue");

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/browser/FileDataView.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/browser/FileDataView.java
@@ -11,12 +11,16 @@ import java.text.DecimalFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Optional;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxFallbackLink;
+import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.extensions.ajax.markup.html.IndicatingAjaxFallbackLink;
 import org.apache.wicket.extensions.markup.html.repeater.data.sort.OrderByBorder;
-import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnLoadHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -153,16 +157,26 @@ public abstract class FileDataView extends Panel {
                     }
                 };
 
-        fileContent =
-                new WebMarkupContainer("fileContent") {
-                    @Override
-                    protected void onComponentTag(ComponentTag tag) {
-                        if (tableHeight != null) {
-                            tag.getAttributes()
-                                    .put("style", "overflow:auto; height:" + tableHeight);
+        fileContent = new WebMarkupContainer("fileContent");
+        if (tableHeight != null) {
+            fileContent.setOutputMarkupId(true);
+            fileContent.add(AttributeModifier.replace("class", "overflowAuto"));
+            fileContent.add(
+                    new Behavior() {
+                        private static final long serialVersionUID = 4820788798632906484L;
+
+                        @Override
+                        public void renderHead(Component component, IHeaderResponse response) {
+                            String script =
+                                    "document.getElementById('"
+                                            + fileContent.getMarkupId()
+                                            + "').style.height = '"
+                                            + StringEscapeUtils.escapeEcmaScript(tableHeight)
+                                            + "';";
+                            response.render(OnLoadHeaderItem.forScript(script));
                         }
-                    }
-                };
+                    });
+        }
 
         fileContent.add(fileTable);
 

--- a/src/web/core/src/test/java/org/geoserver/web/CustomGeoServerNodeIdTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/CustomGeoServerNodeIdTest.java
@@ -6,9 +6,7 @@
 package org.geoserver.web;
 
 import java.util.List;
-import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
-import org.apache.wicket.model.Model;
 import org.geoserver.GeoServerNodeData;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -48,7 +46,6 @@ public class CustomGeoServerNodeIdTest extends GeoServerWicketTestSupport {
 
     public static class CustomNodeInfo implements GeoServerNodeInfo {
         static String ID = null;
-        static String STYLE = null;
 
         @Override
         public String getId() {
@@ -57,14 +54,10 @@ public class CustomGeoServerNodeIdTest extends GeoServerWicketTestSupport {
 
         @Override
         public GeoServerNodeData getData() {
-            return new GeoServerNodeData(ID, STYLE);
+            return new GeoServerNodeData(ID, null);
         }
 
         @Override
-        public void customize(WebMarkupContainer nodeInfoContainer) {
-            if (STYLE != null) {
-                nodeInfoContainer.add(new AttributeAppender("style", new Model<>(STYLE), ";"));
-            }
-        }
+        public void customize(WebMarkupContainer nodeInfoContainer) {}
     }
 }

--- a/src/web/demo/src/main/resources/org/geoserver/web/demo/demo-requests.css
+++ b/src/web/demo/src/main/resources/org/geoserver/web/demo/demo-requests.css
@@ -17,7 +17,7 @@
     flex-direction: row;
 }
 
-tdNoWidth {
+.tdNoWidth {
     width: 1%;
 }
 

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/statusbar.css
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/statusbar.css
@@ -16,6 +16,8 @@
 	background-color: green;
 	height: 10px;
 	width: 50px;
+	left: 5px;
+	border-left: inherit;
 }
 
 .statusBarExcess {

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GridSubsetsEditor.java
@@ -199,10 +199,7 @@ class GridSubsetsEditor extends FormComponentPanel<Set<XMLGridSubset>> {
                                         new PropertyModel<>(item.getModel(), "gridSetName"));
                         if (!gridsetExists) {
                             gridSetLabel.add(
-                                    new AttributeModifier(
-                                            "style",
-                                            new Model<>(
-                                                    "color:red;text-decoration:line-through;")));
+                                    AttributeModifier.replace("class", "gwc-missing-gridset"));
                             getPage()
                                     .warn(
                                             "GridSet "

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/AbstractConfirmRemovalPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/AbstractConfirmRemovalPanel.html
@@ -1,27 +1,10 @@
 <html xmlns:wicket="http://wicket.apache.org/">
-<wicket:head>
-  <style type="text/css">
-    div.removalDialog h3 {
-       margin-left: auto;
-       max-width: 90%;
-    }
-    div.removalDialog {
-       padding: 2em;
-    }
-    div.removalDialog span {
-       color: #000;
-    }
-    div.removalDialog ul ul {
-       padding-left: 0.75em;
-    }
-  </style>
-</wicket:head>
 <body>
 <wicket:panel>
    
 <div wicket:id="rootObjects">
 </div>
-  <div class="removalDialog">
+  <div class="sec-removal-dialog">
     <h3><wicket:message key="AbstractConfirmRemovelPanel.aboutRemove">About to remove</wicket:message></h3>
     <ul>
       <li>

--- a/src/web/security/core/src/main/java/org/geoserver/security/web/SecurityNamedServiceEditPage$ErrorPanel.html
+++ b/src/web/security/core/src/main/java/org/geoserver/security/web/SecurityNamedServiceEditPage$ErrorPanel.html
@@ -1,10 +1,4 @@
 <html xmlns:wicket="http://wicket.apache.org/">
-<head>
-<wicket:head>
-  <style type="text/css">
-  </style>
-</wicket:head>
-</head>
 <body>
 <wicket:panel>
   <form>

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/ExternalGraphicPanel.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/ExternalGraphicPanel.java
@@ -152,7 +152,7 @@ public class ExternalGraphicPanel extends Panel {
         height.setOutputMarkupId(true);
         table.add(height);
 
-        table.add(new AttributeModifier("style", showhideStyleModel));
+        table.add(AttributeModifier.replace("class", showhideStyleModel));
 
         container.add(table);
 
@@ -279,12 +279,7 @@ public class ExternalGraphicPanel extends Panel {
     }
 
     private void updateVisibility(boolean b) {
-        if (b) {
-            showhideStyleModel.setObject("");
-        } else {
-            showhideStyleModel.setObject("display:none");
-        }
-        // table.setVisible(b);
+        showhideStyleModel.setObject(b ? "" : "hidden");
         autoFill.setVisible(b);
         hide.setVisible(b);
         show.setVisible(!b);

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StyleEditPage.java
@@ -8,13 +8,12 @@ package org.geoserver.wms.web.data;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.logging.Level;
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.WicketRuntimeException;
-import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnLoadHeaderItem;
-import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.geoserver.catalog.SLDHandler;
@@ -55,9 +54,8 @@ public class StyleEditPage extends AbstractStylePage {
             if (si.getWorkspace() == null) {
                 styleForm.setEnabled(false);
 
-                editor.add(new AttributeAppender("class", new Model<>("disabled"), " "));
-                get("validate")
-                        .add(new AttributeAppender("style", new Model<>("display:none;"), " "));
+                editor.add(AttributeModifier.append("class", "disabled"));
+                get("validate").add(AttributeModifier.append("class", "hidden"));
                 add(
                         new Behavior() {
 

--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/StylePage.css
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/StylePage.css
@@ -1,34 +1,34 @@
 /* CSS for the StyleAdminPanel. */
 
-style-data-span {
+.style-data-span {
     width: 45%;
     margin-right: 5%;
     margin-bottom: 0px;
 }
 
-style-legend-span {
+.style-legend-span {
     width: 45%;
     margin-right: 5%;
 }
 
-w-27-em {
+.w-27-em {
     width: 27em;
 }
 
-display-inline-block {
+.display-inline-block {
     display: inline-block;
 }
 
-bottom-margin-0em {
+.bottom-margin-0em {
     margin-bottom: 0em
 }
 
-style-button-group {
+.style-button-group {
     margin-top: 0.5em;
     margin-left: -1px;
     clear: left;
 }
 
-top-padding-2em {
+.top-padding-2em {
     padding-top: 2em;
 }


### PR DESCRIPTION
This PR fixes some CSP issues with after the Wicket 9 upgrade. The big one is with the node info since that has an API change.

The org.geoserver.web.csp.strict property isn't working correctly and this PR fixes it so that it actually disables blocking CSP violations by default. My separate CSP PR that Jody is reviewing allows an administrator to switch between blocking or reporting headers or completely disabling CSP through the UI.

The period in front of CSS class names actually matters and isn't just a code style issue. An easy way to to see this is that the Style Editor is missing a black border around the main text editor (at least in Chrome).

I'm only reviewing a few extensions and no community modules but besides the modal dialog and the Tile Layers page, the remaining CSP violations I've encountered are with the CodeMirror library used by the Style Editor and Demo Requests page (specifically the Find, Find Next, Replace buttons) and the Spectrum.js library used by the Choose Color button in the Style Editor. I'm not sure what can be done about them since they are third-party libraries and upgrading the libraries wouldn't fix the CSP issues.

A separate PR was created to fix the Tile Layers page since it already had a JIRA ticket: https://github.com/geoserver/geoserver/pull/7977
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->