### PR TITLE
Make tutorial easier to understand by using full path to plugin folder in vectortiles tutorial.

### DIFF
--- a/doc/en/user/source/extensions/vectortiles/install.rst
+++ b/doc/en/user/source/extensions/vectortiles/install.rst
@@ -7,7 +7,11 @@ Installing the Vector Tiles Extension
 
    .. warning:: Make sure to match the version of the extension to the version of GeoServer.
 
-#. Extract the archive and copy the contents into the GeoServer :file:`webapps/geoserver/WEB-INF/lib` directory.
+#. Extract the archive and copy the contents into the GeoServer library :file:`WEB-INF/lib` directory located in:
+   
+  * GeoServer binary Jetty: :file:`<GEOSERVER_ROOT>/webapps/geoserver/WEB-INF/lib`
+  * Default Tomcat deployment: :file:`<CATALINA_BASE>/webapps/geoserver/WEB-INF/lib`
+
 
 #. Restart GeoServer.
 

--- a/doc/en/user/source/extensions/vectortiles/install.rst
+++ b/doc/en/user/source/extensions/vectortiles/install.rst
@@ -7,7 +7,7 @@ Installing the Vector Tiles Extension
 
    .. warning:: Make sure to match the version of the extension to the version of GeoServer.
 
-#. Extract the archive and copy the contents into the GeoServer :file:`WEB-INF/lib` directory.
+#. Extract the archive and copy the contents into the GeoServer :file:`webapps/geoserver/WEB-INF/lib` directory.
 
 #. Restart GeoServer.
 


### PR DESCRIPTION
I think you should simply provide the actual path to the folder. For me installing a plugin first time I needed to do an 'extensive search' to get this simple information.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).