### PR TITLE
[GEOS-11612] Add proxy base url use headers system property support

### DIFF
--- a/doc/en/user/source/configuration/globalsettings.rst
+++ b/doc/en/user/source/configuration/globalsettings.rst
@@ -46,7 +46,11 @@ Once activated the environment parametrization Proxy Base URL can be parameters 
 Use headers for Proxy URL
 '''''''''''''''''''''''''
 
-Checking this box allows a by-request modification of the proxy URL using templates (templates based on HTTP proxy headers).
+Checking this box allows a by-request modification of the proxy URL using templates (templates based on HTTP proxy headers).  This setting may also be managed using the ``PROXY_BASE_URL_HEADERS`` boolean system property or environment variable defined by a System Administrator: setting it to true will enable the headers variables usage for proxy base URL on all workspaces, overriding any GeoServer datadir configuration.
+
+.. code-block::bash
+
+    -DPROXY_BASE_URL_HEADERS=true
 
 The supported proxy headers are:
 

--- a/doc/en/user/source/configuration/properties/index.rst
+++ b/doc/en/user/source/configuration/properties/index.rst
@@ -209,6 +209,12 @@ GeoServer Property Reference
      - x
      - x
      - x
+   * - PROXY_BASE_URL_HEADER
+       
+       Enables PROXY_BASE_URL to use headers variables if set to true, overriding GeoServer datadir settings.  Default false.
+     - x
+     - x
+     - x
    * - org.geoserver.service.disabled
        
        Default comma separated list of disabled services.

--- a/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
+++ b/src/main/src/main/java/org/geoserver/ows/ProxifyingURLMangler.java
@@ -105,6 +105,7 @@ public class ProxifyingURLMangler implements URLMangler {
     }
 
     private boolean resolveDoMangleHeaders() {
+        if (isUseHeadersSystemPropertyEnabled()) return true;
         Boolean wsAwareFlag = geoServer.getSettings().isUseHeadersProxyURL();
         Boolean resultFlag =
                 wsAwareFlag != null
@@ -112,6 +113,16 @@ public class ProxifyingURLMangler implements URLMangler {
                         : geoServer.getGlobal().getSettings().isUseHeadersProxyURL();
         if (resultFlag != null) return resultFlag;
         return false;
+    }
+
+    /**
+     * Check if the PROXY_BASE_URL_HEADERS system property is set to use headers for proxying.
+     *
+     * @return true if the system property is set to use headers for proxying
+     */
+    private boolean isUseHeadersSystemPropertyEnabled() {
+        String useHeadersProxyURL = GeoServerExtensions.getProperty(Requests.PROXY_HEADER_PARAM);
+        return useHeadersProxyURL != null && "true".equalsIgnoreCase(useHeadersProxyURL.trim());
     }
 
     /**

--- a/src/main/src/main/java/org/vfny/geoserver/util/Requests.java
+++ b/src/main/src/main/java/org/vfny/geoserver/util/Requests.java
@@ -49,6 +49,7 @@ public final class Requests {
     ( See GEOS-598 for more information
     */
     public static final String PROXY_PARAM = "PROXY_BASE_URL";
+    public static final String PROXY_HEADER_PARAM = "PROXY_BASE_URL_HEADERS";
 
     /**
      * Appends a context path to a base url.


### PR DESCRIPTION
[![GEOS-11612](https://badgen.net/badge/JIRA/GEOS-11612/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11612) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Currently, system property activation [is supported for Proxy base URL setting on GeoServer](https://docs.geoserver.org/main/en/user/configuration/globalsettings.html#proxy-base-url), but there is no option to enable the Use Headers setting using the same approach.  This task is focused on add the same flags support level in order to sync both features activation.

The proposed system property is on the example:
```
-DPROXY_BASE_URL_HEADERS=true
```

https://osgeo-org.atlassian.net/browse/GEOS-11612
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->