### PR TITLE
[GEOS-11621] OGC API Services Not Honoring the Skip Misconfigured Layers Setting 2.25.x backport

### DIFF
--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/v1/coverages/CollectionDocument.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/v1/coverages/CollectionDocument.java
@@ -50,6 +50,9 @@ public class CollectionDocument extends AbstractCollectionDocument<CoverageInfo>
         this.title = coverage.getTitle();
         this.description = coverage.getAbstract();
         ReferencedEnvelope bbox = coverage.getLatLonBoundingBox();
+        if (bbox == null) {
+            throw new RuntimeException("Coverage has no bounding box: " + coverage.getName());
+        }
         DateRange timeExtent = TimeExtentCalculator.getTimeExtent(coverage);
         setExtent(new CollectionExtents(bbox, timeExtent));
         this.coverage = coverage;

--- a/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/v1/coverages/CollectionsDocument.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/main/java/org/geoserver/ogcapi/v1/coverages/CollectionsDocument.java
@@ -6,6 +6,7 @@ package org.geoserver.ogcapi.v1.coverages;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -14,8 +15,10 @@ import java.util.logging.Logger;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.config.GeoServer;
+import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.ogcapi.AbstractDocument;
 import org.geoserver.ogcapi.Link;
+import org.geoserver.platform.ServiceException;
 import org.geotools.api.filter.Filter;
 import org.geotools.util.logging.Logging;
 
