### PR TITLE
[GEOS-11647] Restore "quiet on not found" configuration for REST in global settings

### DIFF
--- a/src/rest/pom.xml
+++ b/src/rest/pom.xml
@@ -61,4 +61,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- required for logging related tests in ExceptionHandlingTest not to interfere with each other -->
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/rest/src/main/java/org/geoserver/rest/RestControllerAdvice.java
+++ b/src/rest/src/main/java/org/geoserver/rest/RestControllerAdvice.java
@@ -147,9 +147,8 @@ public class RestControllerAdvice extends ResponseEntityExceptionHandler {
     }
 
     private boolean isQuietOnNotFound(WebRequest request) {
-        return Boolean.parseBoolean(
-                        request.getParameter("quietOnNotFound")) // yes this is seriously a thing
-                || quietOnNotFoundEnabled();
+        String parameter = request.getParameter("quietOnNotFound"); // yes this is seriously a thing
+        return Boolean.parseBoolean(parameter) || quietOnNotFoundEnabled();
     }
 
     /**

--- a/src/rest/src/main/java/org/geoserver/rest/util/RESTUtils.java
+++ b/src/rest/src/main/java/org/geoserver/rest/util/RESTUtils.java
@@ -56,6 +56,10 @@ public class RESTUtils {
 
     public static final String ROOT_KEY = "root";
 
+    /**
+     * Key used to store the boolean in the {@link GeoServerInfo#getSettings() global settings}
+     * metadata map
+     */
     public static final String QUIET_ON_NOT_FOUND_KEY = "quietOnNotFound";
 
     /**

--- a/src/rest/src/test/java/org/geoserver/rest/ExceptionHandlingTest.java
+++ b/src/rest/src/test/java/org/geoserver/rest/ExceptionHandlingTest.java
@@ -4,11 +4,23 @@
  */
 package org.geoserver.rest;
 
+import static org.geoserver.rest.RestBaseController.ROOT_PATH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 
+import java.util.List;
 import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerInfo;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.rest.util.RESTUtils;
 import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -19,18 +31,24 @@ public class ExceptionHandlingTest extends GeoServerSystemTestSupport {
         // no data needed for this test
     }
 
