### PR TITLE
ogcapi-features CITE tests: build from official git repository

### DIFF
--- a/build/cite/ogcapi-features10/build-ets.sh
+++ b/build/cite/ogcapi-features10/build-ets.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
 
 # build the ets-ogcapi-features10 Docker image from the
-# (at the time of writing, ogccite/ets-ogcapi-features10:1.8-SNAPSHOT-teamengine-5.4.1)
-# from the geoserver's fork `geoserver/integration` branch, which applies
+# https://github.com/opengeospatial/ets-ogcapi-features10 main repo's master branch,
+# since the required pull request has been merged (https://github.com/opengeospatial/ets-ogcapi-features10/pull/255)
+# but there's no new beta release so far.
+# This will build ogccite/ets-ogcapi-features10:1.8-SNAPSHOT-teamengine-5.4.1
+#
+# May other patches be needed in the future, we'll use the
+# geoserver's fork `geoserver/integration` branch again, which is intended to apply
 # patches to the ets that have not yet being released upstream
 
-echo "Building the ogccite/ets-ogcapi-features10 docker image from the geoserver/integration branch"
+echo "Building the ogccite/ets-ogcapi-features10 docker image from opengeospatial/ets-ogcapi-features10 master branch"
 rm -rf ets-ogcapi-features10
-git clone https://github.com/geoserver/ets-ogcapi-features10.git
+#git clone https://github.com/geoserver/ets-ogcapi-features10.git
+git clone https://github.com/opengeospatial/ets-ogcapi-features10.git
 cd ets-ogcapi-features10
-git checkout geoserver/integration && mvn clean install -Pdocker -DskipTests -ntp
+#git checkout geoserver/integration
+mvn clean install -Pdocker -DskipTests -ntp
 cd ..


### PR DESCRIPTION
Revert to build the `ogccite/ets-ogcapi-features10:1.8-SNAPSHOT-teamengine-5.4.1` docker image for ogcapi-features CITE testing from the official repository's `master` branch now that the [requried fix](https://github.com/opengeospatial/ets-ogcapi-features10/pull/255) is merged.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->