### PR TITLE
[2.26.x backport] [GEOS-11636] Store panels won't always show feedback in target panels

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
@@ -84,6 +84,7 @@ public class GeoServerApplication extends WebApplication
 
     /** Name of the cookie used to remember the chosen language across sessions */
     public static final String LANGUAGE_COOKIE_NAME = "GeoServerUILanguage";
+
     /** Default cookie expiration date (one year) */
     public static final int LANGUAGE_COOKIE_AGE = 365 * 24 * 60 * 60;
 

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/AbstractCoverageStorePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/AbstractCoverageStorePage.java
@@ -138,6 +138,7 @@ abstract class AbstractCoverageStorePage extends GeoServerSecuredPage {
             protected void onError(AjaxRequestTarget target, Form form) {
                 super.onError(target, form);
                 target.add(paramsForm);
+                addFeedbackPanels(target);
             }
 
             @Override
@@ -149,6 +150,7 @@ abstract class AbstractCoverageStorePage extends GeoServerSecuredPage {
                     paramsForm.error(e.getMessage());
                     target.add(paramsForm);
                 }
+                addFeedbackPanels(target);
             }
         };
     }
@@ -160,6 +162,7 @@ abstract class AbstractCoverageStorePage extends GeoServerSecuredPage {
             protected void onError(AjaxRequestTarget target, Form form) {
                 super.onError(target, form);
                 target.add(paramsForm);
+                addFeedbackPanels(target);
             }
 
             @Override
@@ -171,6 +174,7 @@ abstract class AbstractCoverageStorePage extends GeoServerSecuredPage {
                     paramsForm.error(e.getMessage());
                     target.add(paramsForm);
                 }
+                addFeedbackPanels(target);
             }
         };
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/AbstractDataAccessPage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/AbstractDataAccessPage.java
@@ -167,6 +167,7 @@ abstract class AbstractDataAccessPage extends GeoServerSecuredPage {
                     protected void onError(AjaxRequestTarget target, Form form) {
                         super.onError(target, form);
                         target.add(paramsForm);
+                        addFeedbackPanels(target);
                     }
 
                     @Override
@@ -178,6 +179,7 @@ abstract class AbstractDataAccessPage extends GeoServerSecuredPage {
                             paramsForm.error(e.getMessage());
                             target.add(paramsForm);
                         }
+                        addFeedbackPanels(target);
                     }
                 });
 
@@ -194,6 +196,7 @@ abstract class AbstractDataAccessPage extends GeoServerSecuredPage {
             protected void onError(AjaxRequestTarget target, Form form) {
                 super.onError(target, form);
                 target.add(paramsForm);
+                addFeedbackPanels(target);
             }
 
             @Override
@@ -205,6 +208,7 @@ abstract class AbstractDataAccessPage extends GeoServerSecuredPage {
                     paramsForm.error(e.getMessage());
                     target.add(paramsForm);
                 }
+                addFeedbackPanels(target);
             }
         };
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/AbstractWMSStorePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/AbstractWMSStorePage.java
@@ -231,6 +231,7 @@ abstract class AbstractWMSStorePage extends GeoServerSecuredPage {
             protected void onError(AjaxRequestTarget target, Form form) {
                 super.onError(target, form);
                 target.add(form);
+                addFeedbackPanels(target);
             }
 
             @Override
@@ -250,6 +251,7 @@ abstract class AbstractWMSStorePage extends GeoServerSecuredPage {
                     form.error(e.getMessage());
                     target.add(form);
                 }
+                addFeedbackPanels(target);
             }
         };
     }

