### PR TITLE
[GEOS-11689] IOUtilsTest should not ping an external web site

### DIFF
--- a/src/rest/src/test/java/org/geoserver/rest/util/IOUtilsTest.java
+++ b/src/rest/src/test/java/org/geoserver/rest/util/IOUtilsTest.java
@@ -31,11 +31,11 @@ public class IOUtilsTest {
     @Rule
     public TemporaryFolder temp = new TemporaryFolder(new File("target"));
 
-    /** URLCheck used to restrict content to schemas.opengis.net. */
-    private static URLChecker opengisChecker = new URLChecker() {
+    /** URLCheck used to restrict content to https://geoserver.org/about. */
+    private static URLChecker geoserverAboutChecker = new URLChecker() {
         @Override
         public String getName() {
-            return "schemas.opengis.net";
+            return "aboutGeoServer";
         }
 
         @Override
@@ -45,7 +45,7 @@ public class IOUtilsTest {
 
         @Override
         public boolean confirm(String s) {
-            return s.startsWith("https://schemas.opengis.net/");
+            return s.startsWith("https://geoserver.org/about");
         }
     };
 
@@ -73,13 +73,13 @@ public class IOUtilsTest {
 
     @BeforeClass
     public static void setupURLCheckers() throws Exception {
-        URLCheckers.register(opengisChecker);
+        URLCheckers.register(geoserverAboutChecker);
         URLCheckers.register(tmpChecker);
     }
 
     @AfterClass
     public static void teardownURLCheckers() throws Exception {
-        URLCheckers.deregister(opengisChecker);
+        URLCheckers.deregister(geoserverAboutChecker);
         URLCheckers.deregister(tmpChecker);
     }
 
@@ -112,9 +112,9 @@ public class IOUtilsTest {
     public void testUpload() throws IOException {
         File destDir = temp.newFolder("upload").toPath().toFile();
         destDir.mkdirs();
-        Resource newFile = new GeoServerResourceLoader(destDir).get("vehicles.xml");
+        Resource newFile = new GeoServerResourceLoader(destDir).get("about.html");
 
-        URL uploadURL = new URL("https://schemas.opengis.net/movingfeatures/1.0/examples/vehicles.xml");
+        URL uploadURL = new URL("https://geoserver.org/about");
         IOUtils.upload(uploadURL, newFile);
         assertSame("uploaded", newFile.getType(), Resource.Type.RESOURCE);
 


### PR DESCRIPTION
[![GEOS-11689](https://badgen.net/badge/JIRA/GEOS-11689/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11689) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Improving build stability

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->