### PR TITLE
[GEOS-11637] DGGS min/max resolution settings stop working after restart

### DIFF
--- a/src/community/ogcapi/dggs/dggs-core/src/main/java/org/geotools/dggs/gstore/DGGSResolutionCalculator.java
+++ b/src/community/ogcapi/dggs/dggs-core/src/main/java/org/geotools/dggs/gstore/DGGSResolutionCalculator.java
@@ -103,11 +103,7 @@ public class DGGSResolutionCalculator {
         if (sd != null) {
             distance = Optional.of(scaleToDistance(DefaultGeographicCRS.WGS84, sd));
         } else {
-            distance =
-                    Optional.ofNullable(hints.get(Hints.GEOMETRY_DISTANCE))
-                            .filter(Number.class::isInstance)
-                            .map(Number.class::cast)
-                            .map(n -> n.doubleValue());
+            distance = getDoubleHint(hints, Hints.GEOMETRY_DISTANCE);
         }
 
         // do we have a resoution delta?
@@ -139,8 +135,15 @@ public class DGGSResolutionCalculator {
      * Optional}.
      */
     private Optional<Integer> getIntegerHint(Hints hints, Object key) {
-        return Optional.ofNullable((Integer) hints.get(key))
-                .map(n -> safeConvert(n, Integer.class));
+        return Optional.ofNullable(hints.get(key)).map(n -> safeConvert(n, Integer.class));
+    }
+
+    /**
+     * Given the hints and a key, returns the double value associated with the key, as an {@link
+     * Optional}.
+     */
+    private Optional<Double> getDoubleHint(Hints hints, Object key) {
+        return Optional.ofNullable(hints.get(key)).map(n -> safeConvert(n, Double.class));
     }
 
     /**

--- a/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.html
+++ b/src/community/ogcapi/dggs/web-dggs/src/main/java/org/geoserver/web/publish/dggs/DGGSConfigPanel.html
@@ -12,7 +12,7 @@
           <input id="minResolution" class="text" type="text" wicket:id="minResolution"></input>
         </li>
         <li>
-          <label for="maxResolution"><wicket:message key="minResolution">maxResolution</wicket:message></label>
+          <label for="maxResolution"><wicket:message key="maxResolution">maxResolution</wicket:message></label>
           <input id="maxResolution" class="text" type="text" wicket:id="maxResolution"></input>
         </li>
         <li>

--- a/src/community/ogcapi/dggs/web-dggs/src/test/java/org/geoserver/dggs/DGGSIntegrationTest.java
+++ b/src/community/ogcapi/dggs/web-dggs/src/test/java/org/geoserver/dggs/DGGSIntegrationTest.java
@@ -1,0 +1,77 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.dggs;
+
+import static org.junit.Assert.assertEquals;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.dggs.gstore.DGGSGeometryStoreFactory;
+import org.geotools.dggs.gstore.DGGSResolutionCalculator;
+import org.geotools.feature.NameImpl;
+import org.junit.Test;
+
+public class DGGSIntegrationTest extends GeoServerSystemTestSupport {
+
+    public static final String TYPENAME = "h3-geometry";
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        Catalog catalog = getCatalog();
+        CatalogBuilder cb = new CatalogBuilder(catalog);
+        DataStoreInfo ds = cb.buildDataStore("h3");
+        ds.getConnectionParameters().put(DGGSGeometryStoreFactory.DGGS_FACTORY_ID.key, "H3");
+        catalog.add(ds);
+
+        cb.setStore(ds);
+        FeatureTypeInfo ft =
+                cb.buildFeatureType(new NameImpl(catalog.getDefaultNamespace().getURI(), "H3"));
+        // alternative name, will ensure a retype feature source is used
+        ft.setName(TYPENAME);
+        // set the min/max resolutions as strings (that's how they are stored anyways)
+        ft.getMetadata().put(DGGSResolutionCalculator.CONFIGURED_MINRES_KEY, "0");
+        ft.getMetadata().put(DGGSResolutionCalculator.CONFIGURED_MAXRES_KEY, "3");
+        catalog.add(ft);
+
+        LayerInfo layer = cb.buildLayer(ft);
+        catalog.add(layer);
+    }
+
+    /**
+     * Does an end to end test of the DGGS extension, by querying the WMS service for the layer
+     * created in the setup, with a different name (to test the retype feature source) and with
+     * resolution settings configured as string.
+     */
+    @Test
+    public void testGetFeatureInfo() throws Exception {
+        String url =
+                "wms?service=WMS&version=1.1.0&request=GetFeatureInfo&layers="
+                        + TYPENAME
+                        + "&styles=&bbox=-180.0,-90.0,180.0,90.0&width=200&height=100&srs=EPSG:4326&format=image/png&info_format=application/json&query_layers="
+                        + TYPENAME
+                        + "&x=100&y=50";
+        JSONObject json = (JSONObject) getAsJSON(url);
+        print(json);
+        assertEquals("FeatureCollection", json.getString("type"));
+        JSONArray features = json.getJSONArray("features");
+        assertEquals(1, features.size());
+        JSONObject feature = features.getJSONObject(0);
+        assertEquals("Feature", feature.getString("type"));
+        JSONObject properties = feature.getJSONObject("properties");
+        assertEquals("0", properties.getString("resolution"));
+        assertEquals("8083fffffffffff", properties.getString("zoneId"));
+        assertEquals("hexagon", properties.getString("shape"));
+    }
+}


### PR DESCRIPTION
[![GEOS-11637](https://badgen.net/badge/JIRA/GEOS-11637/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11637) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Along with it, there is a quick fix for renamed DGGS layers and a GUI label fix.e

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->