### PR TITLE
[GEOS-11677] Hide version info on GWC home page

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/dispatch/GeoServerSecurityFilter.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/dispatch/GeoServerSecurityFilter.java
@@ -7,6 +7,8 @@ package org.geoserver.gwc.dispatch;
 
 import java.util.Objects;
 import org.geoserver.gwc.GWC;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.GeoServerSecurityManager;
 import org.geotools.api.geometry.MismatchedDimensionException;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -17,6 +19,9 @@ import org.geowebcache.filter.security.SecurityFilter;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.SRS;
 import org.geowebcache.layer.TileLayer;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Filter which applies GeoServer security to GWC requests
@@ -46,5 +51,32 @@ public class GeoServerSecurityFilter implements SecurityFilter {
                 throw new GeoWebCacheException(e);
             }
         }
+    }
+
+    // copied from org.geoserver.web.spring.security.GeoServerSession.isAdmin()
+    @Override
+    public boolean isAdmin() {
+        Authentication auth = getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            return false;
+        } else {
+            return GeoServerExtensions.bean(GeoServerSecurityManager.class).checkAuthenticationForAdminRole(auth);
+        }
+    }
+
+    /**
+     * Spring authentication, or {@code null} if not set or anonymous.
+     *
+     * @return spring authentication, or {@code null} if not set or anonymous.
+     */
+    public Authentication getAuthentication() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null
+                && auth.getAuthorities().size() == 1
+                && "ROLE_ANONYMOUS"
+                        .equals(auth.getAuthorities().iterator().next().getAuthority())) {
+            return null;
+        }
+        return auth;
     }
 }

--- a/src/gwc/src/test/java/org/geoserver/gwc/dispatch/GeoServerSecurityFilterTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/dispatch/GeoServerSecurityFilterTest.java
@@ -1,0 +1,72 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.dispatch;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.Test;
+
+public class GeoServerSecurityFilterTest extends GeoServerSystemTestSupport {
+
+    @Override
+    protected void setUpTestData(SystemTestData testData) throws Exception {
+        // Don't set up any test data
+    }
+
+    @Test
+    public void testGwcRootAnonymous() throws Exception {
+        doTestHomePage(false, false);
+    }
+
+    @Test
+    public void testGwcHomeAnonymous() throws Exception {
+        doTestHomePage(true, false);
+    }
+
+    @Test
+    public void testGwcRootUser() throws Exception {
+        login("user", "password", "ROLE_USER");
+        doTestHomePage(false, false);
+    }
+
+    @Test
+    public void testGwcHomeUser() throws Exception {
+        login("user", "password", "ROLE_USER");
+        doTestHomePage(true, false);
+    }
+
+    @Test
+    public void testGwcRootAdmin() throws Exception {
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+        doTestHomePage(false, true);
+    }
+
+    @Test
+    public void testGwcHomeAdmin() throws Exception {
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+        doTestHomePage(true, true);
+    }
+
+    private void doTestHomePage(boolean home, boolean isAdmin) throws Exception {
+        String html = getAsString("gwc" + (home ? "/home" : ""));
+        assertThat(html, containsString("GWC Home"));
+        assertThat(html, containsString("Welcome to GeoWebCache"));
+        if (isAdmin) {
+            assertThat(html, containsString(" version "));
+            assertThat(html, containsString(" build "));
+            assertThat(html, containsString("Runtime Statistics"));
+            assertThat(html, containsString("Storage Locations"));
+        } else {
+            assertThat(html, not(containsString(" version ")));
+            assertThat(html, not(containsString(" build ")));
+            assertThat(html, not(containsString("Runtime Statistics")));
+            assertThat(html, not(containsString("Storage Locations")));
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-11677](https://badgen.net/badge/JIRA/GEOS-11677/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11677) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR hides version information and some other internal server information from the GeoWebCache home page unless the user is logged in as an administrator. The code that determines whether to hide the information is the same as what is used for the About GeoServer page.

This PR is dependent on the GeoWebCache PR https://github.com/GeoWebCache/geowebcache/pull/1345 and will fail until that PR is merged.
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->