### PR TITLE
[GEOS-10844] Exclude xml-apis from build

### DIFF
--- a/src/extension/printing/pom.xml
+++ b/src/extension/printing/pom.xml
@@ -43,6 +43,12 @@
     <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>xml-apis</artifactId>
+          <groupId>xml-apis</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1624,6 +1624,12 @@
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
         <version>2.12.2</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>xml-apis</artifactId>
+            <groupId>xml-apis</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>javax.jms</groupId>


### PR DESCRIPTION
[![GEOS-10844](https://badgen.net/badge/JIRA/GEOS-10844/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10844) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Exclude transitive dependency on xml-apis from xerces and mapfish print

Hopefully remove `xml-apis` from transitive dependencies for good.

Following up on the cruzade to remove `xml-apis` from the build. See
* [GEOS-10844] (cecc81111fd15f98d7ca96d7aa918fe4585a6ce5)
* Exclude `xml-apis` and apache `fop` in the root pom: (95852c258b59c106a2b81898ddd6812663d6e078)
* Remove dependency on xml-apis-xerces on the printing extension (33510b7595b675b28c11fffd313f1f2922f146cd)

Before:

```
mvn dependency:list -Prelease,communityRelease -T1C|grep "xml-apis"|sort -u
[INFO]    xml-apis:xml-apis-ext:jar:1.3.04:compile -- module xml.apis.ext (auto)
[INFO]    xml-apis:xml-apis-ext:jar:1.3.04:provided -- module xml.apis.ext (auto)
[INFO]    xml-apis:xml-apis-ext:jar:1.3.04:test -- module xml.apis.ext (auto)
[INFO]    xml-apis:xml-apis:jar:1.4.01:compile -- module xml.apis (auto)
[INFO]    xml-apis:xml-apis:jar:1.4.01:test -- module xml.apis (auto)
```

After:

```
mvn dependency:list -Prelease,communityRelease -T1C|grep "xml-apis"|sort -u
[INFO]    xml-apis:xml-apis-ext:jar:1.3.04:compile -- module xml.apis.ext (auto)
[INFO]    xml-apis:xml-apis-ext:jar:1.3.04:provided -- module xml.apis.ext (auto)
[INFO]    xml-apis:xml-apis-ext:jar:1.3.04:test -- module xml.apis.ext (auto)
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->