### PR TITLE
[GEOS-11611] When Extracting the WFS Service Name from the HTTP Request A Slash Before the Question Marks Causes Issues

### DIFF
--- a/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
+++ b/src/ows/src/main/java/org/geoserver/ows/Dispatcher.java
@@ -1624,19 +1624,24 @@ public class Dispatcher extends AbstractController {
     }
 
     private static String extractServiceFromHttpRequest(String servletPath) {
-        int startIndex = servletPath.lastIndexOf("/") + 1;
-        int endIndex = servletPath.indexOf("?");
-
-        if (startIndex == 0) {
-            return ""; // No forward slash found
+        // Find the last "/"
+        int lastSlashIndex = servletPath.lastIndexOf('/');
+        if (lastSlashIndex == -1) {
+            // If there is no "/", return a blank string
+            return "";
         }
-
-        if (endIndex == -1) {
-            return servletPath.substring(startIndex); // No question mark found
+        // If there are at least two "/"
+        int secondLastSlashIndex = servletPath.lastIndexOf('/', lastSlashIndex - 1);
+        // second slash is the last character
+        if (secondLastSlashIndex != -1 && lastSlashIndex == servletPath.length() - 1) {
+            // Extract the characters between the second-to-last and the last "/"
+            return servletPath.substring(secondLastSlashIndex + 1, lastSlashIndex);
+        } else {
+            // Does not end with a "/", return everything after the last "/"
+            return servletPath.substring(lastSlashIndex + 1);
         }
-
-        return servletPath.substring(startIndex, endIndex);
     }
+
     /**
      * To be called once determined the incoming request is an HTTP POST request
      * with a request body, and the request's {@link Request#getInput() input

--- a/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v1_1/GetFeatureTest.java
@@ -103,6 +103,26 @@ public class GetFeatureTest extends WFSTestSupport {
             }
         }
         assertEquals(features.getLength(), count);
+
+        // Same test but this time there is a slash before the question mark
+        Document docSlashBeforeQuestion =
+                getAsDOM(
+                        "wfs/?request=GetFeature&typename=cite:Ponds&version=1.1.0&cql_filter=TYPE%3D%27Stock%20Pond%27&propertyname=TYPE");
+        features = docSlashBeforeQuestion.getElementsByTagName("cite:Ponds");
+        assertNotEquals(0, features.getLength());
+        count = 0;
+        for (int i = 0; i < features.getLength(); i++) {
+            Element feature = (Element) features.item(i);
+            for (int j = 0; j < feature.getChildNodes().getLength(); j++) {
+                if (feature.getChildNodes().item(j).getNodeName().equals("cite:TYPE")) {
+                    count++;
+                }
+                if (feature.getChildNodes().item(j).getNodeName().equals("cite:NAME")) {
+                    fail("Unexpected property found");
+                }
+            }
+        }
+        assertEquals(features.getLength(), count);
     }
 
     private void testGetFifteenAll(String request) throws Exception {

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeatureTest.java
@@ -258,6 +258,26 @@ public class GetFeatureTest extends WFS20TestSupport {
             }
         }
         assertEquals(features.getLength(), count);
+
+        // Same test but this time there is a slash before the question mark
+        Document docSlashBeforeQuestion =
+                getAsDOM(
+                        "wfs/?request=GetFeature&typename=cite:Ponds&version=2.0.0&cql_filter=TYPE%3D%27Stock%20Pond%27&propertyname=TYPE");
+        features = docSlashBeforeQuestion.getElementsByTagName("cite:Ponds");
+        assertNotEquals(0, features.getLength());
+        count = 0;
+        for (int i = 0; i < features.getLength(); i++) {
+            Element feature = (Element) features.item(i);
+            for (int j = 0; j < feature.getChildNodes().getLength(); j++) {
+                if (feature.getChildNodes().item(j).getNodeName().equals("cite:TYPE")) {
+                    count++;
+                }
+                if (feature.getChildNodes().item(j).getNodeName().equals("cite:NAME")) {
+                    fail("Unexpected property found");
+                }
+            }
+        }
+        assertEquals(features.getLength(), count);
     }
 
     private void testGetFifteenAll(String request) throws Exception {
@@ -904,6 +924,7 @@ public class GetFeatureTest extends WFS20TestSupport {
         assertGML32(dom);
         assertEquals(0, dom.getElementsByTagName("cdf:Other").getLength());
     }
+
     //
     //    public void testWithGmlObjectId() throws Exception {
     //        String xml = "<wfs:GetFeature xmlns:cdf=\"http://www.opengis.net/cite/data\"


### PR DESCRIPTION
[![GEOS-11611](https://badgen.net/badge/JIRA/GEOS-11611/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11611) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->