### PR TITLE
More Windows VM tolerance for FileSystemResourceTheoryTest

### DIFF
--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceTheoryTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceTheoryTest.java
@@ -49,10 +49,10 @@ import org.junit.rules.TestName;
 public class FileSystemResourceTheoryTest extends ResourceTheoryTest {
 
     /**
-     * On a local machine this is a long wait, but Github action VMs are slow and erratic, let's
-     * give it more time
+     * On a local machine this would be long wait, but Github action VMs are slow and erratic, let's
+     * give them more time
      */
-    private static final int MAX_WAIT_SEC = 20;
+    private static final int MAX_WAIT_SEC = 60;
 
     FileSystemResourceStore store;
 


### PR DESCRIPTION
This test tends to often fail on Windows. Let's try to give it a bit more time.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->