--- a/src/web/core/src/main/java/org/geoserver/web/data/store/AbstractWMTSStorePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/store/AbstractWMTSStorePage.java
@@ -227,6 +227,7 @@ abstract class AbstractWMTSStorePage extends GeoServerSecuredPage {
             protected void onError(AjaxRequestTarget target, Form form) {
                 super.onError(target, form);
                 target.add(form);
+                addFeedbackPanels(target);
             }
 
             @Override
@@ -246,6 +247,7 @@ abstract class AbstractWMTSStorePage extends GeoServerSecuredPage {
                     form.error(e.getMessage());
                     target.add(form);
                 }
+                addFeedbackPanels(target);
             }
         };
     }

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/CoverageStoreNewPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/CoverageStoreNewPageTest.java
@@ -241,12 +241,10 @@ public class CoverageStoreNewPageTest extends GeoServerWicketTestSupport {
 
             List<Serializable> messages = tester.getMessages(FeedbackMessage.ERROR);
             assertEquals(1, messages.size());
-            assertThat(
-                    messages.get(0).toString(),
-                    allOf(
-                            containsString("Access to "),
-                            containsString(tazbmOutside.getAbsolutePath()),
-                            containsString(" denied by file sandboxing")));
+            checkSandboxDeniedMessage(messages.get(0).toString(), tazbmOutside);
+
+            // the error got actually rendered
+            checkSandboxDeniedMessage(tester.getLastResponseAsString(), tazbmOutside);
 
             // now save within the sandbox instead
             tester.clearFeedbackMessages();
@@ -267,5 +265,14 @@ public class CoverageStoreNewPageTest extends GeoServerWicketTestSupport {
             System.clearProperty(GEOSERVER_DATA_SANDBOX);
             GeoServerExtensions.bean(DefaultFileAccessManager.class).reload();
         }
+    }
+
+    private static void checkSandboxDeniedMessage(String message, File tazbmOutside) {
+        assertThat(
+                message,
+                allOf(
+                        containsString("Access to "),
+                        containsString(tazbmOutside.getAbsolutePath()),
+                        containsString(" denied by file sandboxing")));
     }
 }

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/DataAccessEditPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/DataAccessEditPageTest.java
@@ -355,13 +355,11 @@ public class DataAccessEditPageTest extends GeoServerWicketTestSupport {
 
             List<Serializable> messages = tester.getMessages(FeedbackMessage.ERROR);
             assertEquals(1, messages.size());
-            assertThat(
-                    messages.get(0).toString(),
-                    allOf(
-                            containsString("Access to "),
-                            containsString(toppPath),
-                            containsString(" denied by file sandboxing")));
+            checkSandboxDeniedMessage(messages.get(0).toString(), toppPath);
             tester.clearFeedbackMessages();
+
+            // the error got actually rendered
+            checkSandboxDeniedMessage(tester.getLastResponseAsString(), toppPath);
 
             // now try within the sandbox
             form = tester.newFormTester("dataStoreForm");
@@ -380,5 +378,14 @@ public class DataAccessEditPageTest extends GeoServerWicketTestSupport {
             layerSecurity.delete();
             fam.reload();
         }
+    }
+
+    private static void checkSandboxDeniedMessage(String message, String toppPath) {
+        assertThat(
+                message,
+                allOf(
+                        containsString("Access to "),
+                        containsString(toppPath),
+                        containsString(" denied by file sandboxing")));
     }
 }

--- a/src/web/core/src/test/java/org/geoserver/web/data/store/DataAccessNewPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/store/DataAccessNewPageTest.java
@@ -301,13 +301,11 @@ public class DataAccessNewPageTest extends GeoServerWicketTestSupport {
 
             List<Serializable> messages = tester.getMessages(FeedbackMessage.ERROR);
             assertEquals(1, messages.size());
-            assertThat(
-                    messages.get(0).toString(),
-                    allOf(
-                            containsString("Access to "),
-                            containsString(toppPath),
-                            containsString(" denied by file sandboxing")));
+            checkSandboxDeniedMessage(messages.get(0).toString(), toppPath);
             tester.clearFeedbackMessages();
+
+            // the error got actually rendered
+            checkSandboxDeniedMessage(tester.getLastResponseAsString(), toppPath);
 
             // now try within the sandbox
             String citePath = citeFolder.getAbsolutePath();
@@ -329,5 +327,14 @@ public class DataAccessNewPageTest extends GeoServerWicketTestSupport {
             layerSecurity.delete();
             fam.reload();
         }
+    }
+
+    private static void checkSandboxDeniedMessage(String message, String toppPath) {
+        assertThat(
+                message,
+                allOf(
+                        containsString("Access to "),
+                        containsString(toppPath),
+                        containsString(" denied by file sandboxing")));
     }
 }


### PR DESCRIPTION
[![GEOS-11636](https://badgen.net/badge/JIRA/GEOS-11636/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11636) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Same tests , different implementation in wicket 7

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->