### PR TITLE
[Backport 2.25.x] [GEOS-11587] Update mapfish-print-v2 to version 2.3.2

### DIFF
--- a/doc/en/user/source/extensions/printing/protocol.rst
+++ b/doc/en/user/source/extensions/printing/protocol.rst
@@ -255,7 +255,8 @@ Render vector layers. The geometries and the styling comes directly from the spe
 * geoJson (Required) the geoJson to render
 * styleProperty (Defaults to '_style') Name of the property within the features to use as style name. The given property may contain a style object directly.
 * styles (Optional) dictionary of styles. One style is defined as in OpenLayers.Feature.Vector.style.
-* name (Defaults to ``vector``) the layer name.
+* name (Defaults to ``vector``) the layer name. (deprecated: use pdfLayerName instead)
+* pdfLayerName (Defaults to ``vector``) PDF layer name.
 
 WMS
 ---
@@ -271,6 +272,7 @@ Support for the WMS protocol with possibilities to go through a WMS-C service (T
 * format (Required)
 * version (Defaults to ``1.1.1``)
 * useNativeAngle (Defaults to false) it true transform the map angle to customParams.angle for GeoServer, and customParams.map_angle for MapServer.
+* pdfLayerName (Defaults to stringify layers field comma separated) PDF layer name.
 
 WMTS
 ----
@@ -305,6 +307,7 @@ Standard mode:
     }, ...]
 
 * format (Optional, Required id requestEncoding is ``KVP``)
+* pdfLayerName (Defaults to layer field) PDF layer name.
 
 Simple mode:
 
@@ -338,6 +341,7 @@ Support the TMS tile layout.
 * layer (Required)
 * resolutions (Required) Array of resolutions
 * tileOrigin (Optional) Object, tile origin.  Defaults to ``0,0``
+* pdfLayerName (Defaults to layer field) PDF layer name.
 
 Resources:
 
@@ -360,6 +364,7 @@ Support the tile layout z/x/y.<extension>.
 * tileOrigin (Optional) Array, tile origin e.g. ``[420000, 350000]``
 * tileOriginCorner ``tl`` or ``bl`` (Defaults to ``bl``)
 * path_format (Optional) url fragment used to construct the tile location. Can support variable replacement of ``${x}``, ``${y}``, ``${z}`` and ``${extension}``. Defaults to zz/x/y.extension format.  You can use multiple "letters" to indicate a replaceable pattern (aka, ``${zzzz}`` will ensure the z variable is 0 padded to have a length of AT LEAST 4 characters).
+* pdfLayerName (Defaults to "t") PDF layer name.
 
 Osm
 ---
@@ -374,6 +379,7 @@ Support the OSM tile layout.
 * tileSize (Required) Array, tile size e.g. ``[256, 256]``
 * resolutions (Required) Array of resolutions
 * extension (Required) file extension
+* pdfLayerName (Defaults to "t") PDF layer name.
 
 TileCache
 ---------
@@ -389,6 +395,7 @@ Support for the protocol using directly the content of a TileCache directory.
 * tileSize (Required) Array, tile size e.g. ``[256, 256]``
 * resolutions (Required) Array of resolutions
 * extension (Required) file extension
+* pdfLayerName (Defaults to layer field) PDF layer name.
 
 Image
 -----
@@ -398,6 +405,7 @@ Type: image
 * name (Required)
 * baseURL (Required) Service URL
 * extent (Required)
+* pdfLayerName (Defaults to name field) PDF layer name.
 
 MapServer
 ---------
@@ -410,6 +418,7 @@ Support mapserver WMS server.
 * customParams (Optional) Map, additional URL arguments
 * layers (Required)
 * format (Required)
+* pdfLayerName (Defaults to stringify layers field comma separated) PDF layer name.
 
 KaMap
 -----
@@ -426,6 +435,7 @@ Support for the protocol using the KaMap tiling method
 * tileSize (Required) Array, tile size e.g. ``[256, 256]``
 * resolutions (Required) Array of resolutions
 * extension (Required) file extension
+* pdfLayerName (Defaults to map field) PDF layer name.
 
 KaMapCache
 ----------
@@ -445,6 +455,7 @@ Support for the protocol talking directly to a web-accessible ka-Map cache gener
 * tileSize (Required) Array, tile size e.g. ``[256, 256]``
 * resolutions (Required) Array of resolutions
 * extension (Required) file extension
+* pdfLayerName (Defaults to map field) PDF layer name.
 
 Google
 ------
@@ -465,6 +476,7 @@ The google map reader has several custom parameters that can be added to the req
 * maptype (Required) - type of map to display: http://code.google.com/apis/maps/documentation/staticmaps/#MapTypes
 * sensor  (Optional) - specifies whether the application requesting the static map is using a sensor to determine the user's location
 * language (Optional) - language of labels.
+* pdfLayerName (Defaults to "t") PDF layer name.
 * markers (Optional) - add markers to the map: http://code.google.com/apis/maps/documentation/staticmaps/#Markers
 
 .. code-block:: javascript

--- a/src/extension/printing/src/test/resources/test.yaml
+++ b/src/extension/printing/src/test/resources/test.yaml
@@ -139,8 +139,6 @@ layouts:
                 backgroundColor: #A0A0A0
               cell: !text
                 align: center
-                maxWidth: 15
-                maxHeight: 15
                 text: TEXT
         - !text
           font: Helvetica

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -124,7 +124,7 @@
     <interactive.image>false</interactive.image>
     <windows.leniency>true</windows.leniency>
     <gf.version>3.7-SNAPSHOT</gf.version>
-    <mf.version>2.3.0</mf.version>
+    <mf.version>2.3.1</mf.version>
     <jasypt.version>1.9.2</jasypt.version>
     <hibernate-version>3.6.9.Final</hibernate-version>
     <hibernate-generic-dao-version>1.1.0</hibernate-generic-dao-version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -124,7 +124,7 @@
     <interactive.image>false</interactive.image>
     <windows.leniency>true</windows.leniency>
     <gf.version>3.7-SNAPSHOT</gf.version>
-    <mf.version>2.3.1</mf.version>
+    <mf.version>2.3.2</mf.version>
     <jasypt.version>1.9.2</jasypt.version>
     <hibernate-version>3.6.9.Final</hibernate-version>
     <hibernate-generic-dao-version>1.1.0</hibernate-generic-dao-version>


### PR DESCRIPTION
[![GEOS-11587](https://badgen.net/badge/JIRA/GEOS-11587/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11587) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport https://github.com/geoserver/geoserver/pull/7794
Backport https://github.com/geoserver/geoserver/pull/7989