### PR TITLE
[GEOS-11622] WMS 1.3 should return InvalidCRS exception code when fed an invalid CRS

### DIFF
--- a/.github/workflows/cite.yml
+++ b/.github/workflows/cite.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false  # Prevents other matrix jobs from being canceled if one fails
       matrix:
         #suite: [ogcapi-features10, wcs10, wcs11, wfs10, wfs11, wms10, wms11, wms13]
-        suite: [ogcapi-features10, wms11, wfs10, wfs11, wcs11]
+        suite: [ogcapi-features10, wms11, wms13, wfs10, wfs11, wcs11]
 
     steps:
       - name: Checkout repository (shallow clone)

--- a/build/cite/wms13/wms-1.3.0.xml
+++ b/build/cite/wms13/wms-1.3.0.xml
@@ -7,4 +7,6 @@
  <value key="basic">basic</value>
  <value key="queryable">queryable</value>
  <value key="recommended">recommended</value>
+ <value key="submit">yes</value>
+ <value key="answer">yes</value>
 </values>

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
@@ -984,9 +984,7 @@ public class MapMLWMSTest extends MapMLTestSupport {
     public void testNonExistentProjection() throws Exception {
         String response = new MapMLWMSRequest().name("Polgons").srs("EPSG:9999").getAsString();
 
-        assertTrue(
-                response.contains(
-                        "<ServiceException code=\"InvalidParameterValue\" locator=\"crs\">"));
+        assertTrue(response.contains("<ServiceException code=\"InvalidCRS\" locator=\"crs\">"));
     }
 
     @Test

--- a/src/platform/src/main/java/org/geoserver/platform/ServiceException.java
+++ b/src/platform/src/main/java/org/geoserver/platform/ServiceException.java
@@ -42,6 +42,9 @@ public class ServiceException extends RuntimeException {
      */
     public static final String MAX_MEMORY_EXCEEDED = "MaxMemoryExceeded";
 
+    /** WMS 1.3 invalid CRS exception code */
+    public static String InvalidCRS = "InvalidCRS";
+
     /** Application specfic code. */
     protected String code;
 

--- a/src/wms/src/main/java/org/geoserver/wms/WMS.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMS.java
@@ -1030,10 +1030,7 @@ public class WMS implements ApplicationContextAware {
                 }
             } catch (FactoryException e) {
                 throw new ServiceException(
-                        "Could not decode CRS: " + srs,
-                        e,
-                        ServiceException.INVALID_PARAMETER_VALUE,
-                        "crs");
+                        "Could not decode CRS: " + srs, e, ServiceException.InvalidCRS, "crs");
             }
         }
 

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_3/GetMapIntegrationTest.java
@@ -255,6 +255,26 @@ public class GetMapIntegrationTest extends WMSTestSupport {
     }
 
     @Test
+    public void testInvalidCRS() throws Exception {
+        String baseRequest =
+                "wms?service=wms&version=1.3.0&bbox="
+                        + bbox
+                        + "&styles=&layers="
+                        + layers
+                        + "&format=image/png"
+                        + "&request=GetMap"
+                        + "&width=550"
+                        + "&height=250"
+                        + "&crs=NotACRS";
+
+        // parameter repeated, but with the same value, should work
+        MockHttpServletResponse response = getAsServletResponse(baseRequest);
+        assertEquals("text/xml", getBaseMimeType(response.getContentType()));
+        Document dom = dom(response, true);
+        checkLegacyException(dom, "InvalidCRS", "crs");
+    }
+
+    @Test
     public void testSldBody10() throws Exception {
         MockHttpServletResponse response =
                 getAsServletResponse(


### PR DESCRIPTION
[![GEOS-11622](https://badgen.net/badge/JIRA/GEOS-11622/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11622) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details.
Enables WMS 1.3 CITE tests too.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->