### PR TITLE
Github actions: updating artifact upload/download to v4

### DIFF
--- a/.github/workflows/cite.yml
+++ b/.github/workflows/cite.yml
@@ -42,7 +42,7 @@ jobs:
         run: make war
 
       - name: Upload geoserver.war as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: geoserver-war
           path: build/cite/geoserver/geoserver.war
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 1
 
       - name: Download geoserver.war artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: geoserver-war
           path: build/cite/geoserver/
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload logs folder
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cite-${{ matrix.suite }}-logs
           path: build/cite/logs/


### PR DESCRIPTION
Received a mail that v3 is going to be brownout-ed soon and then effectively removed January 30th 2025.
Updating to v4.

See:
* https://github.com/actions/download-artifact
* https://github.com/actions/upload-artifact

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->