### PR TITLE
[GEOS-11658] Time editor dumps stack trace in UI if the start or end time values are intervals

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/resource/DimensionEditorBase.java
+++ b/src/web/core/src/main/java/org/geoserver/web/data/resource/DimensionEditorBase.java
@@ -52,6 +52,7 @@ import org.geoserver.web.wicket.ParamResourceModel;
 import org.geotools.api.coverage.grid.GridCoverageReader;
 import org.geotools.api.feature.type.PropertyDescriptor;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
+import org.geotools.util.DateRange;
 import org.geotools.util.DateTimeParser;
 import org.geotools.util.Range;
 import org.geotools.util.logging.Logging;
@@ -947,12 +948,16 @@ public abstract class DimensionEditorBase<T extends DimensionInfo> extends FormC
         public void validate(IValidatable<String> value) {
             boolean valid = false;
             String errorKey = "invalidStartOrEndDate";
-            DateTimeParser dateTimeParser = new DateTimeParser();
+            DateTimeParser dateTimeParser = new DateTimeParser(-1, 1);
             Date date = null;
             if (dimension.equals("time")) {
                 String timeValue = value.getValue();
                 try {
-                    date = (Date) ((List) dateTimeParser.parse(timeValue)).get(0);
+                    Object dateObject = ((List) dateTimeParser.parse(timeValue)).get(0);
+                    if (dateObject instanceof DateRange) {
+                        throw new ParseException("Invalid date: " + dateObject, 0);
+                    }
+                    date = (Date) dateObject;
                 } catch (ParseException e) {
                     LOGGER.log(
                             Level.WARNING,

--- a/src/web/core/src/test/java/org/geoserver/web/data/resource/DimensionEditorTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/data/resource/DimensionEditorTest.java
@@ -120,4 +120,27 @@ public class DimensionEditorTest extends GeoServerWicketTestSupport {
         // should not be visible
         tester.assertInvisible(prefix + "nearestMatchContainer");
     }
+
+    @Test
+    public void testStartValueErrorMessageWithDateRange() throws Exception {
+        FeatureTypeInfo ft = getCatalog().getFeatureTypeByName(getLayerId(V_TIME_ELEVATION));
+        DimensionInfo time = ft.getMetadata().get(ResourceInfo.TIME, DimensionInfo.class);
+        Model<DimensionInfo> timeModel = new Model<>(time);
+
+        tester.startPage(
+                new FormTestPage(
+                        id -> new DimensionEditor(id, timeModel, ft, Date.class, true, false)));
+        print(tester.getLastRenderedPage(), true, true);
+
+        FormTester form = tester.newFormTester("form");
+        String formPrefix = "panel:configContainer:configs:";
+
+        // Set an invalid value for startValue (for example, an incorrect date format)
+        form.setValue(formPrefix + "startEndContainer:startValue", "invalid-date-format");
+        form.submit();
+
+        // Check if an error message is displayed for startValue
+        tester.assertErrorMessages(
+                "Start data range value must be an ISO8601 DateTime or a construct like 'PRESENT'");
+    }
 }


### PR DESCRIPTION
[![GEOS-11658](https://badgen.net/badge/JIRA/GEOS-11658/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11658) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket.
Supercedes https://github.com/geoserver/geoserver/pull/8128 (the reverted commit is simply removed, QA should pass, has a Jira ticket reference). Count this PR as a review :rofl: 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->