### PR TITLE
[GEOS-11654] Fix multiline strings that are missing a space between the lines

### DIFF
--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/request/TemplatePathVisitor.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/request/TemplatePathVisitor.java
@@ -90,8 +90,7 @@ public class TemplatePathVisitor extends DuplicatingFilterVisitor {
             }
         } catch (Throwable ex) {
             throw new RuntimeException(
-                    "Unable to evaluate template path against "
-                            + "the template. Cause: "
+                    "Unable to evaluate template path against the template. Cause: "
                             + ex.getMessage());
         }
         return null;

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/request/TemplatePathVisitor.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/request/TemplatePathVisitor.java
@@ -90,7 +90,7 @@ public class TemplatePathVisitor extends DuplicatingFilterVisitor {
             }
         } catch (Throwable ex) {
             throw new RuntimeException(
-                    "Unable to evaluate template path against"
+                    "Unable to evaluate template path against "
                             + "the template. Cause: "
                             + ex.getMessage());
         }

--- a/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIBBoxParser.java
+++ b/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIBBoxParser.java
@@ -145,9 +145,7 @@ public class APIBBoxParser {
         // check to make sure that the bounding box has 4 coordinates
         if (unparsed.size() < 4) {
             throw new IllegalArgumentException(
-                    "Requested bounding box contains wrong "
-                            + "number of coordinates (should have "
-                            + "4): "
+                    "Requested bounding box contains wrong number of coordinates (should have 4): "
                             + unparsed.size());
         }
 

--- a/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIBBoxParser.java
+++ b/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIBBoxParser.java
@@ -145,7 +145,7 @@ public class APIBBoxParser {
         // check to make sure that the bounding box has 4 coordinates
         if (unparsed.size() < 4) {
             throw new IllegalArgumentException(
-                    "Requested bounding box contains wrong"
+                    "Requested bounding box contains wrong "
                             + "number of coordinates (should have "
                             + "4): "
                             + unparsed.size());

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ApiTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/ApiTest.java
@@ -327,7 +327,7 @@ public class ApiTest extends FeaturesTestSupport {
     public void testFilterCRS() throws Exception {
         fail(
                 "We should to enumerate all supported filter-crs values, but they are likely too many, "
-                        + "and we'd have to inspect all the collections to find an exhaustive list for the"
+                        + "and we'd have to inspect all the collections to find an exhaustive list for the "
                         + "test. The ATS does not seem to check it either, so taking a not but not "
                         + "implementing for the time being.");
     }

--- a/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/RasterDownload.java
+++ b/src/extension/wps-download/src/main/java/org/geoserver/wps/gs/download/RasterDownload.java
@@ -532,7 +532,7 @@ class RasterDownload {
 
             if (cropped == null || cropped.getRenderedImage() == null) {
                 throw new WPSException(
-                        "The reader did not return anything"
+                        "The reader did not return anything. "
                                 + "It normally means there is nothing there, or the data got filtered out by the ROI or filter");
             }
             return cropped;

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -1486,7 +1486,7 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer, TileJSO
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(
                         Level.FINE,
-                        "Found a GeoServerTileLayer that is not base on either"
+                        "Found a GeoServerTileLayer that is not base on either "
                                 + "LayerInfo or LayerGroupInfo, setting its max age to 0");
             }
             return 0;

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
@@ -658,7 +658,7 @@ public class CoverageViewReader implements GridCoverage2DReader {
                     cs, nBits, true, false, Transparency.TRANSLUCENT, DataBuffer.TYPE_BYTE);
         } else {
             throw new IllegalArgumentException(
-                    "Cannot create a color model with alpha"
+                    "Cannot create a color model with alpha "
                             + "support starting with "
                             + currentBandCount
                             + " bands");

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
@@ -658,8 +658,7 @@ public class CoverageViewReader implements GridCoverage2DReader {
                     cs, nBits, true, false, Transparency.TRANSLUCENT, DataBuffer.TYPE_BYTE);
         } else {
             throw new IllegalArgumentException(
-                    "Cannot create a color model with alpha "
-                            + "support starting with "
+                    "Cannot create a color model with alpha support starting with "
                             + currentBandCount
                             + " bands");
         }

--- a/src/main/src/main/java/org/geoserver/logging/LoggingUtilsDelegate.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingUtilsDelegate.java
@@ -142,7 +142,7 @@ class LoggingUtilsDelegate {
                             "Could setup Log4J using configuration file '"
                                     + configResource.name()
                                     + "'."
-                                    + "Both Log4J 2 and Log4j 1.2 configuration formats were attempted. To troubleshoot"
+                                    + "Both Log4J 2 and Log4j 1.2 configuration formats were attempted. To troubleshoot "
                                     + "configuration setup use ");
             return;
         }

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/BBoxKvpParser.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/BBoxKvpParser.java
@@ -32,7 +32,7 @@ public class BBoxKvpParser extends Wcs10KvpParser {
         // check to make sure that the bounding box has 4 coordinates
         if (unparsed.size() != 4) {
             throw new WcsException(
-                    "Requested bounding box contains wrong"
+                    "Requested bounding box contains wrong "
                             + "number of coordinates: "
                             + unparsed.size(),
                     InvalidParameterValue,

--- a/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/BBoxKvpParser.java
+++ b/src/wcs1_0/src/main/java/org/geoserver/wcs/kvp/BBoxKvpParser.java
@@ -32,8 +32,7 @@ public class BBoxKvpParser extends Wcs10KvpParser {
         // check to make sure that the bounding box has 4 coordinates
         if (unparsed.size() != 4) {
             throw new WcsException(
-                    "Requested bounding box contains wrong "
-                            + "number of coordinates: "
+                    "Requested bounding box contains wrong number of coordinates: "
                             + unparsed.size(),
                     InvalidParameterValue,
                     "bbox");

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/kvp/BoundingBoxKvpParser.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/kvp/BoundingBoxKvpParser.java
@@ -36,8 +36,7 @@ public class BoundingBoxKvpParser extends KvpParser {
         // check to make sure that the bounding box has 4 coordinates
         if (unparsed.size() < 4) {
             throw new WcsException(
-                    "Requested bounding box contains wrong "
-                            + "number of coordinates (should have at least 4): "
+                    "Requested bounding box contains wrong number of coordinates (should have at least 4): "
                             + unparsed.size(),
                     WcsExceptionCode.InvalidParameterValue,
                     "BoundingBox");

--- a/src/wcs1_1/src/main/java/org/geoserver/wcs/kvp/BoundingBoxKvpParser.java
+++ b/src/wcs1_1/src/main/java/org/geoserver/wcs/kvp/BoundingBoxKvpParser.java
@@ -36,7 +36,7 @@ public class BoundingBoxKvpParser extends KvpParser {
         // check to make sure that the bounding box has 4 coordinates
         if (unparsed.size() < 4) {
             throw new WcsException(
-                    "Requested bounding box contains wrong"
+                    "Requested bounding box contains wrong "
                             + "number of coordinates (should have at least 4): "
                             + unparsed.size(),
                     WcsExceptionCode.InvalidParameterValue,

--- a/src/wfs/src/main/java/org/geoserver/wfs/WFSGetFeatureOutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/WFSGetFeatureOutputFormat.java
@@ -125,7 +125,7 @@ public abstract class WFSGetFeatureOutputFormat extends WFSResponse {
             LOGGER.severe(
                     "ERROR IN "
                             + this.getClass()
-                            + " IMPLEMENTATION.  getCapabilitiesElementName() should return a"
+                            + " IMPLEMENTATION.  getCapabilitiesElementName() should return a "
                             + "valid XML element name string for use in the WFS 1.0.0 capabilities document.");
             String name = this.getClass().getName();
             if (name.indexOf('.') != -1) {

--- a/src/wfs/src/main/java/org/geoserver/wfs/kvp/BBoxKvpParser.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/kvp/BBoxKvpParser.java
@@ -30,7 +30,7 @@ public class BBoxKvpParser extends KvpParser {
         // check to make sure that the bounding box has 4 coordinates
         if (unparsed.size() < 4) {
             throw new IllegalArgumentException(
-                    "Requested bounding box contains wrong"
+                    "Requested bounding box contains wrong "
                             + "number of coordinates (should have "
                             + "4): "
                             + unparsed.size());

--- a/src/wfs/src/main/java/org/geoserver/wfs/kvp/BBoxKvpParser.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/kvp/BBoxKvpParser.java
@@ -30,9 +30,7 @@ public class BBoxKvpParser extends KvpParser {
         // check to make sure that the bounding box has 4 coordinates
         if (unparsed.size() < 4) {
             throw new IllegalArgumentException(
-                    "Requested bounding box contains wrong "
-                            + "number of coordinates (should have "
-                            + "4): "
+                    "Requested bounding box contains wrong number of coordinates (should have 4): "
                             + unparsed.size());
         }
 

--- a/src/wfs/src/test/java/org/geoserver/wfs/MaxFeaturesTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/MaxFeaturesTest.java
@@ -145,8 +145,8 @@ public class MaxFeaturesTest extends WFSTestSupport {
 
         Document doc =
                 getAsDOM(
-                        "wfs?request=GetFeature&srsName=EPSG:4326&typename=cdf:Fifteen,cite:BasicPolygon"
-                                + "s&version=1.0.0&service=wfs&maxFeatures=4");
+                        "wfs?request=GetFeature&srsName=EPSG:4326&typename=cdf:Fifteen,cite:BasicPolygons"
+                                + "&version=1.0.0&service=wfs&maxFeatures=4");
         assertEquals("wfs:FeatureCollection", doc.getDocumentElement().getNodeName());
 
         assertEquals(4, doc.getElementsByTagName("gml:featureMember").getLength());
@@ -167,8 +167,8 @@ public class MaxFeaturesTest extends WFSTestSupport {
 
         Document doc =
                 getAsDOM(
-                        "wfs?request=GetFeature&typename=cdf:Fifteen,cite:BasicPolygon"
-                                + "s&version=1.0.0&service=wfs&maxFeatures=3");
+                        "wfs?request=GetFeature&typename=cdf:Fifteen,cite:BasicPolygons"
+                                + "&version=1.0.0&service=wfs&maxFeatures=3");
         assertEquals("wfs:FeatureCollection", doc.getDocumentElement().getNodeName());
 
         assertEquals(3, doc.getElementsByTagName("gml:featureMember").getLength());


### PR DESCRIPTION
https://osgeo-org.atlassian.net/browse/GEOS-11654

Multiline strings where the second line starts with a character, should end with a space in the previous line:

e.g. 
```java
            throw new IllegalArgumentException(
                    "Requested bounding box contains wrong"
                            + "number of coordinates (should have "
...
```
produces `<ows:ExceptionText>java.lang.IllegalArgumentException: Requested bounding box contains wrongnumber of coordinates (should have 4): 0
Requested bounding box contains wrongnumber of coordinates (should have 4): 0</ows:ExceptionText>`

I picked up most with `find . -type f -exec awk '/[^\\][a-zA-Z]"$/ { getline nextline; if (nextline ~ /^[ \t]*\+\s"[a-zA-Z]/) {print FILENAME, $0 "\n" nextline }}' {} +` 

i.e. a character (not preceded by a backslash \) then quotes then newline then whitespace then plus then space then quotes then a character

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->