### PR TITLE
[GEOS-11588] Use JDBCConfiguration.validateConfiguration to provide feedback

### DIFF
--- a/doc/en/user/source/installation/upgrade.rst
+++ b/doc/en/user/source/installation/upgrade.rst
@@ -103,6 +103,16 @@ If the above did not help, then a full cleanup of the GeoServer configuration is
 
 #. Recreate the stores and layers using the known procedures.
 
+Disk Quota validation query (GeoServer 2.25.4 and newer)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using the JDBC Disk Quota:
+
+* Validation query for ``H2`` is limited to ``SELECT 1``.
+* Validation query for ``Oracle`` is limited to ``SELECT 1 FROM DUAL``.
+* Validation query for other JDBC formats receive a warning in the logs if is not one of the common examples above.
+
+.. note:: If you find your JDBC Disk Quota is no longer loaded on startup: check the logs for message about validation query, edit the configuration, and restart.
 
 External Entity Allow List default (GeoServer 2.25 and newer)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/gwc/pom.xml
+++ b/src/gwc/pom.xml
@@ -144,6 +144,12 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geotools.jdbc</groupId>
+      <artifactId>gt-jdbc-h2</artifactId>
+      <version>${gt.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/gwc/src/main/java/org/geoserver/gwc/JDBCConfigurationStorage.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/JDBCConfigurationStorage.java
@@ -57,6 +57,7 @@ class JDBCConfigurationStorage implements ApplicationContextAware, SecurityManag
             throws ConfigurationException, IOException, InterruptedException {
         Resource configFile = configDir.get("geowebcache-diskquota-jdbc.xml");
         if ("JDBC".equals(config.getQuotaStore())) {
+            JDBCConfiguration.validateConfiguration(jdbcConfig);
             JDBCConfiguration encrypted = passwordHelper.encryptPassword(jdbcConfig);
             try (OutputStream os = configFile.out()) {
                 JDBCConfiguration.store(encrypted, os);
@@ -97,6 +98,9 @@ class JDBCConfigurationStorage implements ApplicationContextAware, SecurityManag
      */
     public void testQuotaConfiguration(JDBCConfiguration jdbcConfiguration)
             throws ConfigurationException, IOException {
+
+        JDBCConfiguration.validateConfiguration(jdbcConfiguration);
+
         JDBCQuotaStoreFactory factory = GeoServerExtensions.bean(JDBCQuotaStoreFactory.class);
         QuotaStore qs = null;
         try {

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -1389,6 +1389,66 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
         JDBCQuotaStoreFactory.ENABLE_HSQL_AUTO_SHUTDOWN = false;
     }
 
+    @Test
+    public void testDiskQuotaH2Storage() throws Exception {
+        // normal state, quota is not enabled by default
+        GWC gwc = GWC.get();
+        ConfigurableQuotaStoreProvider provider =
+                GeoServerExtensions.bean(ConfigurableQuotaStoreProvider.class);
+        DiskQuotaConfig quota = gwc.getDiskQuotaConfig();
+        JDBCConfiguration jdbc = gwc.getJDBCDiskQuotaConfig();
+        assertFalse("Disk quota is enabled??", quota.isEnabled());
+        assertNull("jdbc quota config should be missing", jdbc);
+        assertTrue(getActualStore(provider) instanceof DummyQuotaStore);
+
+        GeoServerDataDirectory dd = GeoServerExtensions.bean(GeoServerDataDirectory.class);
+        String jdbcConfigPath = "gwc/geowebcache-diskquota-jdbc.xml";
+        String h2StorePath = "gwc/diskquota_page_store_h2";
+
+        // now enable it in JDBC mode, with HSQL local storage
+        quota.setEnabled(true);
+        quota.setQuotaStore("JDBC");
+        jdbc = new JDBCConfiguration();
+        jdbc.setDialect("H2");
+        ConnectionPoolConfiguration pool = new ConnectionPoolConfiguration();
+        pool.setDriver("org.h2.Driver");
+        pool.setUrl("jdbc:h2:file:./target/quota-h2");
+        pool.setUsername("sa");
+        pool.setPassword("");
+        pool.setMinConnections(1);
+        pool.setMaxConnections(1);
+        pool.setMaxOpenPreparedStatements(50);
+        jdbc.setConnectionPool(pool);
+
+        pool.setValidationQuery("SELECT 1");
+        gwc.saveDiskQuotaConfig(quota, jdbc);
+        assertNotNull(
+                "jdbc config (" + jdbcConfigPath + ") should be there",
+                dd.findFile(jdbcConfigPath));
+        assertNull(
+                "jdbc store (" + h2StorePath + ") should be there", dd.findDataFile(h2StorePath));
+
+        File newQuotaStore = new File("./target/quota-h2.data.db");
+        assertTrue(newQuotaStore.exists());
+        try {
+            pool.setValidationQuery("SELECT 1 FROM DUAL");
+            gwc.saveDiskQuotaConfig(quota, jdbc);
+            fail("Expect configuration due to incorrect validation query used for H2");
+        } catch (ConfigurationException expected) {
+        }
+
+        File jdbcConfigFile = dd.findFile(jdbcConfigPath);
+        try (FileInputStream fis = new FileInputStream(jdbcConfigFile)) {
+            Document dom = dom(fis);
+            // print(dom);
+            String storedPassword =
+                    XMLUnit.newXpathEngine()
+                            .evaluate("/gwcJdbcConfiguration/connectionPool/password", dom);
+            // check the password has been encoded properly
+            assertTrue(storedPassword.startsWith("crypt1:"));
+        }
+    }
+
     private QuotaStore getActualStore(ConfigurableQuotaStoreProvider provider)
             throws ConfigurationException, IOException {
         return ((ConfigurableQuotaStore) provider.getQuotaStore()).getStore();


### PR DESCRIPTION
[![GEOS-11588](https://badgen.net/badge/JIRA/GEOS-11588/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11588) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This makes use of https://github.com/GeoWebCache/geowebcache/pull/1327

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->