### PR TITLE
Clarify the requirements for Content dependent legends parameters

### DIFF
--- a/doc/en/user/source/services/wms/get_legend_graphic/index.rst
+++ b/doc/en/user/source/services/wms/get_legend_graphic/index.rst
@@ -234,14 +234,14 @@ In order to support it the GetLegendGraphic call needs the following extra param
   * BBOX
   * SRS or CRS (depending on the WMS version, SRS for 1.1.1 and CRS for 1.3.0)
   * SRCWIDTH and SRCHEIGHT, the size of the reference map (width and height already have a different meaning in GetLegendGraphic)
+
+and the following LEGEND_OPTIONS parameters:
+
+  * countMatched: adds the number of features matching the particular rule at the end of the rule label (requires visible labels to work). Applicable only to vector layers.
+  * hideEmptyRules:  hides rules that are not matching any feature. Applicable only if countMatched is true.
   
 Other parameters can also be added to better match the GetMap request, for example, it is recommended to mirror 
 filtering vendor parameters such as, for example, CQL_FILTER,FILTER,FEATUREID,TIME,ELEVATION.
-
-Content dependent evaluation is enabled via the following LEGEND_OPTIONS parameters:
- 
-  *  countMatched: adds the number of features matching the particular rule at the end of the rule label (requires visible labels to work). Applicable only to vector layers.
-  *  hideEmptyRules:  hides rules that are not matching any feature. Applicable only if countMatched is true.
   
 For example, let's assume the following layout is added to GeoServer (``legend.xml`` to be placed in ``GEOSERVER_DATA_DIR/layouts``)::
 

--- a/doc/en/user/source/services/wms/get_legend_graphic/index.rst
+++ b/doc/en/user/source/services/wms/get_legend_graphic/index.rst
@@ -238,7 +238,7 @@ In order to support it the GetLegendGraphic call needs the following extra param
 and the following LEGEND_OPTIONS parameters:
 
   * countMatched: adds the number of features matching the particular rule at the end of the rule label (requires visible labels to work). Applicable only to vector layers.
-  * hideEmptyRules:  hides rules that are not matching any feature. Applicable only if countMatched is true.
+  * hideEmptyRules:  hides rules that are not matching any feature.
   
 Other parameters can also be added to better match the GetMap request, for example, it is recommended to mirror 
 filtering vendor parameters such as, for example, CQL_FILTER,FILTER,FEATUREID,TIME,ELEVATION.


### PR DESCRIPTION
The way it is stated now is misleading, because the LEGEND_OPTIONS params are required, but they are mentioned after the optional parameters.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->