### PR TITLE
Re-align the Features - Part 3, Filtering implementation with the finalized standard

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/ConformanceClass.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/ConformanceClass.java
@@ -20,11 +20,14 @@ public class ConformanceClass {
      * CQL filtering conformance classes, shared here to allow STAC using them, without depending on
      * ogc-api-features directly
      */
-    public static final String FEATURES_FILTER =
-            "http://www.opengis.net/spec/ogcapi-features-3/1.0/req/features-filter";
+    public static final String QUERYABLES =
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables";
 
     public static final String FILTER =
-            "http://www.opengis.net/spec/ogcapi-features-3/1.0/req/filter";
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter";
+
+    public static final String FEATURES_FILTER =
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter";
 
     /** Sorting conformance class from OGC API - Records. */
     public static final String SORTBY =

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/FunctionsDocument.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/FunctionsDocument.java
@@ -5,6 +5,7 @@
 package org.geoserver.ogcapi;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -16,7 +17,7 @@ import org.locationtech.jts.geom.Geometry;
 
 /** A document enumerating the available functions */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class FunctionsDocument {
+public class FunctionsDocument extends AbstractDocument {
 
     public static final String REL = "http://www.opengis.net/def/rel/ogc/1.0/functions";
 
@@ -49,12 +50,14 @@ public class FunctionsDocument {
     public static class Function {
         String name;
         String description;
-        Argument returns;
+        List<AttributeType> returns;
         List<Argument> arguments;
 
         Function(FunctionName fn) {
             this.name = fn.getName();
-            this.returns = toParameter(fn.getReturn());
+            this.returns =
+                    Arrays.stream(toParameter(fn.getReturn()).getType())
+                            .collect(Collectors.toList());
             this.description = null; // no support for descriptions in GeoTools functions
             this.arguments =
                     fn.getArguments().stream()
@@ -66,7 +69,7 @@ public class FunctionsDocument {
             return name;
         }
 
-        public Argument getReturns() {
+        public List<AttributeType> getReturns() {
             return returns;
         }
 
@@ -92,6 +95,8 @@ public class FunctionsDocument {
                                 .map(Function::new)
                                 .distinct()
                                 .collect(Collectors.toList());
+
+        addSelfLinks("ogc/features/v1/functions");
     }
 
     private static boolean isSimpleFunction(FunctionName functionName) {

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/Queryables.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/Queryables.java
@@ -19,8 +19,10 @@ import java.util.List;
 public class Queryables extends Schema<Object> {
 
     public static final String REL = "http://www.opengis.net/def/rel/ogc/1.0/queryables";
+    public static final String JSON_SCHEMA_DRAFT_2020_12 =
+            "https://json-schema.org/draft/2020-12/schema";
 
-    private final String schema = "https://json-schema.org/draft/2019-09/schema";
+    private final String schema = JSON_SCHEMA_DRAFT_2020_12;
 
     private String id;
 

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesBuilder.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesBuilder.java
@@ -8,13 +8,16 @@ import static org.geotools.data.complex.util.ComplexFeatureConstants.FEATURE_CHA
 
 import io.swagger.v3.oas.models.media.Schema;
 import java.io.IOException;
+import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geotools.api.feature.type.FeatureType;
-import org.geotools.api.feature.type.PropertyType;
+import org.geotools.api.feature.type.PropertyDescriptor;
+import org.geotools.feature.FeatureTypes;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiLineString;
@@ -25,23 +28,13 @@ import org.locationtech.jts.geom.Polygon;
 
 public class QueryablesBuilder {
 
-    public static final String POINT_SCHEMA_REF = "https://geojson.org/schema/Point.json";
-    public static final String MULTIPOINT_SCHEMA_REF = "https://geojson.org/schema/MultiPoint.json";
-    public static final String LINESTRING_SCHEMA_REF = "https://geojson.org/schema/LineString.json";
-    public static final String MULTILINESTRING_SCHEMA_REF =
-            "https://geojson.org/schema/MultiLineString.json";
-    public static final String POLYGON_SCHEMA_REF = "https://geojson.org/schema/Polygon.json";
-    public static final String MULTIPOLYGON_SCHEMA_REF =
-            "https://geojson.org/schema/MultiPolygon.json";
-    public static final String GEOMETRY_SCHEMA_REF = "https://geojson.org/schema/Geometry.json";
-
     public static final String POINT = "Point";
     public static final String MULTIPOINT = "MultiPoint";
     public static final String LINESTRING = "LineString";
     public static final String MULTILINESTRING = "MultiLineString";
     public static final String POLYGON = "Polygon";
     public static final String MULTIPOLYGON = "MultiPolygon";
-    public static final String GENERIC_GEOMETRY = "Generic geometry";
+    public static final String GENERIC_GEOMETRY = "Any geometry";
     public static final String DATE = "Date";
     public static final String DATE_TIME = "DateTime";
     public static final String TIME = "Time";
@@ -68,7 +61,7 @@ public class QueryablesBuilder {
                         .collect(
                                 Collectors.toMap(
                                         ad -> ad.getName().getLocalPart(),
-                                        ad -> getSchema(ad.getType()),
+                                        ad -> getSchema(ad),
                                         (u, v) -> {
                                             throw new IllegalStateException(
                                                     String.format("Duplicate key %s", u));
@@ -78,9 +71,14 @@ public class QueryablesBuilder {
         return this;
     }
 
-    private Schema<?> getSchema(PropertyType type) {
-        Class<?> binding = type.getBinding();
-        return getSchema(binding);
+    private Schema<?> getSchema(PropertyDescriptor descriptor) {
+        Class<?> binding = descriptor.getType().getBinding();
+        Schema schema = getSchema(binding);
+        int fieldLength = FeatureTypes.getFieldLength(descriptor);
+        if (fieldLength != FeatureTypes.ANY_LENGTH) {
+            schema.setMaxLength(fieldLength);
+        }
+        return schema;
     }
 
     /** Returns the schema for a given data type */
@@ -91,33 +89,30 @@ public class QueryablesBuilder {
 
     private static Schema<?> getGeometrySchema(Class<?> binding) {
         Schema schema = new Schema<>();
-        String ref;
-        String description;
+        String title;
         if (Point.class.isAssignableFrom(binding)) {
-            ref = POINT_SCHEMA_REF;
-            description = POINT;
+            title = POINT;
         } else if (MultiPoint.class.isAssignableFrom(binding)) {
-            ref = MULTIPOINT_SCHEMA_REF;
-            description = MULTIPOINT;
+            title = MULTIPOINT;
         } else if (LineString.class.isAssignableFrom(binding)) {
-            ref = LINESTRING_SCHEMA_REF;
-            description = LINESTRING;
+            title = LINESTRING;
         } else if (MultiLineString.class.isAssignableFrom(binding)) {
-            ref = MULTILINESTRING_SCHEMA_REF;
-            description = MULTILINESTRING;
+            title = MULTILINESTRING;
         } else if (Polygon.class.isAssignableFrom(binding)) {
-            ref = POLYGON_SCHEMA_REF;
-            description = POLYGON;
+            title = POLYGON;
         } else if (MultiPolygon.class.isAssignableFrom(binding)) {
-            ref = MULTIPOLYGON_SCHEMA_REF;
-            description = MULTIPOLYGON;
+            title = MULTIPOLYGON;
         } else {
-            ref = GEOMETRY_SCHEMA_REF;
-            description = GENERIC_GEOMETRY;
+            title = GENERIC_GEOMETRY;
         }
 
-        schema.set$ref(ref);
-        schema.setDescription(description);
+        schema.setTitle(title);
+        if (title.equals(GENERIC_GEOMETRY)) {
+            schema.setFormat("geometry-any");
+        } else {
+            schema.setFormat("geometry-" + title.toLowerCase());
+        }
+
         return schema;
     }
 
@@ -131,16 +126,20 @@ public class QueryablesBuilder {
         Schema<?> schema = new Schema<>();
 
         schema.setType(org.geoserver.ogcapi.AttributeType.fromClass(binding).getType());
-        schema.setDescription(schema.getType());
+        schema.setTitle(schema.getType());
         if (java.sql.Date.class.isAssignableFrom(binding)) {
             schema.setFormat("date");
-            schema.setDescription(DATE);
+            schema.setTitle(DATE);
         } else if (java.sql.Time.class.isAssignableFrom(binding)) {
             schema.setFormat("time");
-            schema.setDescription(TIME);
+            schema.setTitle(TIME);
         } else if (java.util.Date.class.isAssignableFrom(binding)) {
             schema.setFormat("date-time");
-            schema.setDescription(DATE_TIME);
+            schema.setTitle(DATE_TIME);
+        } else if (UUID.class.isAssignableFrom(binding)) {
+            schema.setFormat("uuid");
+        } else if (URL.class.isAssignableFrom(binding)) {
+            schema.setTitle("uri");
         }
         return schema;
     }

--- a/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/queryables.ftl
+++ b/src/community/ogcapi/ogcapi-core/src/main/resources/org/geoserver/ogcapi/queryables.ftl
@@ -13,7 +13,7 @@
       <#if model.getProperties()??>
       <ul id="queryables">
       <#list model.getProperties() as name, definition>
-        <li><b>${name}</b>: ${definition.getDescription()}</li>
+        <li><b>${name}</b>: ${definition.getTitle()}</li>
       </#list>
       </ul>
       <#else>

--- a/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/QueryablesBuilderTest.java
+++ b/src/community/ogcapi/ogcapi-core/src/test/java/org/geoserver/ogcapi/QueryablesBuilderTest.java
@@ -22,69 +22,69 @@ public class QueryablesBuilderTest {
     public void testGetSchema() throws Exception {
         Schema stringSchema = QueryablesBuilder.getSchema(String.class);
         assertEquals("string", stringSchema.getType());
-        assertEquals("string", stringSchema.getDescription());
+        assertEquals("string", stringSchema.getTitle());
 
         Schema integerSchema = QueryablesBuilder.getSchema(Integer.class);
         assertEquals("integer", integerSchema.getType());
-        assertEquals("integer", integerSchema.getDescription());
+        assertEquals("integer", integerSchema.getTitle());
 
         Schema longSchema = QueryablesBuilder.getSchema(Long.class);
         assertEquals("integer", longSchema.getType());
-        assertEquals("integer", longSchema.getDescription());
+        assertEquals("integer", longSchema.getTitle());
 
         Schema doubleSchema = QueryablesBuilder.getSchema(Double.class);
         assertEquals("number", doubleSchema.getType());
-        assertEquals("number", doubleSchema.getDescription());
+        assertEquals("number", doubleSchema.getTitle());
 
         Schema floatSchema = QueryablesBuilder.getSchema(Float.class);
         assertEquals("number", floatSchema.getType());
-        assertEquals("number", floatSchema.getDescription());
+        assertEquals("number", floatSchema.getTitle());
 
         Schema booleanSchema = QueryablesBuilder.getSchema(Boolean.class);
         assertEquals("boolean", booleanSchema.getType());
-        assertEquals("boolean", booleanSchema.getDescription());
+        assertEquals("boolean", booleanSchema.getTitle());
 
         Schema timeSchema = QueryablesBuilder.getSchema(java.sql.Time.class);
         assertEquals("string", timeSchema.getType());
         assertEquals("time", timeSchema.getFormat());
-        assertEquals("Time", timeSchema.getDescription());
+        assertEquals("Time", timeSchema.getTitle());
 
         Schema dateSChema = QueryablesBuilder.getSchema(java.sql.Date.class);
         assertEquals("string", dateSChema.getType());
         assertEquals("date", dateSChema.getFormat());
-        assertEquals("Date", dateSChema.getDescription());
+        assertEquals("Date", dateSChema.getTitle());
 
         Schema dateTimeSchema = QueryablesBuilder.getSchema(java.util.Date.class);
         assertEquals("string", dateTimeSchema.getType());
         assertEquals("date-time", dateTimeSchema.getFormat());
-        assertEquals("DateTime", dateTimeSchema.getDescription());
+        assertEquals("DateTime", dateTimeSchema.getTitle());
 
         Schema pointSchema = QueryablesBuilder.getSchema(Point.class);
-        assertEquals(QueryablesBuilder.POINT_SCHEMA_REF, pointSchema.get$ref());
-        assertEquals("Point", pointSchema.getDescription());
+        assertEquals("geometry-point", pointSchema.getFormat());
+        assertEquals("Point", pointSchema.getTitle());
 
         Schema multiPointSchema = QueryablesBuilder.getSchema(MultiPoint.class);
-        assertEquals(QueryablesBuilder.MULTIPOINT_SCHEMA_REF, multiPointSchema.get$ref());
-        assertEquals("MultiPoint", multiPointSchema.getDescription());
+        assertEquals("geometry-multipoint", multiPointSchema.getFormat());
+        assertEquals("MultiPoint", multiPointSchema.getTitle());
 
         Schema lineStringSchema = QueryablesBuilder.getSchema(LineString.class);
-        assertEquals(QueryablesBuilder.LINESTRING_SCHEMA_REF, lineStringSchema.get$ref());
-        assertEquals("LineString", lineStringSchema.getDescription());
+        assertEquals("geometry-linestring", lineStringSchema.getFormat());
+        assertEquals("LineString", lineStringSchema.getTitle());
 
         Schema multiLineStringSchema = QueryablesBuilder.getSchema(MultiLineString.class);
-        assertEquals(QueryablesBuilder.MULTILINESTRING_SCHEMA_REF, multiLineStringSchema.get$ref());
-        assertEquals("MultiLineString", multiLineStringSchema.getDescription());
+        assertEquals("geometry-multilinestring", multiLineStringSchema.getFormat());
+        assertEquals("MultiLineString", multiLineStringSchema.getTitle());
 
         Schema polygonSchema = QueryablesBuilder.getSchema(Polygon.class);
-        assertEquals(QueryablesBuilder.POLYGON_SCHEMA_REF, polygonSchema.get$ref());
-        assertEquals("Polygon", polygonSchema.getDescription());
+        assertEquals("geometry-polygon", polygonSchema.getFormat());
+        assertEquals("Polygon", polygonSchema.getTitle());
 
         Schema multiPolygonSchema = QueryablesBuilder.getSchema(MultiPolygon.class);
-        assertEquals(QueryablesBuilder.MULTIPOLYGON_SCHEMA_REF, multiPolygonSchema.get$ref());
-        assertEquals("MultiPolygon", multiPolygonSchema.getDescription());
+        assertEquals("geometry-multipolygon", multiPolygonSchema.getFormat());
+        assertEquals("MultiPolygon", multiPolygonSchema.getTitle());
 
         Schema geometrySchema = QueryablesBuilder.getSchema(Geometry.class);
-        assertEquals(QueryablesBuilder.GEOMETRY_SCHEMA_REF, geometrySchema.get$ref());
-        assertEquals("Generic geometry", geometrySchema.getDescription());
+        assertEquals("geometry-any", geometrySchema.getFormat());
+        assertEquals("Any geometry", geometrySchema.getTitle());
     }
 }

--- a/src/community/ogcapi/ogcapi-features/pom.xml
+++ b/src/community/ogcapi/ogcapi-features/pom.xml
@@ -89,5 +89,11 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.erosb</groupId>
+      <artifactId>json-sKema</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
@@ -17,6 +17,7 @@ import static org.geoserver.ogcapi.ConformanceClass.ECQL_TEXT;
 import static org.geoserver.ogcapi.ConformanceClass.FEATURES_FILTER;
 import static org.geoserver.ogcapi.ConformanceClass.FILTER;
 import static org.geoserver.ogcapi.ConformanceClass.IDS;
+import static org.geoserver.ogcapi.ConformanceClass.QUERYABLES;
 import static org.geoserver.ogcapi.ConformanceClass.SEARCH;
 import static org.geoserver.ogcapi.ConformanceClass.SORTBY;
 import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
@@ -318,8 +319,9 @@ public class FeatureService {
                         GEOJSON,
                         /* GMLSF0, GS does not use the gmlsf namespace */
                         CRS_BY_REFERENCE,
-                        FEATURES_FILTER,
                         FILTER,
+                        QUERYABLES,
+                        FEATURES_FILTER,
                         SEARCH,
                         ECQL,
                         ECQL_TEXT,

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeaturesAPIBuilder.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeaturesAPIBuilder.java
@@ -61,6 +61,7 @@ public class FeaturesAPIBuilder extends org.geoserver.ogcapi.OpenAPIBuilder<WFSI
         Catalog catalog = wfs.getGeoServer().getCatalog();
         List<String> validCollectionIds =
                 catalog.getFeatureTypes().stream()
+                        .filter(ft -> ft.isEnabled() && ft.isAdvertised())
                         .map(ft -> ft.prefixedName())
                         .collect(Collectors.toList());
         collectionId.getSchema().setEnum(validCollectionIds);

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/functions.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/functions.ftl
@@ -7,12 +7,12 @@
        <#list model.functions as f>
          <h3>${f.name}</h3>
          <ul>
-         <li>Returns: <#list f.returns.type as t>${t} </#list></li>
+         <li>Returns: <#list f.returns as t>${t} </#list></li>
          <li>Arguments:
          <table class="function-table">
-         <tr><th>Name</th><th>Description</th><th>Type</th></tr>
+         <tr><th>Name</th><th>Title</th><th>Type</th></tr>
          <#list f.arguments as arg>
-            <tr><td>${arg.title}</td><td>${arg.description!""}</td><td><#list f.returns.type as t>${t} </#list></td></tr>
+            <tr><td>${arg.title}</td><td>${arg.title!""}</td><td><#list arg.type as t>${t} </#list></td></tr>
          </#list>
          </table>
          </li>

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/landingPage.ftl
@@ -28,6 +28,16 @@
         </div>
       </div>
     </div>
+
+    <div class="col-6 col-xl-3 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h2>Functions</h2>
+          <p>The <a id="functionsLink" href="${model.getLinkUrl('functions', 'text/html')!}"> collection page</a> provides a list of all the collections available in this service.
+          <br/>
+        </div>
+      </div>
+    </div>
     
     ${htmlExtensions('landing')?no_esc}
 

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/openapi.yaml
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/openapi.yaml
@@ -329,28 +329,30 @@ components:
     filter:
       name: filter
       in: query
+      required: false
       description: Defines a filter that will be applied on items, only items matching the filter will be returned
       schema:
         type: string
+      explode: false
     filter-lang:
       name: filter-lang
       in: query
+      required: false
       description: Filter encoding used in the filter parameter
       schema:
         type: string
         enum:
           - cql-text
           - cql2-text
-        default: cql-text
+        default: cql2-text
     filter-crs:
       name: filter-crs
       in: query
-      description: Filter CRS which is being used to encode geometries in the filter parameter
       required: false
+      description: Filter CRS which is being used to encode geometries in the filter parameter
       schema:
         type: string
         format: uri-reference
-      style: form
       explode: false
     sortby:
       name: sortby

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ApiTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,6 +39,7 @@ import org.geoserver.test.GeoServerBaseTestSupport;
 import org.geoserver.wfs.WFSInfo;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -271,5 +273,15 @@ public class ApiTest extends FeaturesTestSupport {
                         .map(ft -> ft.getName())
                         .collect(Collectors.toList());
         assertThat(collectionIdValues, equalTo(expectedCollectionIds));
+    }
+
+    @Test
+    @Ignore
+    public void testFilterCRS() throws Exception {
+        fail(
+                "We should to enumerate all supported filter-crs values, but they are likely too many, "
+                        + "and we'd have to inspect all the collections to find an exhaustive list for the"
+                        + "test. The ATS does not seem to check it either, so taking a not but not "
+                        + "implementing for the time being.");
     }
 }

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/CollectionTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/CollectionTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.custommonkey.xmlunit.XMLAssert;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.data.test.MockData;
@@ -38,10 +37,8 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wfs.WFSInfo;
 import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.MediaType;
-import org.w3c.dom.Document;
 
 public class CollectionTest extends FeaturesTestSupport {
 
@@ -188,26 +185,6 @@ public class CollectionTest extends FeaturesTestSupport {
     }
 
     @Test
-    @Ignore // ignoring XML output for the moment, we need to migrated it to use JAXB2 to be of any
-    // usefulness
-    public void testCollectionXML() throws Exception {
-        Document dom =
-                getAsDOM(
-                        "ogc/features/v1/collections/"
-                                + getLayerId(ROAD_SEGMENTS)
-                                + "?f=application/xml");
-        print(dom);
-        String expected =
-                "http://localhost:8080/geoserver/ogc/features/v1/collections/cite%3ARoadSegments"
-                        + "/items?f=application%2Fjson";
-        XMLAssert.assertXpathEvaluatesTo(
-                expected,
-                "//wfs:Collection[wfs:id='cite:RoadSegments']/atom:link[@atom:type='application"
-                        + "/json']/@atom:href",
-                dom);
-    }
-
-    @Test
     public void testCollectionYaml() throws Exception {
         getAsString(
                 "ogc/features/v1/collections/"
@@ -238,28 +215,6 @@ public class CollectionTest extends FeaturesTestSupport {
         assertThat(html, containsString("form-select-open-basic"));
         assertThat(html, containsString("form-select-open-limit"));
         assertThat(html, not(containsString("onchange")));
-    }
-
-    @Test
-    public void testQueryables() throws Exception {
-        String roadSegments = ROAD_SEGMENTS.getLocalPart();
-        DocumentContext json =
-                getAsJSONPath(
-                        "cite/ogc/features/v1/collections/" + roadSegments + "/queryables", 200);
-        assertThat(
-                json.read("properties.the_geom.$ref"),
-                equalTo("https://geojson.org/schema/MultiLineString.json"));
-        assertThat(json.read("properties.FID.type"), equalTo("string"));
-        assertThat(json.read("properties.NAME.type"), equalTo("string"));
-    }
-
-    @Test
-    public void testQueryablesHTML() throws Exception {
-        String roadSegments = ROAD_SEGMENTS.getLocalPart();
-        org.jsoup.nodes.Document document =
-                getAsJSoup(
-                        "cite/ogc/features/v1/collections/" + roadSegments + "/queryables?f=html");
-        assertEquals("the_geom: MultiLineString", document.select("#queryables li:eq(0)").text());
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/CollectionsTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/CollectionsTest.java
@@ -37,12 +37,10 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wfs.WFSInfo;
 import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.w3c.dom.Document;
 
 public class CollectionsTest extends FeaturesTestSupport {
 
@@ -140,14 +138,6 @@ public class CollectionsTest extends FeaturesTestSupport {
         assertEquals(
                 "http://localhost:8080/geoserver/cdf/ogc/features/v1/collections/Deletes/items?f=application%2Fgeo%2Bjson",
                 ((JSONArray) json.read(deleteHrefPath)).get(0));
-    }
-
-    @Test
-    @Ignore
-    public void testCollectionsXML() throws Exception {
-        Document dom = getAsDOM("ogc/features/v1/collections?f=application/xml");
-        print(dom);
-        // TODO: add actual tests
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ConformanceTest.java
@@ -17,8 +17,14 @@ import static org.geoserver.ogcapi.ConformanceClass.ECQL_TEXT;
 import static org.geoserver.ogcapi.ConformanceClass.FEATURES_FILTER;
 import static org.geoserver.ogcapi.ConformanceClass.FILTER;
 import static org.geoserver.ogcapi.ConformanceClass.IDS;
+import static org.geoserver.ogcapi.ConformanceClass.QUERYABLES;
 import static org.geoserver.ogcapi.ConformanceClass.SEARCH;
 import static org.geoserver.ogcapi.ConformanceClass.SORTBY;
+import static org.geoserver.ogcapi.v1.features.FeatureService.CORE;
+import static org.geoserver.ogcapi.v1.features.FeatureService.CRS_BY_REFERENCE;
+import static org.geoserver.ogcapi.v1.features.FeatureService.GEOJSON;
+import static org.geoserver.ogcapi.v1.features.FeatureService.HTML;
+import static org.geoserver.ogcapi.v1.features.FeatureService.OAS30;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
@@ -26,9 +32,7 @@ import static org.junit.Assert.assertEquals;
 import com.jayway.jsonpath.DocumentContext;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.w3c.dom.Document;
 
 public class ConformanceTest extends FeaturesTestSupport {
 
@@ -45,13 +49,14 @@ public class ConformanceTest extends FeaturesTestSupport {
 
     private String[] getExpectedConformanceClasses() {
         return new String[] {
-            FeatureService.CORE,
-            FeatureService.OAS30,
-            FeatureService.HTML,
-            FeatureService.GEOJSON,
-            FeatureService.CRS_BY_REFERENCE,
-            FEATURES_FILTER,
+            CORE,
+            OAS30,
+            HTML,
+            GEOJSON,
+            CRS_BY_REFERENCE,
             FILTER,
+            QUERYABLES,
+            FEATURES_FILTER,
             SEARCH,
             ECQL,
             ECQL_TEXT,
@@ -66,13 +71,6 @@ public class ConformanceTest extends FeaturesTestSupport {
             SORTBY,
             IDS
         };
-    }
-
-    @Test
-    @Ignore
-    public void testConformanceXML() throws Exception {
-        Document dom = getAsDOM("ogc/features/v1?f=application/xml");
-        print(dom);
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
@@ -154,10 +154,10 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testBBoxFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/items?bbox=35,0,60,3",
+                        "ogc/features/v1/collections/" + collectionName + "/items?bbox=35,0,60,3",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         // should return only f002 and f003
@@ -170,13 +170,13 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testBBoxCRSFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         ReferencedEnvelope bbox = new ReferencedEnvelope(35, 60, 0, 3, DefaultGeographicCRS.WGS84);
         ReferencedEnvelope wmBox = bbox.transform(CRS.decode("EPSG:3857", true), true);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?"
                                 + bboxCrsQueryParameters(wmBox),
                         200);
@@ -209,11 +209,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testBBOXOGCAuthority() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?"
                                 + "bbox=35,0,60,3"
                                 + "&bbox-crs=http://www.opengis.net/def/crs/OGC/1.3/CRS84",
@@ -229,11 +229,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testInvalidBBOXCRS() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?"
                                 + "bbox=35,0,60,3"
                                 + "&bbox-crs=http://www.opengis.net/def/crs/OGC/1.3/INVALID",
@@ -246,10 +246,10 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testBBoxDatelineCrossingFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/items?bbox=170,0,60,3",
+                        "ogc/features/v1/collections/" + collectionName + "/items?bbox=170,0,60,3",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         // should return only f002 and f003
@@ -262,11 +262,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testCqlFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?filter=name='name-f001'",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -278,11 +278,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testCql2JsonFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?filter=%7B%22op%22%3A%22%3D%22%2C%22args%22%3A%5B%7B%22property%22%3A%22name%22%7D%2C%22name-f001%22%5D%7D" // {"op":"=","args":[{"property":"name"},"name-f001"]}
                                 + "&filter-lang=cql2-json",
                         200);
@@ -295,11 +295,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testCqlSpatialFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?filter=BBOX(pointProperty,38,1,40,3)&filter-lang=cql-text",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -311,11 +311,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testCql2JsonSpatialFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?filter=%7B%22op%22%3A%22s_intersects%22%2C%22args%22%3A%5B%7B%22property%22%3A%22pointProperty%22%7D%2C%7B%22bbox%22%3A%5B38%2C1%2C40%2C3%5D%7D%5D%7D" //
                                 + "&filter-lang=cql2-json",
                         200);
@@ -328,14 +328,14 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testCqlSpatialFilterWithFilterCrs() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         ReferencedEnvelope bbox = new ReferencedEnvelope(38, 40, 1, 3, DefaultGeographicCRS.WGS84);
         ReferencedEnvelope wmBox = bbox.transform(CRS.decode("EPSG:3857", true), true);
 
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?"
                                 + filterCrsQueryParameters(wmBox),
                         200);
@@ -353,13 +353,29 @@ public class FeatureTest extends FeaturesTestSupport {
     }
 
     @Test
-    public void testCqlFilterInvalidCrs() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+    public void testCqlFilterInvalidFilter() throws Exception {
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
 
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
+                                + "/items?filter=THIS IS NOT A FILTER",
+                        400);
+        assertEquals("InvalidParameterValue", json.read("code", String.class));
+        assertThat(
+                json.read("description", String.class),
+                Matchers.containsString("THIS IS NOT A FILTER"));
+    }
+
+    @Test
+    public void testCqlFilterInvalidCrs() throws Exception {
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+
+        DocumentContext json =
+                getAsJSONPath(
+                        "ogc/features/v1/collections/"
+                                + collectionName
                                 + "/items?filter=BBOX(pointProperty,38,1,40,3)&"
                                 + "filter-crs="
                                 + FeatureService.CRS_PREFIX
@@ -371,11 +387,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testCqlFilterInvalidLanguage() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?filter=name='name-f001'&filter-lang=foo-bar",
                         400);
         assertEquals("InvalidParameterValue", json.read("code", String.class));
@@ -384,11 +400,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testTimeFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?datetime=2006-10-25",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -400,11 +416,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testTimeRangeFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?datetime=2006-09-01/2006-10-23",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -417,11 +433,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testTimeDurationFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?datetime=2006-09-01/P1M23DT12H31M12S",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -434,11 +450,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testCombinedSpaceTimeFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?datetime=2006-09-01/2006-10-23&bbox=35,0,60,3",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -449,11 +465,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSortByWithDefaultSortOrder() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?sortby=name&limit=2",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -464,11 +480,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSortByWithAscendingSortOrder() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?sortby=%2Bname&limit=2",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -479,11 +495,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSortByWithDescendingSortOrder() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?sortby=-name&limit=2",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -494,11 +510,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSortByMultipleProperties() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/features/v1/collections/"
-                                + roadSegments
+                                + collectionName
                                 + "/items?sortby=booleanProperty,-intProperty",
                         200);
         assertEquals("FeatureCollection", json.read("type", String.class));
@@ -527,7 +543,7 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSearchCql2JsonFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         String request =
                 "{\n"
                         + "  \"filter\": {\"op\":\"=\",\"args\":[{\"property\":\"name\"},\"name-f001\"]},"
@@ -535,7 +551,7 @@ public class FeatureTest extends FeaturesTestSupport {
                         + "}";
         DocumentContext json =
                 postAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/search", request, 200);
+                        "ogc/features/v1/collections/" + collectionName + "/search", request, 200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         // should return only f001
         assertEquals(1, (int) json.read("features.length()", Integer.class));
@@ -545,7 +561,7 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSearchCql2TextFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         String request =
                 "{\n"
                         + "  \"filter\": \"BBOX(pointProperty,38,1,40,3)\",\n"
@@ -553,7 +569,7 @@ public class FeatureTest extends FeaturesTestSupport {
                         + "}";
         DocumentContext json =
                 postAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/search", request, 200);
+                        "ogc/features/v1/collections/" + collectionName + "/search", request, 200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         // should return only f001
         assertEquals(1, (int) json.read("features.length()", Integer.class));
@@ -563,7 +579,7 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSearchCql2TextFilterWithFilterCrs() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         ReferencedEnvelope bbox = new ReferencedEnvelope(38, 40, 1, 3, DefaultGeographicCRS.WGS84);
         ReferencedEnvelope wmBox = bbox.transform(CRS.decode("EPSG:3857", true), true);
         String crsValue = crsQueryParameter(wmBox);
@@ -579,7 +595,7 @@ public class FeatureTest extends FeaturesTestSupport {
                         + "\"\n}";
         DocumentContext json =
                 postAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/search", request, 200);
+                        "ogc/features/v1/collections/" + collectionName + "/search", request, 200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         // should return only f001
         assertEquals(1, (int) json.read("features.length()", Integer.class));
@@ -589,11 +605,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSearchBBoxJsonFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         String request = "{\"bbox\":[35, 0, 60, 3]}";
         DocumentContext json =
                 postAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/search", request, 200);
+                        "ogc/features/v1/collections/" + collectionName + "/search", request, 200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         // should return only f002 and f003
         assertEquals(2, (int) json.read("features.length()", Integer.class));
@@ -605,11 +621,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSearchBBoxTextFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         String request = "{\"bbox\":\"35,0,60,3\"}";
         DocumentContext json =
                 postAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/search", request, 200);
+                        "ogc/features/v1/collections/" + collectionName + "/search", request, 200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         // should return only f002 and f003
         assertEquals(2, (int) json.read("features.length()", Integer.class));
@@ -621,7 +637,7 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSearchBBoxCRSFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         ReferencedEnvelope bbox = new ReferencedEnvelope(35, 60, 0, 3, DefaultGeographicCRS.WGS84);
         ReferencedEnvelope wmBox = bbox.transform(CRS.decode("EPSG:3857", true), true);
         String boxValue = bboxQueryParameter(wmBox);
@@ -629,7 +645,7 @@ public class FeatureTest extends FeaturesTestSupport {
         String request = "{\"bbox\":\"" + boxValue + "\",\"bbox-crs\":\"" + bboxCrsValue + "\"}";
         DocumentContext json =
                 postAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/search", request, 200);
+                        "ogc/features/v1/collections/" + collectionName + "/search", request, 200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         // should return only f002 and f003
         assertEquals(2, (int) json.read("features.length()", Integer.class));
@@ -694,11 +710,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSearchDatetimeFilter() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         String request = "{\"datetime\":\"2006-10-25\"}";
         DocumentContext json =
                 postAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/search", request, 200);
+                        "ogc/features/v1/collections/" + collectionName + "/search", request, 200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         // should return only f001
         assertEquals(1, (int) json.read("features.length()", Integer.class));
@@ -708,11 +724,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSearchSortByJson() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         String request = "{\"sortby\":[\"name\"],\"limit\":2}";
         DocumentContext json =
                 postAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/search", request, 200);
+                        "ogc/features/v1/collections/" + collectionName + "/search", request, 200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         assertEquals(2, (int) json.read("features.length()", Integer.class));
         assertEquals(null, json.read("features[0].properties.name", String.class));
@@ -721,11 +737,11 @@ public class FeatureTest extends FeaturesTestSupport {
 
     @Test
     public void testSearchSortByText() throws Exception {
-        String roadSegments = getLayerId(MockData.PRIMITIVEGEOFEATURE);
+        String collectionName = getLayerId(MockData.PRIMITIVEGEOFEATURE);
         String request = "{\"sortby\":\"name\",\"limit\":2}";
         DocumentContext json =
                 postAsJSONPath(
-                        "ogc/features/v1/collections/" + roadSegments + "/search", request, 200);
+                        "ogc/features/v1/collections/" + collectionName + "/search", request, 200);
         assertEquals("FeatureCollection", json.read("type", String.class));
         assertEquals(2, (int) json.read("features.length()", Integer.class));
         assertEquals(null, json.read("features[0].properties.name", String.class));

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FunctionsTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FunctionsTest.java
@@ -4,11 +4,23 @@
  */
 package org.geoserver.ogcapi.v1.features;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
+import com.github.erosb.jsonsKema.FormatValidationPolicy;
+import com.github.erosb.jsonsKema.JsonParser;
+import com.github.erosb.jsonsKema.JsonValue;
+import com.github.erosb.jsonsKema.Schema;
+import com.github.erosb.jsonsKema.SchemaLoader;
+import com.github.erosb.jsonsKema.ValidationFailure;
+import com.github.erosb.jsonsKema.Validator;
+import com.github.erosb.jsonsKema.ValidatorConfig;
 import com.jayway.jsonpath.DocumentContext;
 import org.geoserver.data.test.SystemTestData;
+import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 public class FunctionsTest extends FeaturesTestSupport {
 
@@ -18,18 +30,53 @@ public class FunctionsTest extends FeaturesTestSupport {
     }
 
     @Test
-    public void testCapabilities() throws Exception {
+    public void testSchemaValid() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse("ogc/features/v1/functions");
+
+        // check the response abides to the functions schema
+        Schema schema =
+                SchemaLoader.forURL(
+                                "classpath:/org/geoserver/ogcapi/v1/features/functions-schema.yml")
+                        .load();
+        JsonValue functionsJSON = new JsonParser(response.getContentAsString()).parse();
+        Validator validator =
+                Validator.create(schema, new ValidatorConfig(FormatValidationPolicy.ALWAYS));
+        ValidationFailure failure = validator.validate(functionsJSON);
+        assertNull(failure);
+    }
+
+    @Test
+    public void testFunctions() throws Exception {
         DocumentContext json = getAsJSONPath("ogc/features/v1/functions", 200);
 
         // test one random function
         DocumentContext function = readSingleContext(json, "functions[?(@.name=='strSubstring')]");
-        assertEquals("substring", function.read("returns.title"));
-        assertEquals("string", readSingle(function, "returns.type"));
+        assertEquals("string", function.read("returns[0]"));
         assertEquals("string", function.read("arguments[0].title"));
         assertEquals("string", readSingle(function, "arguments[0].type"));
         assertEquals("beginIndex", function.read("arguments[1].title"));
         assertEquals("integer", readSingle(function, "arguments[1].type"));
         assertEquals("endIndex", function.read("arguments[2].title"));
         assertEquals("integer", readSingle(function, "arguments[2].type"));
+    }
+
+    @Test
+    public void testFunctionsHTML() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse("ogc/features/v1/functions?f=html");
+        assertEquals("text/html", response.getContentType());
+        // the table is hard to look up, so let's check the representation for a given function
+        assertThat(
+                response.getContentAsString(),
+                Matchers.containsString(
+                        "<h3>Area</h3>\n"
+                                + "         <ul>\n"
+                                + "         <li>Returns: number </li>\n"
+                                + "         <li>Arguments:\n"
+                                + "         <table class=\"function-table\">\n"
+                                + "         <tr><th>Name</th><th>Title</th><th>Type</th></tr>\n"
+                                + "            <tr><td>geometry</td><td>geometry</td><td>geometry </td></tr>\n"
+                                + "         </table>\n"
+                                + "         </li>\n"
+                                + "         </ul>"));
     }
 }

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/LandingPageTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNotNull;
 import com.jayway.jsonpath.DocumentContext;
 import java.util.List;
 import org.geoserver.config.GeoServer;
+import org.geoserver.ogcapi.FunctionsDocument;
 import org.geoserver.ogcapi.Link;
 import org.geoserver.ogcapi.OpenAPIMessageConverter;
 import org.geoserver.platform.Service;
@@ -19,10 +20,8 @@ import org.geoserver.wfs.WFSInfo;
 import org.geotools.util.Version;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.w3c.dom.Document;
 
 public class LandingPageTest extends FeaturesTestSupport {
 
@@ -71,14 +70,6 @@ public class LandingPageTest extends FeaturesTestSupport {
     public void testLandingPageWorkspaceSpecific() throws Exception {
         DocumentContext json = getAsJSONPath("ogc/features/v1", 200);
         checkJSONLandingPage(json);
-    }
-
-    @Test
-    @Ignore
-    public void testLandingPageXML() throws Exception {
-        Document dom = getAsDOM("ogc/features/v1?f=application/xml");
-        print(dom);
-        // TODO: add actual tests in here
     }
 
     @Test
@@ -170,6 +161,15 @@ public class LandingPageTest extends FeaturesTestSupport {
                 Link.REL_DATA,
                 Link.REL_DATA,
                 Link.REL_DATA);
+
+        // check collection links
+        assertJSONList(
+                json,
+                "links[?(@.href =~ /.*ogc\\/features\\/v1\\/functions.*/)].rel",
+                FunctionsDocument.REL,
+                FunctionsDocument.REL,
+                FunctionsDocument.REL);
+
         // check title
         assertEquals("Features 1.0 server", json.read("title"));
         // check description

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/QueryablesTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/QueryablesTest.java
@@ -1,0 +1,93 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.ogcapi.v1.features;
+
+import static org.geoserver.data.test.CiteTestData.ROAD_SEGMENTS;
+import static org.junit.Assert.assertEquals;
+
+import com.github.erosb.jsonsKema.JsonParser;
+import com.github.erosb.jsonsKema.JsonValue;
+import com.github.erosb.jsonsKema.SchemaLoader;
+import com.jayway.jsonpath.DocumentContext;
+import java.io.UnsupportedEncodingException;
+import org.geoserver.data.test.MockData;
+import org.geoserver.ogcapi.Queryables;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class QueryablesTest extends FeaturesTestSupport {
+
+    @Test
+    public void testDefaultFormat() throws Exception {
+        MockHttpServletResponse response =
+                getAsMockHttpServletResponse(roadSegmentQueryables(), 200);
+        assertEquals("application/schema+json", response.getContentType());
+
+        checkRoadSegmentsQueryables(response);
+    }
+
+    @Test
+    public void testFullFormatParameter() throws Exception {
+        MockHttpServletResponse response =
+                getAsMockHttpServletResponse(
+                        roadSegmentQueryables() + "?f=application/schema%2Bjson", 200);
+        assertEquals("application/schema+json", response.getContentType());
+
+        checkRoadSegmentsQueryables(response);
+    }
+
+    private String roadSegmentQueryables() {
+        return "ogc/features/v1/collections/" + getLayerId(ROAD_SEGMENTS) + "/queryables";
+    }
+
+    @Test
+    public void testAcceptHeader() throws Exception {
+        MockHttpServletRequest request = createRequest(roadSegmentQueryables());
+        request.setMethod("GET");
+        request.addHeader("Accept", "application/schema+json");
+
+        MockHttpServletResponse response = dispatch(request, null);
+        assertEquals(200, response.getStatus());
+        checkRoadSegmentsQueryables(response);
+    }
+
+    private void checkRoadSegmentsQueryables(MockHttpServletResponse response)
+            throws UnsupportedEncodingException {
+        DocumentContext json = getAsJSONPath(response);
+        assertEquals("geometry-multilinestring", json.read("properties.the_geom.format"));
+        assertEquals("string", json.read("properties.FID.type"));
+        assertEquals("string", json.read("properties.FID.title"));
+        assertEquals("string", json.read("properties.NAME.type"));
+        assertEquals("string", json.read("properties.NAME.title"));
+        assertEquals(Queryables.JSON_SCHEMA_DRAFT_2020_12, readSingle(json, ".$schema"));
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/features/v1/collections/cite%3ARoadSegments/queryables",
+                readSingle(json, ".$id"));
+        assertEquals("object", json.read("type"));
+    }
+
+    @Test
+    public void testQueryablesHTML() throws Exception {
+        String roadSegments = MockData.ROAD_SEGMENTS.getLocalPart();
+        org.jsoup.nodes.Document document =
+                getAsJSoup(
+                        "cite/ogc/features/v1/collections/" + roadSegments + "/queryables?f=html");
+        assertEquals("the_geom: MultiLineString", document.select("#queryables li:eq(0)").text());
+    }
+
+    @Test
+    public void queryablesSchema() throws Exception {
+        MockHttpServletResponse response =
+                getAsMockHttpServletResponse(
+                        roadSegmentQueryables() + "?f=application/schema%2Bjson", 200);
+
+        // check the response can be read as a valid JSON schema (will fail with an exception if
+        // not)
+        JsonValue schemaJSON = new JsonParser(response.getContentAsString()).parse();
+        new SchemaLoader(schemaJSON).load();
+    }
+}

--- a/src/community/ogcapi/ogcapi-features/src/test/resources/org/geoserver/ogcapi/v1/features/functions-schema.yml
+++ b/src/community/ogcapi/ogcapi-features/src/test/resources/org/geoserver/ogcapi/v1/features/functions-schema.yml
@@ -1,0 +1,52 @@
+type: object
+required:
+  - functions
+properties:
+  functions:
+    type: array
+    items:
+      type: object
+      required:
+        - name
+        - returns
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        metadataUrl:
+          type: string
+          format: uri-reference
+        arguments:
+          type: array
+          items:
+            type: object
+            required:
+              - type
+            properties:
+              title:
+                type: string
+              description:
+                type: string
+              type:
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - string
+                    - number
+                    - integer
+                    - datetime
+                    - geometry
+                    - boolean
+        returns:
+          type: array
+          items:
+            type: string
+            enum:
+              - string
+              - number
+              - integer
+              - datetime
+              - geometry
+              - boolean

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/QueryablesTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/QueryablesTest.java
@@ -35,14 +35,12 @@ public class QueryablesTest extends TilesTestSupport {
     }
 
     @Test
-    public void queryablesOnRoadSegements() throws Exception {
+    public void queryablesOnRoadSegments() throws Exception {
         DocumentContext json =
                 getAsJSONPath(
                         "ogc/tiles/v1/collections/" + getLayerId(ROAD_SEGMENTS) + "/queryables",
                         200);
-        assertEquals(
-                "https://geojson.org/schema/MultiLineString.json",
-                json.read("properties.the_geom.$ref"));
+        assertEquals("geometry-multilinestring", json.read("properties.the_geom.format"));
         assertEquals("string", json.read("properties.FID.type"));
         assertEquals("string", json.read("properties.NAME.type"));
     }

--- a/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACQueryablesBuilder.java
+++ b/src/community/oseo/oseo-stac/src/main/java/org/geoserver/ogcapi/v1/stac/STACQueryablesBuilder.java
@@ -200,10 +200,11 @@ public class STACQueryablesBuilder {
         return expressions;
     }
 
-    private Schema<?> getSchema(String description, String ref) {
+    private Schema<?> getSchema(String title, String ref) {
         Schema schema = new Schema();
         schema.set$ref(ref);
-        schema.setDescription(description);
+        schema.setTitle(title);
+        schema.setDescription(title);
         return schema;
     }
 

--- a/src/community/oseo/oseo-stac/src/main/resources/org/geoserver/ogcapi/v1/stac/queryables-common.ftl
+++ b/src/community/oseo/oseo-stac/src/main/resources/org/geoserver/ogcapi/v1/stac/queryables-common.ftl
@@ -2,7 +2,7 @@
       <#if model.getProperties()??>
       <ul id="queryables">
       <#list model.getProperties() as name, definition>
-        <li><b>${name}</b>: ${definition.getDescription()}</li>
+        <li><b>${name}</b>: ${definition.getTitle()}</li>
       </#list>
       </ul>
       <#else>

--- a/src/community/oseo/oseo-stac/src/main/resources/org/geoserver/ogcapi/v1/stac/sortables-common.ftl
+++ b/src/community/oseo/oseo-stac/src/main/resources/org/geoserver/ogcapi/v1/stac/sortables-common.ftl
@@ -2,7 +2,7 @@
       <#if model.getProperties()??>
       <ul id="sortables">
       <#list model.getProperties() as name, definition>
-        <li><b>${name}</b>: ${definition.getDescription()}</li>
+        <li><b>${name}</b>: ${definition.getTitle()}</li>
       </#list>
       </ul>
       <#else>

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/ApiTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/ApiTest.java
@@ -82,7 +82,7 @@ public class ApiTest extends STACTestSupport {
         assertThat(
                 html,
                 containsString(
-                        "url: \"http://localhost:8080/geoserver/ogc/stac/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
+                        "value=\"http://localhost:8080/geoserver/ogc/stac/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0"));
     }
 
     @Test

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/QueryablesTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/QueryablesTest.java
@@ -56,12 +56,12 @@ public class QueryablesTest extends STACTestSupport {
         // custom one that is there instead
         DocumentContext cc = readContext(properties, "eo:cloud_cover");
         assertEquals("integer", cc.read("type"));
-        assertEquals("integer", cc.read("description"));
+        assertEquals("integer", cc.read("title"));
 
         // top level queryable
         DocumentContext kw = readContext(properties, "keywords");
         assertEquals("string", kw.read("type"));
-        assertEquals("string", kw.read("description"));
+        assertEquals("string", kw.read("title"));
     }
 
     /**
@@ -94,16 +94,16 @@ public class QueryablesTest extends STACTestSupport {
             // custom one that is there instead
             DocumentContext cc = readContext(properties, "eo:cloud_cover");
             assertEquals("integer", cc.read("type"));
-            assertEquals("integer", cc.read("description"));
+            assertEquals("integer", cc.read("title"));
 
             // check the custom global queryables as well
             DocumentContext constellation = readContext(json, "properties.constellation");
             assertEquals("string", constellation.read("type"));
-            assertEquals("string", constellation.read("description"));
+            assertEquals("string", constellation.read("title"));
 
             DocumentContext sun_azimuth = readContext(json, "properties.view:sun_azimuth");
             assertEquals("number", sun_azimuth.read("type"));
-            assertEquals("number", sun_azimuth.read("description"));
+            assertEquals("number", sun_azimuth.read("title"));
         } finally {
             oseo.getGlobalQueryables().clear();
             gs.save(oseo);
@@ -142,7 +142,7 @@ public class QueryablesTest extends STACTestSupport {
         // check the one custom queryable added in LANDSAT8 template
         DocumentContext orbit = readContext(json, "properties.landsat:orbit");
         assertEquals("integer", orbit.read("type"));
-        assertEquals("integer", orbit.read("description"));
+        assertEquals("integer", orbit.read("title"));
     }
 
     @Test
@@ -159,11 +159,11 @@ public class QueryablesTest extends STACTestSupport {
             // check the custom queryables added above
             DocumentContext constellation = readContext(json, "properties.constellation");
             assertEquals("string", constellation.read("type"));
-            assertEquals("string", constellation.read("description"));
+            assertEquals("string", constellation.read("title"));
 
             DocumentContext sun_azimuth = readContext(json, "properties.view:sun_azimuth");
             assertEquals("number", sun_azimuth.read("type"));
-            assertEquals("number", sun_azimuth.read("description"));
+            assertEquals("number", sun_azimuth.read("title"));
         } finally {
             oseo.getGlobalQueryables().clear();
             gs.save(oseo);
@@ -184,11 +184,11 @@ public class QueryablesTest extends STACTestSupport {
             // check the custom queryables added above
             DocumentContext constellation = readContext(json, "properties.constellation");
             assertEquals("string", constellation.read("type"));
-            assertEquals("string", constellation.read("description"));
+            assertEquals("string", constellation.read("title"));
 
             DocumentContext sun_azimuth = readContext(json, "properties.view:sun_azimuth");
             assertEquals("number", sun_azimuth.read("type"));
-            assertEquals("number", sun_azimuth.read("description"));
+            assertEquals("number", sun_azimuth.read("title"));
         } finally {
             oseo.getGlobalQueryables().clear();
             gs.save(oseo);

--- a/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/SortablesTest.java
+++ b/src/community/oseo/oseo-stac/src/test/java/org/geoserver/ogcapi/v1/stac/SortablesTest.java
@@ -72,7 +72,7 @@ public class SortablesTest extends STACTestSupport {
         // check the one custom sortables added in LANDSAT8 template
         DocumentContext orbit = readContext(json, "properties.landsat:orbit");
         assertEquals("integer", orbit.read("type"));
-        assertEquals("integer", orbit.read("description"));
+        assertEquals("integer", orbit.read("title"));
     }
 
     private void checkSortableProperties(DocumentContext json) {

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1769,6 +1769,12 @@
         <artifactId>wiremock-jre8-standalone</artifactId>
         <version>2.35.1</version>
       </dependency>
+      <dependency>
+        <groupId>com.github.erosb</groupId>
+        <artifactId>json-sKema</artifactId>
+        <version>0.19.0</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
We were implementing and early draft, the finalized standard has a number of differences, closed the gap.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->