### PR TITLE
[GEOS-11691] Smart data loader accepts bigint and bigserial but not int8 postgresql type alias

### DIFF
--- a/src/community/smart-data-loader/src/main/java/org/geoserver/smartdataloader/domain/DomainModelBuilder.java
+++ b/src/community/smart-data-loader/src/main/java/org/geoserver/smartdataloader/domain/DomainModelBuilder.java
@@ -150,6 +150,7 @@ public final class DomainModelBuilder {
                 domainAttribute.setType(DomainAttributeType.INT);
                 break;
             case "bigint":
+            case "int8":
             case "bigserial":
                 domainAttribute.setType(DomainAttributeType.INTEGER);
             case "text":

--- a/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/JDBCFixtureHelper.java
+++ b/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/JDBCFixtureHelper.java
@@ -9,13 +9,13 @@ public interface JDBCFixtureHelper {
     default Properties createExampleFixture() {
         Properties fixture = new Properties();
 
-        fixture.put("url", "url=jdbc\\:postgresql\\://localhost/mock");
+        fixture.put("url", "jdbc\\:postgresql\\://localhost/mock");
         fixture.put("dbtype", "postgis");
         fixture.put("database", "mock");
         fixture.put("port", "5432");
         fixture.put("host", "localhost");
         fixture.put("user", "geoserver");
-        fixture.put("passwd", "geoserver");
+        fixture.put("password", "geoserver");
         fixture.put("driver", "org.postgresql.Driver");
 
         return fixture;

--- a/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/postgis/MeteoStationsPostGISTestSetUp.java
+++ b/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/postgis/MeteoStationsPostGISTestSetUp.java
@@ -7,9 +7,15 @@ import org.junit.Before;
 
 public class MeteoStationsPostGISTestSetUp extends PostGISTestSetUp {
 
-    protected String METEOS_SQL_SCRIPT = "meteo_db.sql";
+    protected final String meteoSqlScriptFileName;
 
-    public MeteoStationsPostGISTestSetUp() {}
+    public MeteoStationsPostGISTestSetUp() {
+        this.meteoSqlScriptFileName = "meteo_db.sql";
+    }
+
+    public MeteoStationsPostGISTestSetUp(String sqlScriptFileName) {
+        this.meteoSqlScriptFileName = sqlScriptFileName;
+    }
 
     @Before
     @Override
@@ -23,7 +29,7 @@ public class MeteoStationsPostGISTestSetUp extends PostGISTestSetUp {
         super.setUpData();
 
         String sql = IOUtils.toString(
-                getClass().getResourceAsStream("./mockdata/" + METEOS_SQL_SCRIPT), Charset.defaultCharset());
+                getClass().getResourceAsStream("./mockdata/" + meteoSqlScriptFileName), Charset.defaultCharset());
         run(sql);
     }
 

--- a/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/postgis/PostGisDomainModelBuilderTest.java
+++ b/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/postgis/PostGisDomainModelBuilderTest.java
@@ -11,6 +11,6 @@ public class PostGisDomainModelBuilderTest extends DomainModelBuilderTest {
 
     @Override
     protected JDBCTestSetup createTestSetup() {
-        return new MeteoStationsPostGISTestSetUp();
+        return new MeteoStationsPostGISTestSetUp("meteo_int8_db.sql");
     }
 }

--- a/src/community/smart-data-loader/src/test/resources/org/geoserver/smartdataloader/postgis/mockdata/meteo_int8_db.sql
+++ b/src/community/smart-data-loader/src/test/resources/org/geoserver/smartdataloader/postgis/mockdata/meteo_int8_db.sql
@@ -1,0 +1,77 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+DROP SCHEMA IF EXISTS smartappschematest CASCADE;
+CREATE SCHEMA smartappschematest;
+
+ALTER SCHEMA smartappschematest OWNER TO postgres;
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA smartappschematest;
+
+
+COMMENT ON EXTENSION postgis IS 'PostGIS geometry, geography, and raster spatial types and functions';
+SET search_path = smartappschematest, pg_catalog;
+SET default_tablespace = '';
+SET default_with_oids = false;
+
+CREATE TABLE smartappschematest.meteo_observations (id integer NOT NULL,parameter_id integer NOT NULL,station_id integer NOT NULL,"time" timestamp without time zone,value double PRECISION, decimal_value float4);
+ALTER TABLE smartappschematest.meteo_observations OWNER TO postgres;
+CREATE SEQUENCE meteo_observations_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+ALTER TABLE smartappschematest.meteo_observations_id_seq OWNER TO postgres;
+ALTER SEQUENCE meteo_observations_id_seq OWNED BY meteo_observations.id;
+CREATE TABLE smartappschematest.meteo_parameters (id integer NOT NULL,param_name character varying(50),param_unit character varying(10));
+ALTER TABLE smartappschematest.meteo_parameters OWNER TO postgres;
+CREATE TABLE smartappschematest.meteo_stations (id integer NOT NULL,code character varying(3),common_name character varying(50),"position" public.geometry(Point,4326));
+ALTER TABLE smartappschematest.meteo_stations OWNER TO postgres;
+ALTER TABLE ONLY smartappschematest.meteo_observations ALTER COLUMN id SET DEFAULT nextval('meteo_observations_id_seq'::regclass);
+CREATE TABLE smartappschematest.meteo_maintainers (id integer NOT NULL, name character varying(50), surname character varying(50), company character varying(50), active boolean, "place" public.geography(POINT,4326), code_number int8);
+ALTER TABLE smartappschematest.meteo_maintainers OWNER TO postgres;
+CREATE TABLE smartappschematest.meteo_stations_maintainers (id integer NOT NULL, station_id integer, manteiner_id integer);
+ALTER TABLE smartappschematest.meteo_stations_maintainers OWNER TO postgres;
+
+INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (1,1,13,'2016-12-19 06:26:40',20, 20.3);
+INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (2,2,13,'2016-12-19 06:27:13',155, 155.4);
+INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (3,1,7,'2016-12-19 06:28:31',35, 31.1);
+INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (4,1,7,'2016-12-19 06:28:55',25, 25.3);
+INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (5,2,7,'2016-12-19 06:29:24',80, 80.4);
+INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (6,3,7,'2016-12-19 06:30:26',1019, 1019.3);
+INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (7,3,7,'2016-12-19 06:30:51',1015, 1015.2);
+
+SELECT pg_catalog.setval('meteo_observations_id_seq', 7, true);
+
+INSERT INTO smartappschematest.meteo_parameters (id, param_name, param_unit) VALUES (1,'temperature','C');
+INSERT INTO smartappschematest.meteo_parameters (id, param_name, param_unit) VALUES (2,'wind speed','Km/h');
+INSERT INTO smartappschematest.meteo_parameters (id, param_name, param_unit) VALUES (3,'pressure','hPa');
+
+INSERT INTO smartappschematest.meteo_stations (id, code, common_name, "position") VALUES (13,'ALS','Alessandria','0101000020E6100000C3F5285C8F422140F6285C8FC2754640');
+INSERT INTO smartappschematest.meteo_stations (id, code, common_name, "position") VALUES (7,'BOL','Bologna','0101000020E6100000AE47E17A14AE26400000000000404640');
+INSERT INTO smartappschematest.meteo_stations (id, code, common_name, "position") VALUES (21,'ROV','Rovereto','0101000020E61000009A9999999919264052B81E85EBF14640');
+
+INSERT INTO smartappschematest.meteo_maintainers (id, name, surname, company, active,"place", code_number) VALUES (1,'Franco','Migliorini','SRS srl', false, 'SRID=4326;POINT(-118.4079 33.9434)', 1);
+INSERT INTO smartappschematest.meteo_maintainers (id, name, surname, company, active,"place", code_number) VALUES (2,'Alberto','Rossi','SRS srl', true, 'SRID=4326;POINT(-118.4079 33.9434)', 2);
+INSERT INTO smartappschematest.meteo_maintainers (id, name, surname, company, active,"place", code_number) VALUES (3,'Mario','Bianchi','CYS srl', true,'SRID=4326;POINT(-118.4079 33.9434)', 3);
+
+INSERT INTO smartappschematest.meteo_stations_maintainers (id, station_id, manteiner_id) VALUES (1,13,1);
+INSERT INTO smartappschematest.meteo_stations_maintainers (id, station_id, manteiner_id) VALUES (2,13,2);
+INSERT INTO smartappschematest.meteo_stations_maintainers (id, station_id, manteiner_id) VALUES (3,7,2);
+INSERT INTO smartappschematest.meteo_stations_maintainers (id, station_id, manteiner_id) VALUES (4,7,3);
+INSERT INTO smartappschematest.meteo_stations_maintainers (id, station_id, manteiner_id) VALUES (5,21,3);
+
+
+ALTER TABLE ONLY smartappschematest.meteo_observations ADD CONSTRAINT meteo_observations_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY smartappschematest.meteo_parameters ADD CONSTRAINT meteo_parameters_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY smartappschematest.meteo_stations ADD CONSTRAINT meteo_stations_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY smartappschematest.meteo_observations ADD CONSTRAINT fk_parameter FOREIGN KEY (parameter_id) REFERENCES smartappschematest.meteo_parameters(id);
+ALTER TABLE ONLY smartappschematest.meteo_observations ADD CONSTRAINT fk_station FOREIGN KEY (station_id) REFERENCES smartappschematest.meteo_stations(id);
+ALTER TABLE ONLY smartappschematest.meteo_maintainers ADD CONSTRAINT meteo_manteneirs_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY smartappschematest.meteo_stations_maintainers ADD CONSTRAINT meteo_stations_manteneirs_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY smartappschematest.meteo_stations_maintainers ADD CONSTRAINT fk_stations_rel FOREIGN KEY (station_id) REFERENCES smartappschematest.meteo_stations(id);
+ALTER TABLE ONLY smartappschematest.meteo_stations_maintainers ADD CONSTRAINT fk_maintainers_rel FOREIGN KEY (manteiner_id) REFERENCES smartappschematest.meteo_maintainers(id);


### PR DESCRIPTION
[![GEOS-11691](https://badgen.net/badge/JIRA/GEOS-11691/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11691) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[GEOS-11691] Smart data loader acepts bigint and bigserial but not int8 postgresql type alias
https://osgeo-org.atlassian.net/browse/GEOS-11691

This PR introduces a fix for int8 postgresql type support on smart data loader module (bug described on the JIRA issue).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->