### PR TITLE
[GEOS-11613] Increase control-flow logging admin visibility in logs

### DIFF
--- a/doc/en/user/source/extensions/controlflow/CONTROL_FLOW_LOGGING.xml
+++ b/doc/en/user/source/extensions/controlflow/CONTROL_FLOW_LOGGING.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration name="CONTROL_FLOW_LOGGING_LOGGING" status="fatal" dest="out">
+    <Appenders>
+        <Console name="stdout" target="SYSTEM_OUT">
+            <PatternLayout pattern="%date{dd mmm HH:mm:ss} '%tn' %-6level [%logger{2}] - %msg%n%throwable{filters(org.junit,org.apache.maven,sun.reflect,java.lang.reflect)}"/>
+        </Console>
+        <RollingFile name="geoserverlogfile">
+            <filename>logs/geoserver.log</filename>
+            <filePattern>logs/geoserver-%i.log</filePattern>
+            <PatternLayout pattern="%date{dd mmm HH:mm:ss} '%tn' %-6level [%logger{2}] - %msg%n%throwable{filters(org.junit,org.apache.maven,sun.reflect,java.lang.reflect)}"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="20 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="3" fileIndex="min"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+
+        <Logger name="org.geoserver.flow" level="debug" additivity="false">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="geoserverlogfile"/>
+        </Logger>
+
+        <Logger name="org.geotools" level="warn" additivity="false">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="geoserverlogfile"/>
+        </Logger>
+        <Logger name="org.geotools.factory" level="warn" additivity="false">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="geoserverlogfile"/>
+        </Logger>
+
+        <Logger name="org.geoserver" level="warn" additivity="false">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="geoserverlogfile"/>
+        </Logger>
+        <Logger name="org.vfny.geoserver" level="warn" additivity="false">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="geoserverlogfile"/>
+        </Logger>
+
+        <Logger name="org.springframework" level="warn" additivity="false">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="geoserverlogfile"/>
+        </Logger>
+
+        <Logger name="org.geowebcache" level="error" additivity="false">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="geoserverlogfile"/>
+        </Logger>
+
+        <Root level="warn">
+            <AppenderRef ref="stdout"/>
+            <AppenderRef ref="geoserverlogfile"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/HttpHeaderPriorityProvider.java
+++ b/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/HttpHeaderPriorityProvider.java
@@ -77,4 +77,9 @@ public class HttpHeaderPriorityProvider implements PriorityProvider {
     public int getDefaultPriority() {
         return defaultPriority;
     }
+
+    @Override
+    public String toString() {
+        return "HttpHeaderPriorityProvider(" + headerName + "," + defaultPriority + ")";
+    }
 }

--- a/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/PriorityThreadBlocker.java
+++ b/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/PriorityThreadBlocker.java
@@ -174,4 +174,9 @@ public class PriorityThreadBlocker implements ThreadBlocker {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return "PriorityBlocker(" + maxRunningRequests + ", " + priorityProvider + ")";
+    }
 }

--- a/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/QueueController.java
+++ b/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/QueueController.java
@@ -9,8 +9,11 @@ package org.geoserver.flow.controller;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.geoserver.flow.FlowController;
 import org.geoserver.ows.Request;
+import org.geotools.util.logging.Logging;
 
 /**
  * Base class for flow controllers using a queue
@@ -18,11 +21,22 @@ import org.geoserver.ows.Request;
  * @author Juan Marin, OpenGeo
  */
 public abstract class QueueController implements FlowController {
+    private static final Logger LOGGER = Logging.getLogger(QueueController.class);
+
     /** The size of each queue */
-    int queueSize;
+    int queueMaxSize;
 
     /** The per request queue collection */
     Map<String, TimedBlockingQueue> queues = new ConcurrentHashMap<>();
+
+    /** Last time we've performed a queue cleanup */
+    long lastCleanup = System.currentTimeMillis();
+
+    /** Number of queues at which we start looking for purging stale ones */
+    int maxQueues = 100;
+
+    /** Time it takes for an inactive queue to be considered stale */
+    int maxAge = 10000;
 
     @Override
     public boolean requestIncoming(Request request, long timeout) {
@@ -31,7 +45,36 @@ public abstract class QueueController implements FlowController {
 
     @Override
     public int getPriority() {
-        return queueSize;
+        return queueMaxSize;
+    }
+
+    protected void cleanUpQueues(long now) {
+        // cleanup stale queues if necessary
+        int queuesSize = queues.size();
+        if ((queuesSize > maxQueues && (now - lastCleanup) > (maxAge / 10))
+                || (now - lastCleanup) > maxAge) {
+            int cleanupCount = 0;
+            synchronized (this) {
+                for (String key : queues.keySet()) {
+                    TimedBlockingQueue tbq = queues.get(key);
+                    if (now - tbq.lastModified > maxAge && tbq.isEmpty()) {
+                        queues.remove(key);
+                        cleanupCount++;
+                    }
+                }
+                lastCleanup = now;
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(
+                            getClass().getSimpleName()
+                                    + "("
+                                    + queueMaxSize
+                                    + ") purged "
+                                    + cleanupCount
+                                    + " stale queues out of "
+                                    + queuesSize);
+                }
+            }
+        }
     }
 
     @SuppressWarnings("serial")

--- a/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/SimpleThreadBlocker.java
+++ b/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/SimpleThreadBlocker.java
@@ -22,7 +22,10 @@ public class SimpleThreadBlocker implements ThreadBlocker {
      */
     BlockingQueue<Request> queue;
 
+    private final int queueSize;
+
     public SimpleThreadBlocker(int queueSize) {
+        this.queueSize = queueSize;
         queue = new ArrayBlockingQueue<>(queueSize, true);
     }
 
@@ -47,5 +50,10 @@ public class SimpleThreadBlocker implements ThreadBlocker {
             queue.put(request);
             return true;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleBlocker(" + queueSize + ")";
     }
 }

--- a/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/SingleIpFlowController.java
+++ b/src/extension/control-flow/src/main/java/org/geoserver/flow/controller/SingleIpFlowController.java
@@ -15,8 +15,13 @@ package org.geoserver.flow.controller;
 public class SingleIpFlowController extends SingleQueueFlowController {
 
     public SingleIpFlowController(final int queueSize, final String ip) {
-        // building a simpLe thread blocker as this queue is for a single IP, there is no priority
+        // building a simple thread blocker as this queue is for a single IP, there is no priority
         // concept here
         super(new IpRequestMatcher(ip), queueSize, new SimpleThreadBlocker(queueSize));
+    }
+
+    @Override
+    public String toString() {
+        return "SingleIpFlowController(" + matcher + "," + blocker + ")";
     }
 }


### PR DESCRIPTION
[![GEOS-11613](https://badgen.net/badge/JIRA/GEOS-11613/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11613) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->