### PR TITLE
ogcapi-features10 CITE: swap default published CRS 3857 by 4087

### DIFF
--- a/build/cite/ogcapi-features10/release/wfs.xml
+++ b/build/cite/ogcapi-features10/release/wfs.xml
@@ -64,7 +64,7 @@
   <includeWFSRequestDumpFile>false</includeWFSRequestDumpFile>
   <srs>
     <string>4326</string>
-    <string>3857</string>
+    <string>4087</string>
   </srs>
   <getFeatureOutputTypeCheckingEnabled>false</getFeatureOutputTypeCheckingEnabled>
 </wfs>

--- a/build/cite/ogcapi-features10/release/workspaces/tiger/nyc/giant_polygon/featuretype.xml
+++ b/build/cite/ogcapi-features10/release/workspaces/tiger/nyc/giant_polygon/featuretype.xml
@@ -34,7 +34,7 @@
     <crs>EPSG:4326</crs>
   </latLonBoundingBox>
   <projectionPolicy>FORCE_DECLARED</projectionPolicy>
-  <enabled>false</enabled>
+  <enabled>true</enabled>
   <metadata>
     <entry key="kml.regionateFeatureLimit">10</entry>
     <entry key="cacheAgeMax">3600</entry>


### PR DESCRIPTION
`EPSG:4087` (WGS 84 / World Equidistant Cylindrical) is a global projection, while `EPSG:3857` (WGS 84 / Pseudo-Mercator) is not.

Since the `ogcapi-features-1.0` ETS fails while doing coordinate transformations on itself, despite GeoServer having returned transformed geometries (albeit outside the area of validity of the target CRS), let's use two default published CRS's that cover the whole globe.

Re-enable the `tiger:giant_polygon` layer, since now it can be reprojected across the declared global CRS's.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->