@@ -30,6 +33,7 @@ public class CollectionsDocument extends AbstractDocument {
 
     private final GeoServer geoServer;
     private final List<String> crs;
+    private final boolean skipInvalid;
 
     public CollectionsDocument(GeoServer geoServer, List<String> crsList) {
         this.geoServer = geoServer;
@@ -38,6 +42,9 @@ public class CollectionsDocument extends AbstractDocument {
         // build the self links
         String path = "ogc/coverages/v1/collections/";
         addSelfLinks(path);
+        skipInvalid =
+                geoServer.getGlobal().getResourceErrorHandling()
+                        == ResourceErrorHandling.SKIP_MISCONFIGURED_LAYERS;
     }
 
     @Override
@@ -61,31 +68,32 @@ public class CollectionsDocument extends AbstractDocument {
                     return true;
                 }
 
-                try {
-                    while (coverages.hasNext()) {
-                        CoverageInfo coverage = coverages.next();
-                        try {
-                            List<String> crs =
-                                    CoveragesService.getCoverageCRS(
-                                            coverage, Collections.singletonList("#/crs"));
-                            CollectionDocument collection =
-                                    new CollectionDocument(geoServer, coverage, crs);
-
-                            next = collection;
-                            return true;
-                        } catch (Exception e) {
-                            // e.g., maybe the plugin to read the format is missing
+                while (coverages.hasNext()) {
+                    CoverageInfo coverage = coverages.next();
+                    try {
+                        List<String> crs =
+                                CoveragesService.getCoverageCRS(
+                                        coverage, Collections.singletonList("#/crs"));
+                        CollectionDocument collection = getCollectionDocument(coverage, coverages);
+                        next = collection;
+                        return next != null;
+                    } catch (Exception e) {
+                        if (skipInvalid) {
                             LOGGER.log(
                                     Level.WARNING,
-                                    "Failed to build collection for "
-                                            + coverage.prefixedName()
-                                            + ", skipping",
+                                    "Skipping coverage type " + coverage.prefixedName());
+                        } else {
+                            LOGGER.log(
+                                    Level.WARNING,
+                                    "Failed to build collection for " + coverage.prefixedName(),
                                     e);
+                            coverages.close();
+                            throw new ServiceException(
+                                    "Failed to iterate over the coverage types in the catalog", e);
                         }
                     }
-                } catch (Exception e) {
-                    LOGGER.log(Level.WARNING, "Failed while iterating over collections", e);
                 }
+
                 coverages.close();
                 return false;
             }
@@ -97,6 +105,14 @@ public class CollectionsDocument extends AbstractDocument {
                 return result;
             }
         };
+    }
+
+    private CollectionDocument getCollectionDocument(
+            CoverageInfo coverage, CloseableIterator<CoverageInfo> coverages) throws IOException {
+        List<String> crs =
+                CoveragesService.getCoverageCRS(coverage, Collections.singletonList("#/crs"));
+        CollectionDocument collection = new CollectionDocument(geoServer, coverage, crs);
+        return collection;
     }
 
     public List<String> getCrs() {

--- a/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/CollectionsTest.java
+++ b/src/community/ogcapi/ogcapi-coverages/src/test/java/org/geoserver/ogcapi/v1/coverages/CollectionsTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.jayway.jsonpath.DocumentContext;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -24,12 +25,15 @@ import net.minidev.json.JSONArray;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.ogcapi.APIDispatcher;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wcs.WCSInfo;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -37,10 +41,37 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 public class CollectionsTest extends CoveragesTestSupport {
 
+    @Before
+    public void revertChanges() throws IOException {
+        CoverageInfo c = getCatalog().getCoverageByName("rs", "BlueMarble");
+        ReferencedEnvelope blueMarbleExtent =
+                new ReferencedEnvelope(
+                        146.49999999999477,
+                        147.99999999999474,
+                        -44.49999999999785,
+                        -42.99999999999787,
+                        c.getCRS());
+        c.setLatLonBoundingBox(blueMarbleExtent);
+        getCatalog().save(c);
+    }
+
     @Test
-    public void testCollectionsJson() throws Exception {
+    public void testSkipMisconfigured() throws Exception {
+        // enable skipping of misconfigured layers
+        GeoServerInfo global = getGeoServer().getGlobal();
+        global.setResourceErrorHandling(ResourceErrorHandling.SKIP_MISCONFIGURED_LAYERS);
+        getGeoServer().save(global);
+
+        CoverageInfo c = getCatalog().getCoverageByName("rs", "BlueMarble");
+        int expected = getCatalog().getCoverages().size();
         DocumentContext json = getAsJSONPath("ogc/coverages/v1/collections", 200);
-        testCollectionsJson(json);
+        assertEquals(expected, (int) json.read("collections.length()", Integer.class));
+        // manually misconfigure one layer
+        c.setLatLonBoundingBox(null);
+        getCatalog().save(c);
+        DocumentContext json2 = getAsJSONPath("ogc/coverages/v1/collections", 200);
+        // expect one fewer layers due to skipping
+        assertEquals(expected - 1, (int) json2.read("collections.length()", Integer.class));
     }
 
     @SuppressWarnings("unchecked") // generics varargs creation by hamcrest

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/CollectionsDocument.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/CollectionsDocument.java
@@ -7,18 +7,23 @@ package org.geoserver.ogcapi.v1.features;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.config.GeoServer;
+import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.ogcapi.AbstractDocument;
 import org.geoserver.ogcapi.Link;
 import org.geoserver.platform.ServiceException;
 import org.geotools.api.filter.Filter;
+import org.geotools.util.logging.Logging;
 
 /**
  * A class representing the OGC API for Features server "collections" in a way that Jackson can
@@ -27,10 +32,11 @@ import org.geotools.api.filter.Filter;
 @JacksonXmlRootElement(localName = "Collections", namespace = "http://www.opengis.net/wfs/3.0")
 @JsonPropertyOrder({"links", "collections"})
 public class CollectionsDocument extends AbstractDocument {
-
+    static final Logger LOGGER = Logging.getLogger(CollectionsDocument.class);
     private final GeoServer geoServer;
     private final List<String> crs;
     private final List<Consumer<CollectionDocument>> collectionDecorators = new ArrayList<>();
+    private final boolean skipInvalid;
 
     public CollectionsDocument(GeoServer geoServer, List<String> crsList) {
         this.geoServer = geoServer;
@@ -40,6 +46,9 @@ public class CollectionsDocument extends AbstractDocument {
         // build the self links
         String path = "ogc/features/v1/collections/";
         addSelfLinks(path);
+        skipInvalid =
+                geoServer.getGlobal().getResourceErrorHandling()
+                        == ResourceErrorHandling.SKIP_MISCONFIGURED_LAYERS;
     }
 
     @Override
@@ -53,7 +62,7 @@ public class CollectionsDocument extends AbstractDocument {
     public Iterator<CollectionDocument> getCollections() {
         CloseableIterator<FeatureTypeInfo> featureTypes =
                 geoServer.getCatalog().list(FeatureTypeInfo.class, Filter.INCLUDE);
-        return new Iterator<CollectionDocument>() {
+        return new Iterator<>() {
 
             CollectionDocument next;
 
@@ -62,32 +71,22 @@ public class CollectionsDocument extends AbstractDocument {
                 if (next != null) {
                     return true;
                 }
-
-                boolean hasNext = featureTypes.hasNext();
-                if (!hasNext) {
-                    featureTypes.close();
-                    return false;
-                } else {
+                while (featureTypes.hasNext()) {
+                    FeatureTypeInfo featureType = featureTypes.next();
                     try {
-                        FeatureTypeInfo featureType = featureTypes.next();
-                        List<String> crs =
-                                FeatureService.getFeatureTypeCRS(
-                                        featureType, Collections.singletonList("#/crs"));
-                        CollectionDocument collection =
-                                new CollectionDocument(geoServer, featureType, crs);
-                        for (Consumer<CollectionDocument> collectionDecorator :
-                                collectionDecorators) {
-                            collectionDecorator.accept(collection);
-                        }
-
-                        next = collection;
+                        next = getCollectionDocument(featureType, featureTypes);
                         return true;
                     } catch (Exception e) {
-                        featureTypes.close();
-                        throw new ServiceException(
-                                "Failed to iterate over the feature types in the catalog", e);
+                        if (skipInvalid) {
+                            LOGGER.log(Level.WARNING, "Skipping feature type " + featureType);
+                        } else {
+                            featureTypes.close();
+                            throw new ServiceException(
+                                    "Failed to iterate over the feature types in the catalog", e);
+                        }
                     }
                 }
+                return next != null;
             }
 
             @Override
@@ -97,6 +96,18 @@ public class CollectionsDocument extends AbstractDocument {
                 return result;
             }
         };
+    }
+
+    private CollectionDocument getCollectionDocument(
+            FeatureTypeInfo featureType, CloseableIterator<FeatureTypeInfo> featureTypes)
+            throws IOException {
+        List<String> crs =
+                FeatureService.getFeatureTypeCRS(featureType, Collections.singletonList("#/crs"));
+        CollectionDocument collection = new CollectionDocument(geoServer, featureType, crs);
+        for (Consumer<CollectionDocument> collectionDecorator : collectionDecorators) {
+            collectionDecorator.accept(collection);
+        }
+        return collection;
     }
 
     public List<String> getCrs() {

--- a/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/CollectionsTest.java
+++ b/src/community/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/CollectionsTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.jayway.jsonpath.DocumentContext;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,6 +28,7 @@ import net.minidev.json.JSONArray;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.config.SettingsInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
@@ -37,6 +39,7 @@ import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wfs.WFSInfo;
 import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.MediaType;
@@ -48,6 +51,8 @@ public class CollectionsTest extends FeaturesTestSupport {
 
     public static final String BASIC_POLYGONS_TITLE = "Basic polygons";
     public static final String BASIC_POLYGONS_DESCRIPTION = "I love basic polygons!";
+    public static final String MISCONFIGURED_TITLE = "Misconfigured";
+    public static final String MISCONFIGURED_DESCRIPTION = "I am misconfigured";
 
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
@@ -63,10 +68,36 @@ public class CollectionsTest extends FeaturesTestSupport {
         getCatalog().save(basicPolygons);
     }
 
+    @Before
+    public void revertChanges() throws IOException {
+        revertLayer(MockData.BUILDINGS);
+    }
+
     @Test
     public void testCollectionsJson() throws Exception {
         DocumentContext json = getAsJSONPath("ogc/features/v1/collections", 200);
         testCollectionsJson(json);
+    }
+
+    @Test
+    public void testSkipMisconfigured() throws Exception {
+        // enable skipping of misconfigured layers
+        GeoServerInfo global = getGeoServer().getGlobal();
+        global.setResourceErrorHandling(ResourceErrorHandling.SKIP_MISCONFIGURED_LAYERS);
+        getGeoServer().save(global);
+        // not misconfigured yet
+        FeatureTypeInfo misconfigured =
+                getCatalog().getFeatureTypeByName(getLayerId(MockData.BUILDINGS));
+
+        DocumentContext json = getAsJSONPath("ogc/features/v1/collections", 200);
+        int expected = getCatalog().getFeatureTypes().size();
+        assertEquals(expected, (int) json.read("collections.length()", Integer.class));
+        // now misconfigure
+        misconfigured.setLatLonBoundingBox(null);
+        getCatalog().save(misconfigured);
+        DocumentContext json2 = getAsJSONPath("ogc/features/v1/collections", 200);
+        // expect one fewer layers due to skipping
+        assertEquals(expected - 1, (int) json2.read("collections.length()", Integer.class));
     }
 
     @SuppressWarnings("unchecked") // generic varargs in matcher

--- a/src/community/ogcapi/ogcapi-maps/src/main/java/org/geoserver/ogcapi/v1/maps/CollectionDocument.java
+++ b/src/community/ogcapi/ogcapi-maps/src/main/java/org/geoserver/ogcapi/v1/maps/CollectionDocument.java
@@ -60,6 +60,9 @@ public class CollectionDocument extends AbstractCollectionDocument<PublishedInfo
     private ReferencedEnvelope getSpatialExtents(PublishedInfo published) {
         try {
             if (published instanceof LayerInfo) {
+                if (((LayerInfo) published).getResource().getLatLonBoundingBox() == null) {
+                    throw new RuntimeException("Layer has no bounding box: " + published);
+                }
                 return ((LayerInfo) published).getResource().getLatLonBoundingBox();
             } else if (published instanceof LayerGroupInfo) {
                 ReferencedEnvelope bounds = ((LayerGroupInfo) published).getBounds();


### PR DESCRIPTION
[![GEOS-11621](https://badgen.net/badge/JIRA/GEOS-11621/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11621) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…ers Setting

Got features test working

added maps collections

added coverages

cleanup

fixed features and coverages not to return null when skipping

fixed nulls for maps

Changed to non-recursion version

removed redundant check

One more redundant

[GEOS-11621] OGC API Services Not Honoring the Skip Misconfigured Layers Setting 2.25.x backport


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->