### PR TITLE
[GEOS-11669] Patch jscolor to work with Wicket's CSP

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/wicket/ColorPickerField.java
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/ColorPickerField.java
@@ -5,14 +5,11 @@
  */
 package org.geoserver.web.wicket;
 
-import org.apache.wicket.Component;
-import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.behavior.Behavior;
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.Model;
 import org.apache.wicket.request.resource.PackageResourceReference;
 
 /**
@@ -27,25 +24,17 @@ public class ColorPickerField extends TextField<String> {
             new PackageResourceReference(ColorPickerField.class, "js/jscolor/jscolor.js");
 
     public ColorPickerField(String id) {
-        super(id, String.class);
-        initComponents();
+        this(id, null);
     }
 
     public ColorPickerField(String id, IModel<String> model) {
         super(id, model, String.class);
-        initComponents();
+        add(AttributeModifier.replace("class", "color {\"required\":false}"));
     }
 
-    void initComponents() {
-        add(new Behavior() {
-            private static final long serialVersionUID = 4269437302317170665L;
-
-            @Override
-            public void renderHead(Component component, IHeaderResponse response) {
-                super.renderHead(component, response);
-                response.render(JavaScriptHeaderItem.forReference(JSCOLOR_JS));
-            }
-        });
-        add(new AttributeAppender("class", new Model<>("color {required:false}"), ","));
+    @Override
+    public void renderHead(IHeaderResponse response) {
+        super.renderHead(response);
+        response.render(JavaScriptHeaderItem.forReference(JSCOLOR_JS));
     }
 }

--- a/src/web/core/src/main/java/org/geoserver/web/wicket/js/jscolor/jscolor.js
+++ b/src/web/core/src/main/java/org/geoserver/web/wicket/js/jscolor/jscolor.js
@@ -74,9 +74,13 @@ var jscolor = {
 			if(!e[i].color && e[i].className && (m = e[i].className.match(matchClass))) {
 				var prop = {}
 				if(m[3]) {
-					try {
-						eval('prop='+m[3])
-					} catch(eInvalidProp) {}
+                    // Start GEOS-11669 Changes
+                    // Original Code:
+					// try {
+					// 	eval('prop='+m[3])
+					// } catch(eInvalidProp) {}
+                    prop = JSON.parse(m[3]);
+                    // End GEOS-11669 Changes
 				}
 				e[i].color = new jscolor.color(e[i], prop)
 			}


### PR DESCRIPTION
[![GEOS-11669](https://badgen.net/badge/JIRA/GEOS-11669/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11669) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR patches the jscolor library to parse the JSON using JSON.parse instead of eval which is blocked by Wicket's CSP and updates the ColorPickerField class to be valid JSON. I looked into upgrading jscolor instead but it has other CSP violations that would need to be patched anyways. The indentation only looks weird because the jscolor file uses tabs but the code I added uses spaces.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->