-    /*
-     * Override getAsServletResponse(path) to quiet RestControllerAdvice logger.
-     */
-    @Override
-    protected MockHttpServletResponse getAsServletResponse(String path) throws Exception {
-        Level level = RestControllerAdvice.LOGGER.getLevel();
+    private Level level;
+
+    @Before
+    public void disableRestControllerAdviceLogging() {
+        level = RestControllerAdvice.LOGGER.getLevel();
         RestControllerAdvice.LOGGER.setLevel(Level.OFF);
-        try {
-            return super.getAsServletResponse(path);
-        } finally {
-            RestControllerAdvice.LOGGER.setLevel(level);
-        }
+    }
+
+    @After
+    public void enableRestControllerAdviceLogging() {
+        RestControllerAdvice.LOGGER.setLevel(level);
+    }
+
+    @After
+    public void resetQuietOnNotFountConfig() {
+        GeoServerInfo global = getGeoServer().getGlobal();
+        global.getSettings().getMetadata().remove(RESTUtils.QUIET_ON_NOT_FOUND_KEY);
+        getGeoServer().save(global);
     }
 
     @Test
@@ -46,8 +64,7 @@ public class ExceptionHandlingTest extends GeoServerSystemTestSupport {
 
     @Test
     public void testInternalError() throws Exception {
-        MockHttpServletResponse response =
-                getAsServletResponse(RestBaseController.ROOT_PATH + "/error");
+        MockHttpServletResponse response = getAsServletResponse(ROOT_PATH + "/error");
         assertEquals(500, response.getStatus());
         assertEquals("text/plain", response.getContentType());
         String txt = response.getContentAsString();
@@ -56,18 +73,76 @@ public class ExceptionHandlingTest extends GeoServerSystemTestSupport {
 
     @Test
     public void testNotFound() throws Exception {
-        MockHttpServletResponse response =
-                getAsServletResponse(RestBaseController.ROOT_PATH + "/notfound");
-        assertEquals(404, response.getStatus());
+        MockHttpServletResponse response = assertNotFound(ROOT_PATH + "/notfound");
         assertEquals("text/plain", response.getContentType());
         String txt = response.getContentAsString();
         assertEquals("I'm not there", txt);
     }
 
     @Test
+    public void testQuietOnNotFoundLogging_default() throws Exception {
+        String path = ROOT_PATH + "/notfound";
+        List<String> loggingMessages = captureNotFoundLogs(path);
+        assertThat(loggingMessages, is(not(empty())));
+    }
+
+    @Test
+    public void testQuietOnNotFoundLogging_queryParam() throws Exception {
+        String path = ROOT_PATH + "/notfound?quietOnNotFound=true";
+        List<String> loggingMessages = captureNotFoundLogs(path);
+        assertThat(loggingMessages, is(empty()));
+
+        path = ROOT_PATH + "/notfound?quietOnNotFound=false";
+        loggingMessages = captureNotFoundLogs(path);
+        assertThat(loggingMessages, is(not(empty())));
+    }
+
+    @Test
+    public void testQuietOnNotFoundLogging_globalSettings() throws Exception {
+        GeoServer geoserver = super.getGeoServer();
+
+        final String path = ROOT_PATH + "/notfound";
+        List<String> loggingMessages;
+
+        loggingMessages = captureNotFoundLogs(path);
+        assertThat(loggingMessages, is(not(empty())));
+
+        GeoServerInfo global;
+        global = geoserver.getGlobal();
+        global.getSettings().getMetadata().put(RESTUtils.QUIET_ON_NOT_FOUND_KEY, false);
+        geoserver.save(global);
+
+        loggingMessages = captureNotFoundLogs(path);
+        assertThat(loggingMessages, is(not(empty())));
+
+        global = geoserver.getGlobal();
+        global.getSettings().getMetadata().put(RESTUtils.QUIET_ON_NOT_FOUND_KEY, true);
+        geoserver.save(global);
+        loggingMessages = captureNotFoundLogs(path);
+        assertThat(loggingMessages, is(empty()));
+    }
+
+    private List<String> captureNotFoundLogs(String path) throws Exception {
+        Logger logger = RestControllerAdvice.LOGGER;
+        logger.setLevel(Level.SEVERE);
+        LoggingCapturer capturer = new LoggingCapturer(RestControllerAdvice.LOGGER).start();
+        try {
+            assertNotFound(path);
+        } finally {
+            capturer.stop();
+        }
+        return capturer.getMessages();
+    }
+
+    private MockHttpServletResponse assertNotFound(String path) throws Exception {
+        MockHttpServletResponse response = getAsServletResponse(path);
+        assertEquals(404, response.getStatus());
+        return response;
+    }
+
+    @Test
     public void testNullPointerException() throws Exception {
-        MockHttpServletResponse response =
-                getAsServletResponse(RestBaseController.ROOT_PATH + "/npe");
+        MockHttpServletResponse response = getAsServletResponse(ROOT_PATH + "/npe");
         assertEquals(500, response.getStatus());
         assertEquals("text/plain", response.getContentType());
         String txt = response.getContentAsString();

--- a/src/rest/src/test/java/org/geoserver/rest/LoggingCapturer.java
+++ b/src/rest/src/test/java/org/geoserver/rest/LoggingCapturer.java
@@ -1,0 +1,127 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.geotools.util.logging.Log4J2Logger;
+import org.geotools.util.logging.LoggerAdapter;
+
+class LoggingCapturer {
+
+    private Logger logger;
+    private List<String> messages = List.of();
+
+    private CapturingAdaptor capturer;
+
+    private static interface CapturingAdaptor {
+        void startCapturing();
+
+        void stopCapturing();
+    }
+
+    public LoggingCapturer(Logger logger) {
+        this.logger = logger;
+    }
+
+    public LoggingCapturer start() {
+        stop();
+        capturer = createCapturer();
+        messages = new CopyOnWriteArrayList<>();
+        capturer.startCapturing();
+        return this;
+    }
+
+    /** Unregisters the handler to capture the log events */
+    public List<String> stop() {
+        if (null != capturer) {
+            capturer.stopCapturing();
+        }
+        capturer = null;
+        return getMessages();
+    }
+
+    public List<String> getMessages() {
+        return List.copyOf(messages);
+    }
+
+    private CapturingAdaptor createCapturer() {
+        if (logger instanceof LoggerAdapter) {
+            if (logger instanceof Log4J2Logger) {
+                return new Log4j2Capturer();
+            }
+            throw new UnsupportedOperationException(
+                    "There's capturing adapter for " + logger.getClass().getCanonicalName());
+        }
+
+        return new JULCapturer();
+    }
+
+    private class JULCapturer extends java.util.logging.Handler implements CapturingAdaptor {
+
+        @Override
+        public void startCapturing() {
+            logger.addHandler(this);
+        }
+
+        @Override
+        public void stopCapturing() {
+            logger.removeHandler(this);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            messages.add(record.getMessage());
+        }
+
+        @Override
+        public void flush() {
+            // no-op
+        }
+
+        @Override
+        public void close() throws SecurityException {
+            // no-op
+        }
+    }
+
+    private class Log4j2Capturer extends AbstractAppender implements CapturingAdaptor {
+
+        org.apache.logging.log4j.core.Logger coreLogger;
+
+        public Log4j2Capturer() {
+            super("TestCapturingAppender", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void startCapturing() {
+            String name = logger.getName();
+            org.apache.logging.log4j.Logger log4jLogger = LogManager.getLogger(name);
+            // Get the root logger's configuration
+            coreLogger = (org.apache.logging.log4j.core.Logger) log4jLogger;
+            coreLogger.addAppender(this);
+            super.start(); // Start the custom appender
+        }
+
+        @Override
+        public void stopCapturing() {
+            if (null != coreLogger) {
+                coreLogger.removeAppender(this);
+                coreLogger = null;
+            }
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-11647](https://badgen.net/badge/JIRA/GEOS-11647/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11647) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

In [this commit](e57616971c4c11f6efdd7d12b855b509fbbe9ae1) from 2014, each resource lookup in the REST API would check for the configuration setting, and avoid throwing `RestletException` (which we use `ResourceNotFoundException` for those cases).

For example:

```
boolean quietOnNotFound=quietOnNotFoundEnabled(request)
if(quietOnNotFound){
    return null;
}
throw new RestletException( "No such layer: " + layer, Status.CLIENT_ERROR_NOT_FOUND );
```

Now the checkbox to enable it persists in `org.geoserver.web.RESTSettingsPanel` but it has no effect, and the only way to silence the log flooding is by adding a `?quietOnNotFound=true` parameter to every REST API request.

Make `org.geserver.rest.RestControllerAdvice` account for either the request parameter or the global settings configuration when deciding if it'll log the stack trace or not.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->