### PR TITLE
[GEOS-11540] OGC API queryables features call not working in JSON

### DIFF
--- a/src/community/ogcapi/ogcapi-changeset/src/main/java/org/geoserver/ogcapi/v1/changeset/ZippedChangesetMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-changeset/src/main/java/org/geoserver/ogcapi/v1/changeset/ZippedChangesetMessageConverter.java
@@ -57,7 +57,8 @@ public class ZippedChangesetMessageConverter implements HttpMessageConverter<Cha
 
     @Override
     public boolean canWrite(Class<?> clazz, MediaType mediaType) {
-        return clazz.equals(ChangeSet.class) && ZIP_MEDIA_TYPE.equals(mediaType);
+        return clazz.equals(ChangeSet.class)
+                && (mediaType == null || ZIP_MEDIA_TYPE.equals(mediaType));
     }
 
     @Override

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIBodyMethodProcessor.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIBodyMethodProcessor.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
@@ -34,11 +33,9 @@ import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.lang.Nullable;
-import org.springframework.util.CollectionUtils;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.context.request.ServletWebRequest;
-import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.mvc.method.annotation.JsonViewResponseBodyAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor;
 
@@ -272,12 +269,9 @@ public class APIBodyMethodProcessor extends RequestResponseBodyMethodProcessor {
             @Nullable Type targetType,
             Object value) {
 
-        Set<MediaType> mediaTypes =
-                (Set<MediaType>)
-                        request.getAttribute(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);
-        if (!CollectionUtils.isEmpty(mediaTypes)) {
-            return new ArrayList<>(mediaTypes);
-        }
+        // Not accessing request.getAttribute(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE),
+        // the producible media types are being set by some other Spring machinery that is not
+        // accounting for the capabilities of this class
         List<MediaType> result = new ArrayList<>();
         for (HttpMessageConverter<?> converter : this.messageConverters) {
             if (converter instanceof ResponseMessageConverter

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/MappingJackson2HttpMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/MappingJackson2HttpMessageConverter.java
@@ -7,6 +7,7 @@ package org.geoserver.ogcapi;
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
 import java.lang.reflect.Type;
 import org.geoserver.rest.wrapper.RestWrapper;
 import org.springframework.http.MediaType;
@@ -51,6 +52,7 @@ public class MappingJackson2HttpMessageConverter
     static boolean canJacksonHandle(Class<?> clazz) {
         return clazz.getAnnotation(JsonIgnoreType.class) == null
                 && !RestWrapper.class.isAssignableFrom(clazz)
-                && !OpenAPI.class.isAssignableFrom(clazz);
+                && !OpenAPI.class.isAssignableFrom(clazz)
+                && !Schema.class.isAssignableFrom(clazz);
     }
 }

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/MappingJackson2YAMLMessageConverter.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/MappingJackson2YAMLMessageConverter.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.ogcapi;
 
+import static org.geoserver.ogcapi.MappingJackson2HttpMessageConverter.canJacksonHandle;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import io.swagger.v3.core.util.Yaml;
 import java.io.IOException;

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/Queryables.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/Queryables.java
@@ -77,6 +77,21 @@ public class Queryables extends Schema<Object> {
     }
 
     public void addSelfLinks(String path) {
-        linksHolder.addSelfLinks(path);
+        APIRequestInfo requestInfo = APIRequestInfo.get();
+        List<Link> links =
+                new LinksBuilder(getClass(), path)
+                        .rel(Link.REL_ALTERNATE)
+                        .title("This document as ")
+                        .updater(
+                                (mt, l) -> {
+                                    if (requestInfo.isFormatRequested(
+                                            mt, JSONSchemaMessageConverter.SCHEMA_TYPE)) {
+                                        l.setRel(Link.REL_SELF);
+                                        l.setClassification(Link.REL_SELF);
+                                        l.setTitle("This document");
+                                    }
+                                })
+                        .build();
+        linksHolder.getLinks().addAll(links);
     }
 }

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
@@ -275,7 +275,7 @@ public class FeatureService {
                         null,
                         URLMangler.URLType.RESOURCE);
         Queryables queryables = new QueryablesBuilder(id).forType(ft).build();
-        queryables.addSelfLinks("collections/" + collectionId + "/queryables");
+        queryables.addSelfLinks("ogc/features/v1/collections/" + collectionId + "/queryables");
         return queryables;
     }
 

