### PR TITLE
Upgrade wiremock from 2.35.1 to 3.10.0

### DIFF
--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -46,7 +46,7 @@ jobs:
         mvn -B -ntp -nsu -N -f src/pom.xml assembly:single
     - name: Build and package community modules (without tests)
       run: |
-        mvn -B -ntp -U -T3 -DskipTests -PcommunityRelease,assembly -f src/community/pom.xml install
+        mvn -B -ntp -nsu -U -T3 -DskipTests -PcommunityRelease,assembly -f src/community/pom.xml install
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/src/community/security/keycloak/pom.xml
+++ b/src/community/security/keycloak/pom.xml
@@ -125,8 +125,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/pom.xml
@@ -128,8 +128,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdConnectIntegrationTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdConnectIntegrationTest.java
@@ -119,7 +119,7 @@ public class OpenIdConnectIntegrationTest extends GeoServerSystemTestSupport {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        openIdService.shutdown();
+        openIdService.stop();
     }
 
     @Override

--- a/src/community/web-service-auth/pom.xml
+++ b/src/community/web-service-auth/pom.xml
@@ -61,8 +61,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/web-service-auth/src/test/java/org/geoserver/security/auth/WebAuthProviderTest.java
+++ b/src/community/web-service-auth/src/test/java/org/geoserver/security/auth/WebAuthProviderTest.java
@@ -29,6 +29,7 @@ import org.geoserver.security.auth.web.WebServiceAuthenticationProvider;
 import org.geoserver.security.config.BasicAuthenticationFilterConfig;
 import org.geoserver.security.filter.GeoServerBasicAuthenticationFilter;
 import org.geoserver.security.impl.GeoServerRole;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.http.MediaType;
@@ -96,6 +97,11 @@ public class WebAuthProviderTest extends AbstractAuthenticationProviderTest {
                                         .withStatus(401)
                                         .withHeader("Content-Type", MediaType.TEXT_PLAIN_VALUE)
                                         .withBody(NO_AUTH_RESPONSE)));
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        externalHTTPService.stop();
     }
 
     @Override

--- a/src/extension/mapml/pom.xml
+++ b/src/extension/mapml/pom.xml
@@ -119,8 +119,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLBaseProxyTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLBaseProxyTest.java
@@ -59,7 +59,7 @@ public class MapMLBaseProxyTest extends MapMLTestSupport {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        mockService.shutdown();
+        mockService.stop();
     }
 
     protected static final String BASE_REQUEST =

--- a/src/extension/wps/wps-core/pom.xml
+++ b/src/extension/wps/wps-core/pom.xml
@@ -135,8 +135,8 @@
       <artifactId>gt-csv</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteURLCheckTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/ExecuteURLCheckTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.io.IOUtils;
 import org.geoserver.security.urlchecks.GeoServerURLChecker;
 import org.geoserver.security.urlchecks.RegexURLCheck;
 import org.geoserver.security.urlchecks.URLCheckDAO;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -64,6 +65,11 @@ public class ExecuteURLCheckTest extends WPSTestSupport {
         try (InputStream is = ExecuteURLCheckTest.class.getResourceAsStream(resource)) {
             return IOUtils.toString(is, StandardCharsets.UTF_8);
         }
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        service.stop();
     }
 
     @Before

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1774,9 +1774,9 @@
         <version>${hazelcast.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8-standalone</artifactId>
-        <version>2.35.1</version>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock-standalone</artifactId>
+        <version>3.10.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.erosb</groupId>

--- a/src/web/core/pom.xml
+++ b/src/web/core/pom.xml
@@ -137,8 +137,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/WMSStoreNewPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/WMSStoreNewPageTest.java
@@ -67,7 +67,7 @@ public class WMSStoreNewPageTest extends GeoServerWicketTestSupport {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        wmsService.shutdown();
+        wmsService.stop();
     }
 
     @Before

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/WMTSStoreNewPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/WMTSStoreNewPageTest.java
@@ -70,7 +70,7 @@ public class WMTSStoreNewPageTest extends GeoServerWicketTestSupport {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        wmtsService.shutdown();
+        wmtsService.stop();
     }
 
     @Before

--- a/src/wms/pom.xml
+++ b/src/wms/pom.xml
@@ -150,8 +150,8 @@
       <artifactId>httpclient-cache</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapURLCheckersTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/wms_1_1_1/GetMapURLCheckersTest.java
@@ -147,7 +147,7 @@ public class GetMapURLCheckersTest extends WMSTestSupport {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        service.shutdown();
+        service.stop();
     }
 
     @Before


### PR DESCRIPTION
Upgrade the wiremock dependency to the current version. GeoServer uses the standalone JAR which includes all of its dependencies under a separate package so it isn't impacted by wiremock's Tomcat 11 and Jakarta EE dependencies.

The assembly workflow was updated to ensure that community modules are built using the root GeoServer POM from the local PR branch and not what is published in the public Maven repository which would cause invalid POM errors when a PR adds or changes a dependency's groupId/artifactId in the root POM.

One of the WPS test classes was updated to properly use the class rule which improves performance when the test classes contain a lot of tests. Some tests that programmatically handle the wiremock server weren't shutting down the server when the tests were finished and some other tests were changed to call stop() instead of shutdown() which is the documented way to stop the server.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->