### PR TITLE
[GEOS-11346] Enable strict Content-Security-Policy by default

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/csp/CSPConfiguration.java
+++ b/src/main/src/main/java/org/geoserver/security/csp/CSPConfiguration.java
@@ -20,8 +20,7 @@ public class CSPConfiguration implements Serializable {
 
     // default values
     private static final Boolean DEFAULT_ENABLED = true;
-    // TODO: can switch to false after all Wicket CSP issues are fixed
-    private static final Boolean DEFAULT_REPORT_ONLY = true;
+    private static final Boolean DEFAULT_REPORT_ONLY = false;
     private static final Boolean DEFAULT_ALLOW_OVERRIDE = false;
     private static final Boolean DEFAULT_INJECT_PROXY_BASE = false;
     private static final String DEFAULT_REMOTE_RESOURCES = "";

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerApplication.java
@@ -102,7 +102,7 @@ public class GeoServerApplication extends WebApplication
      *
      * <p>Sample use: {@code org.geoserver.web.csp.strict=true}
      */
-    public static boolean CSP_STRICT = Boolean.valueOf(System.getProperty("org.geoserver.web.csp.strict", "false"));
+    public static boolean CSP_STRICT = Boolean.valueOf(System.getProperty("org.geoserver.web.csp.strict", "true"));
 
     public static final String GEOSERVER_CSRF_DISABLED = "GEOSERVER_CSRF_DISABLED";
     public static final String GEOSERVER_CSRF_WHITELIST = "GEOSERVER_CSRF_WHITELIST";


### PR DESCRIPTION
Using the `Content-Security-Policy-Report-Only` header was necessary to support the Wicket 9 upgrade but the `Content-Security-Policy` header which blocks CSP violations can be used now that most of the remaining CSP violations, particularly the modal window, have been resolved. This will provide a more secure default mode, make any remaining CSP violations (if there are any left) more obvious and ensure that developers do not add new CSP violations.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
