### PR TITLE
ogcapi-features CITE: build 1.8-teamengine-5.7 image out of the 1.8 tag upstream

### DIFF
--- a/build/cite/ogcapi-features10/build-ets.sh
+++ b/build/cite/ogcapi-features10/build-ets.sh
@@ -16,5 +16,6 @@ rm -rf ets-ogcapi-features10
 git clone https://github.com/opengeospatial/ets-ogcapi-features10.git
 cd ets-ogcapi-features10
 #git checkout geoserver/integration
+git checkout 1.8
 mvn clean install -Pdocker -DskipTests -ntp
 cd ..

--- a/build/cite/ogcapi-features10/compose.override.yml
+++ b/build/cite/ogcapi-features10/compose.override.yml
@@ -13,8 +13,8 @@ services:
     # there's ogccite/teamengine-production and ogccite/teamengine-beta
     # that we could use to migrate the other OWS tests to newer teamengine images
     # image: ogccite/ets-ogcapi-features10:1.7.1-teamengine-5.4.1
-    # using :1.8-SNAPSHOT-teamengine-5.7 (as built by make build), waiting for the release of :1.8-teamengine-5.7
-    image: ogccite/ets-ogcapi-features10:1.8-SNAPSHOT-teamengine-5.7
+    # 1.8 is tagged (building 1.8-teamengine-5.7) but no docker image is yet published 
+    image: ogccite/ets-ogcapi-features10:1.8-teamengine-5.7
     healthcheck:
       test: "curl -f http://localhost:8080/teamengine/ || exit 1"
       interval: 15s


### PR DESCRIPTION
Update `build/cite/ogcapi-features10/build-ets.sh` to use the new `1.8` tag and hence the `ogccite/ets-ogcapi-features10:1.8-teamengine-5.7` docker image, which is still not published in dockerhub.

This could be left as-is from now on since at least we now have a stable git tag to build from that includes the required fixes to the test engine.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->