### PR TITLE
[GEOS-11716] Added resource error handling check while initializing WFS configuration.

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSXmlUtils.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/WFSXmlUtils.java
@@ -9,10 +9,13 @@ import java.io.Reader;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.config.GeoServer;
+import org.geoserver.config.ResourceErrorHandling;
 import org.geoserver.ows.XmlRequestReader;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.wfs.CatalogNamespaceSupport;
@@ -24,6 +27,7 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.gml2.FeatureTypeCache;
 import org.geotools.gml2.SrsSyntax;
 import org.geotools.util.Converters;
+import org.geotools.util.logging.Logging;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.OptionalComponentParameter;
 import org.geotools.xsd.Parser;
@@ -41,6 +45,8 @@ import org.xml.sax.InputSource;
  * @author Justin Deoliveira, OpenGeo
  */
 public class WFSXmlUtils {
+
+    private static final Logger LOGGER = Logging.getLogger(WFSXmlUtils.class);
 
     public static final String ENTITY_EXPANSION_LIMIT = "org.geoserver.wfs.xml.entityExpansionLimit";
 
@@ -108,6 +114,11 @@ public class WFSXmlUtils {
             try {
                 featureType = meta.getFeatureType();
             } catch (Exception e) {
+                if (ResourceErrorHandling.SKIP_MISCONFIGURED_LAYERS
+                        == gs.getGlobal().getResourceErrorHandling()) {
+                    LOGGER.log(Level.FINE, "Skipping misconfigured feature type", e);
+                    break;
+                }
                 throw new RuntimeException(e);
             }
 


### PR DESCRIPTION
[![GEOS-11716](https://badgen.net/badge/JIRA/GEOS-11716/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11716) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

If a layer is currently in an erroneous state (e.g. the backing source table has been deleted), POST requests to WFS GetFeature fail with an error, even when the request does not query the problematic layer.

These changes add the possibility to avoid failures in these cases, checking the value of global's `ResourceErrorHandling`.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->