### PR TITLE
Update calls to deprecated methods in DataStoreFinder

### DIFF
--- a/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/ResourcePoolTest.java
@@ -174,12 +174,12 @@ public class ResourcePoolTest extends GeoServerSystemTestSupport {
     @BeforeClass
     public static void registerTestDirectoryStore() {
         // a "catch-all" datastore that will use any File without requiring a filetype/dbtype
-        DataStoreFinder.registerFactrory(TEST_DIRECTORY_STORE_FACTORY_SPI);
+        DataStoreFinder.registerFactory(TEST_DIRECTORY_STORE_FACTORY_SPI);
     }
 
     @AfterClass
     public static void deregisterTestDirectoryStore() {
-        DataStoreFinder.deregisterFactrory(TEST_DIRECTORY_STORE_FACTORY_SPI);
+        DataStoreFinder.deregisterFactory(TEST_DIRECTORY_STORE_FACTORY_SPI);
     }
 
     @Override

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/DataStoreControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/DataStoreControllerTest.java
@@ -53,12 +53,12 @@ public class DataStoreControllerTest extends CatalogRESTTestSupport {
     @BeforeClass
     public static void registerTestDirectoryStore() {
         // a "catch-all" datastore that will use any File without requiring a filetype/dbtype
-        DataStoreFinder.registerFactrory(TEST_DIRECTORY_STORE_FACTORY_SPI);
+        DataStoreFinder.registerFactory(TEST_DIRECTORY_STORE_FACTORY_SPI);
     }
 
     @AfterClass
     public static void deregisterTestDirectoryStore() {
-        DataStoreFinder.deregisterFactrory(TEST_DIRECTORY_STORE_FACTORY_SPI);
+        DataStoreFinder.deregisterFactory(TEST_DIRECTORY_STORE_FACTORY_SPI);
     }
 
     @Before


### PR DESCRIPTION
One more follow up on https://github.com/geotools/geotools/pull/4973 (all QA builds in GeoServer are now failing)

@elahrvivaz when deprecating methods you should make sure that nothing is using them any longer, including in GeoServer. 
We should probably have a "downstream QA" build in GeoTools to prevent this from happening.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->