### PR TITLE
[GEOS-11644] Introducing the rest/security/acl/catalog/reload rest endpoint

### DIFF
--- a/doc/en/api/1.0.0/security.yaml
+++ b/doc/en/api/1.0.0/security.yaml
@@ -198,6 +198,41 @@ paths:
         405:
           description: Method Not Allowed
 
+  /rest/security/acl/catalog/reload:
+    get:
+      operationId: getReload
+      tags:
+       - "Reload"
+      description: Invalid. Use PUT or POST to reload the catalog and configuation.
+      responses:
+        405:
+          description: Method Not Allowed
+    put:
+      operationId: putReload
+      tags:
+       - "Reload"
+      summary: Reload the configuration from disk, and reset all caches.
+      description: Reloads the GeoServer Security Manager catalog and configuration from disk. This operation is used in cases where an external tool has modified the on-disk configuration.
+      responses:
+        200:
+          description: OK
+    post:
+      operationId: postReload
+      tags:
+       - "Reload"
+      summary: Reload the configuration from disk, and reset all caches.
+      description: Reloads the GeoServer Security Manager catalog and configuration from disk. This operation is used in cases where an external tool has modified the on-disk configuration.
+      responses:
+        200:
+          description: OK
+    delete:
+      operationId: deleteReload
+      tags:
+       - "Reload"
+      description: Invalid. Use PUT or POST to reload the catalog and configuation.
+      responses:
+        405:
+          description: Method Not Allowed
 
   /rest/security/acl/layers:
 

--- a/src/restconfig/src/main/java/org/geoserver/rest/security/CatalogSecurityController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/security/CatalogSecurityController.java
@@ -1,0 +1,42 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.security;
+
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.rest.RestException;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/** CatalogSecurityController provides REST endpoints to Reload GeoServer's SecurityManager */
+@RestController
+@RequestMapping(path = RestBaseController.ROOT_PATH + "/security/acl/catalog")
+public class CatalogSecurityController {
+
+    GeoServerSecurityManager getSecurityManager() {
+        return GeoServerExtensions.bean(GeoServerSecurityManager.class);
+    }
+
+    protected void checkUserIsAdmin() {
+        if (!getSecurityManager().checkAuthenticationForAdminRole()) {
+            throw new RestException("Administrative privileges required", HttpStatus.FORBIDDEN);
+        }
+    }
+
+    // Existing endpoints for GET/PUT on catalog mode...
+    // -----------------------------------------------
+
+    /** Reload endpoint for /acl/catalog POST or PUT /geoserver/rest/security/acl/catalog/reload */
+    @RequestMapping(
+            value = "/reload",
+            method = {RequestMethod.POST, RequestMethod.PUT})
+    public void reloadCatalogSecurity() throws Exception {
+        checkUserIsAdmin();
+        getSecurityManager().reload();
+    }
+}


### PR DESCRIPTION
[![GEOS-11644](https://badgen.net/badge/JIRA/GEOS-11644/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11644) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

By default, the rest/catalog/reload GeoServer REST endpoint only refreshes the GeoServer catalog and does not reload the Security Manager. To address this limitation, we propose adding a dedicated endpoint that allows an administrator to programmatically trigger a Security Manager reload.

This feature is particularly useful when batch operations directly modify security files on disk (e.g., adding or removing roles), and the updated information must be reflected in memory without requiring a full GeoServer restart. By exposing this new endpoint, administrators can ensure the Security Manager picks up changes to the security configuration immediately.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->