--- a/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/landingPage.ftl
@@ -33,7 +33,7 @@
       <div class="card h-100">
         <div class="card-body">
           <h2>Functions</h2>
-          <p>The <a id="functionsLink" href="${model.getLinkUrl('functions', 'text/html')!}"> collection page</a> provides a list of all the collections available in this service.
+          <p>The <a id="functionsLink" href="${model.getLinkUrl('functions', 'text/html')!}"> functions page</a> provides a list of all the functions available to build filters.
           <br/>
         </div>
       </div>

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/QueryablesTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/QueryablesTest.java
@@ -6,6 +6,7 @@
 package org.geoserver.ogcapi.v1.features;
 
 import static org.geoserver.data.test.CiteTestData.ROAD_SEGMENTS;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import com.github.erosb.jsonsKema.JsonParser;
@@ -15,6 +16,7 @@ import com.jayway.jsonpath.DocumentContext;
 import java.io.UnsupportedEncodingException;
 import org.geoserver.data.test.MockData;
 import org.geoserver.ogcapi.Queryables;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -68,6 +70,18 @@ public class QueryablesTest extends FeaturesTestSupport {
                 "http://localhost:8080/geoserver/ogc/features/v1/collections/cite%3ARoadSegments/queryables",
                 readSingle(json, ".$id"));
         assertEquals("object", json.read("type"));
+
+        // JSON schema can be represented only by the schema encoder, the YAML one, and HTML one.
+        assertEquals(Integer.valueOf(3), json.read("$..links.length()", Integer.class));
+        DocumentContext selfLink = readSingleContext(json, "links[?(@.rel=='self')]");
+        assertEquals("application/schema+json", selfLink.read("type"));
+        DocumentContext htmlLink =
+                readSingleContext(json, "links[?(@.rel=='alternate' && @.type=='text/html')]");
+        assertThat(htmlLink.read("href"), Matchers.endsWith("queryables?f=text%2Fhtml"));
+        DocumentContext yamlLink =
+                readSingleContext(
+                        json, "links[?(@.rel=='alternate' && @.type=='application/yaml')]");
+        assertThat(yamlLink.read("href"), Matchers.endsWith("queryables?f=application%2Fyaml"));
     }
 
     @Test

--- a/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/CollectionTest.java
+++ b/src/community/ogcapi/ogcapi-tiles/src/test/java/org/geoserver/ogcapi/v1/tiles/CollectionTest.java
@@ -102,15 +102,16 @@ public class CollectionTest extends TilesTestSupport {
         // queryables
         String queryablesLink =
                 readSingle(
-                        json, "$.links[?(@.rel=='queryables' && @.type=='application/json')].href");
+                        json,
+                        "$.links[?(@.rel=='queryables' && @.type=='application/schema+json')].href");
         assertEquals(
-                "http://localhost:8080/geoserver/ogc/tiles/v1/collections/cite:RoadSegments/queryables?f=application%2Fjson",
+                "http://localhost:8080/geoserver/ogc/tiles/v1/collections/cite:RoadSegments/queryables?f=application%2Fschema%2Bjson",
                 queryablesLink);
         String queryablesTitle =
                 readSingle(
                         json,
-                        "$.links[?(@.rel=='queryables' && @.type=='application/json')].title");
-        assertEquals("Collection queryables as application/json", queryablesTitle);
+                        "$.links[?(@.rel=='queryables' && @.type=='application/schema+json')].title");
+        assertEquals("Collection queryables as application/schema+json", queryablesTitle);
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-11540](https://badgen.net/badge/JIRA/GEOS-11540/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11540) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->