### PR TITLE
Enforce Maven 3.8+ for improved plugin version resolution

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -2024,6 +2024,16 @@
           <artifactId>markdown-page-generator-plugin</artifactId>
           <version>2.4.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.18.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -2375,7 +2385,40 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven-version</id>
+            <!-- Enforcing a minimum Maven version is crucial to ensure that:
+                 - Plugin version resolution works as expected: Different Maven versions
+                   may resolve plugin versions differently due to changes in the default
+                   lifecycle mappings, dependency resolution behavior, and plugin inheritance.
+                 - Features and bug fixes required by newer plugins are available: For example,
+                   some plugins (e.g., surefire-plugin 3.x) require Maven 3.6+ or 3.8+.
+                 - Consistent builds across environments: Without enforcing a Maven version,
+                   developers or CI/CD pipelines using different Maven versions may face
+                   unexpected build failures or inconsistencies.
+            -->
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.8,4.0)</version>
+                  <message>You must use Maven 3.8 or higher to build this project.</message>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+      </plugin>
     </plugins>
 
   </build>


### PR DESCRIPTION
Enforcing Maven 3.8+ ensures consistent plugin version resolution across all environments. Different Maven versions may resolve plugin versions differently due to changes in:

- Default lifecycle plugin mappings (e.g., maven-compiler-plugin, maven-surefire-plugin)
- Dependency resolution behavior for both plugins and their transitive dependencies
- Compatibility improvements and bug fixes in newer Maven versions

By standardizing the required Maven version, we can ensure:
- Plugins work correctly with the expected Maven features
- Consistent builds in both developer machines and CI/CD environments
- Easier decision-making regarding which plugin versions to use for compatibility and stability

This change will prevent unexpected build failures or inconsistencies caused by older Maven versions and will help identify the best plugin versions to use that are fully compatible with Maven 3.8+.

---
Note this doesn't change any plugin version, but helps in resolving which plugins versions to eventually upgrade to in a consistent way. As an example, check out the output of the following command in `main`:

```shell
mvn versions:display-plugin-updates -Prelease | grep "\->" | sort -u | grep -Ev "beta|-M|jetty"
[INFO]   com.diffplug.spotless:spotless-maven-plugin ...... 2.43.0 -> 2.44.2
[INFO]   com.github.ekryd.sortpom:sortpom-maven-plugin ..... 2.15.0 -> 4.0.0
[INFO]   com.github.spotbugs:spotbugs-maven-plugin ..... 4.7.3.4 -> 3.1.12.2
[INFO]   com.github.spotbugs:spotbugs-maven-plugin ...... 4.7.3.4 -> 4.8.3.1
[INFO]   com.github.spotbugs:spotbugs-maven-plugin ...... 4.7.3.4 -> 4.8.6.6
[INFO]   com.github.spotbugs:spotbugs-maven-plugin ........ 4.7.3.4 -> 3.1.1
[INFO]   com.github.spotbugs:spotbugs-maven-plugin ........ 4.7.3.4 -> 4.4.2
[INFO]   com.ruleoftech:markdown-page-generator-plugin ...... 2.4.0 -> 2.4.2
[INFO]   maven-antrun-plugin ................................ 3.1.0 -> 3.0.0
[INFO]   maven-antrun-plugin .................................. 3.1.0 -> 1.2
[INFO]   maven-antrun-plugin .................................. 3.1.0 -> 1.3
[INFO]   maven-antrun-plugin .................................. 3.1.0 -> 1.6
[INFO]   maven-antrun-plugin .................................. 3.1.0 -> 1.7
[INFO]   maven-antrun-plugin .................................. 3.1.0 -> 1.8
[INFO]   maven-assembly-plugin .............................. 3.2.0 -> 3.3.0
[INFO]   maven-assembly-plugin .............................. 3.2.0 -> 3.6.0
[INFO]   maven-assembly-plugin .............................. 3.2.0 -> 3.7.1
[INFO]   maven-assembly-plugin .............................. 3.7.1 -> 3.3.0
[INFO]   maven-assembly-plugin .............................. 3.7.1 -> 3.6.0
[INFO]   maven-assembly-plugin ................................ 3.2.0 -> 2.2
[INFO]   maven-assembly-plugin ................................ 3.2.0 -> 2.6
[INFO]   maven-assembly-plugin ................................ 3.7.1 -> 2.2
[INFO]   maven-assembly-plugin ................................ 3.7.1 -> 2.6
[INFO]   maven-checkstyle-plugin ............................ 3.1.1 -> 3.1.2
[INFO]   maven-checkstyle-plugin ............................ 3.1.1 -> 3.3.1
[INFO]   maven-checkstyle-plugin ............................ 3.1.1 -> 3.6.0
[INFO]   maven-checkstyle-plugin ............................. 3.1.1 -> 2.17
[INFO]   maven-checkstyle-plugin .............................. 3.1.1 -> 2.1
[INFO]   maven-checkstyle-plugin .............................. 3.1.1 -> 2.8
[INFO]   maven-compiler-plugin ............................ 3.10.1 -> 3.12.1
[INFO]   maven-compiler-plugin ............................ 3.10.1 -> 3.13.0
[INFO]   maven-compiler-plugin ............................. 3.10.1 -> 2.0.2
[INFO]   maven-compiler-plugin ............................. 3.10.1 -> 3.8.1
[INFO]   maven-compiler-plugin ............................... 3.10.1 -> 3.2
[INFO]   maven-compiler-plugin ............................... 3.10.1 -> 3.3
[INFO]   maven-dependency-plugin ............................ 3.3.0 -> 3.1.2
[INFO]   maven-dependency-plugin ............................ 3.3.0 -> 3.6.1
[INFO]   maven-dependency-plugin ............................ 3.3.0 -> 3.8.1
[INFO]   maven-dependency-plugin ............................. 3.3.0 -> 2.10
[INFO]   maven-dependency-plugin .............................. 3.3.0 -> 2.2
[INFO]   maven-dependency-plugin .............................. 3.3.0 -> 2.8
[INFO]   maven-eclipse-plugin .................................. 2.10 -> 2.8
[INFO]   maven-eclipse-plugin .................................. 2.10 -> 2.9
[INFO]   maven-enforcer-plugin .............................. 3.0.0 -> 3.4.1
[INFO]   maven-enforcer-plugin .............................. 3.0.0 -> 3.5.0
[INFO]   maven-jar-plugin ................................... 3.0.2 -> 3.2.0
[INFO]   maven-jar-plugin ................................... 3.0.2 -> 3.2.2
[INFO]   maven-jar-plugin ................................... 3.0.2 -> 3.3.0
[INFO]   maven-jar-plugin ................................... 3.0.2 -> 3.4.2
[INFO]   maven-jar-plugin ..................................... 2.4 -> 3.2.0
[INFO]   maven-jar-plugin ..................................... 2.4 -> 3.2.2
[INFO]   maven-jar-plugin ..................................... 2.4 -> 3.3.0
[INFO]   maven-jar-plugin ..................................... 2.4 -> 3.4.2
[INFO]   maven-jar-plugin ..................................... 3.0.2 -> 2.1
[INFO]   maven-jar-plugin ..................................... 3.0.2 -> 2.5
[INFO]   maven-jar-plugin ..................................... 3.0.2 -> 2.6
[INFO]   maven-jar-plugin ....................................... 2.4 -> 2.1
[INFO]   maven-jar-plugin ....................................... 2.4 -> 2.5
[INFO]   maven-jar-plugin ....................................... 2.4 -> 2.6
[INFO]   maven-javadoc-plugin ............................. 2.10.3 -> 2.10.4
[INFO]   maven-javadoc-plugin ............................. 2.10.3 -> 3.11.2
[INFO]   maven-javadoc-plugin .............................. 2.10.3 -> 2.8.1
[INFO]   maven-javadoc-plugin .............................. 2.10.3 -> 3.3.2
[INFO]   maven-javadoc-plugin .............................. 2.10.3 -> 3.6.3
[INFO]   maven-javadoc-plugin ................................ 2.10.3 -> 2.2
[INFO]   maven-javadoc-plugin ................................ 2.10.3 -> 2.3
[INFO]   maven-javadoc-plugin ................................ 2.10.3 -> 2.4
[INFO]   maven-jxr-plugin ..................................... 2.1 -> 3.0.0
[INFO]   maven-jxr-plugin ..................................... 2.1 -> 3.1.1
[INFO]   maven-jxr-plugin ..................................... 2.1 -> 3.3.2
[INFO]   maven-jxr-plugin ..................................... 2.1 -> 3.6.0
[INFO]   maven-jxr-plugin ....................................... 2.1 -> 2.2
[INFO]   maven-jxr-plugin ....................................... 2.1 -> 2.4
[INFO]   maven-jxr-plugin ....................................... 2.1 -> 2.5
[INFO]   maven-pmd-plugin ................................. 3.24.0 -> 3.14.0
[INFO]   maven-pmd-plugin ................................. 3.24.0 -> 3.15.0
[INFO]   maven-pmd-plugin ................................. 3.24.0 -> 3.16.0
[INFO]   maven-pmd-plugin ................................. 3.24.0 -> 3.22.0
[INFO]   maven-pmd-plugin ................................. 3.24.0 -> 3.26.0
[INFO]   maven-pmd-plugin .................................... 3.24.0 -> 2.2
[INFO]   maven-pmd-plugin .................................... 3.24.0 -> 2.6
[INFO]   maven-pmd-plugin .................................... 3.24.0 -> 3.8
[INFO]   maven-project-info-reports-plugin .................... 2.4 -> 2.0.1
[INFO]   maven-project-info-reports-plugin .................... 2.4 -> 2.1.2
[INFO]   maven-project-info-reports-plugin .................... 2.4 -> 3.2.2
[INFO]   maven-project-info-reports-plugin .................... 2.4 -> 3.5.0
[INFO]   maven-project-info-reports-plugin .................... 2.4 -> 3.8.0
[INFO]   maven-project-info-reports-plugin ...................... 2.4 -> 2.2
[INFO]   maven-project-info-reports-plugin ...................... 2.4 -> 2.6
[INFO]   maven-project-info-reports-plugin ...................... 2.4 -> 2.9
[INFO]   maven-resources-plugin ............................. 3.3.0 -> 3.1.0
[INFO]   maven-resources-plugin ............................. 3.3.0 -> 3.2.0
[INFO]   maven-resources-plugin ............................. 3.3.0 -> 3.3.1
[INFO]   maven-resources-plugin ............................... 2.4 -> 3.1.0
[INFO]   maven-resources-plugin ............................... 2.4 -> 3.2.0
[INFO]   maven-resources-plugin ............................... 2.4 -> 3.3.1
[INFO]   maven-resources-plugin ............................... 3.3.0 -> 2.6
[INFO]   maven-resources-plugin ............................... 3.3.0 -> 2.7
[INFO]   maven-resources-plugin ................................. 2.4 -> 2.6
[INFO]   maven-resources-plugin ................................. 2.4 -> 2.7
[INFO]   maven-site-plugin ................................... 3.0 -> 3.11.0
[INFO]   maven-site-plugin .................................... 3.0 -> 2.0.1
[INFO]   maven-site-plugin .................................... 3.0 -> 2.1.1
[INFO]   maven-site-plugin .................................... 3.0 -> 3.7.1
[INFO]   maven-site-plugin .................................... 3.0 -> 3.9.0
[INFO]   maven-source-plugin ................................ 2.2.1 -> 2.0.4
[INFO]   maven-source-plugin ................................ 2.2.1 -> 2.1.2
[INFO]   maven-source-plugin ................................ 2.2.1 -> 3.2.1
[INFO]   maven-source-plugin ................................ 2.2.1 -> 3.3.1
[INFO]   maven-source-plugin .................................. 2.2.1 -> 2.3
[INFO]   maven-source-plugin .................................. 2.2.1 -> 2.4
[INFO]   maven-surefire-plugin ............................. 2.22.2 -> 2.4.3
[INFO]   maven-surefire-plugin ............................. 2.22.2 -> 3.2.5
[INFO]   maven-surefire-plugin ............................. 2.22.2 -> 3.5.2
[INFO]   maven-surefire-plugin .............................. 2.22.2 -> 2.17
[INFO]   maven-surefire-report-plugin ....................... 2.12 -> 2.22.2
[INFO]   maven-surefire-report-plugin ........................ 2.12 -> 2.4.3
[INFO]   maven-surefire-report-plugin ........................ 2.12 -> 2.7.1
[INFO]   maven-surefire-report-plugin ........................ 2.12 -> 3.2.5
[INFO]   maven-surefire-report-plugin ........................ 2.12 -> 3.5.2
[INFO]   maven-surefire-report-plugin ......................... 2.12 -> 2.17
[INFO]   maven-war-plugin ................................... 3.4.0 -> 2.0.2
[INFO]   maven-war-plugin ................................... 3.4.0 -> 3.3.1
[INFO]   maven-war-plugin ................................... 3.4.0 -> 3.3.2
[INFO]   maven-war-plugin ..................................... 3.4.0 -> 2.4
[INFO]   maven-war-plugin ..................................... 3.4.0 -> 2.6
[INFO]   org.codehaus.mojo:build-helper-maven-plugin ........ 3.0.0 -> 3.3.0
[INFO]   org.codehaus.mojo:build-helper-maven-plugin ........ 3.0.0 -> 3.4.0
[INFO]   org.codehaus.mojo:build-helper-maven-plugin ........ 3.0.0 -> 3.6.0
[INFO]   org.codehaus.mojo:build-helper-maven-plugin ......... 3.0.0 -> 1.12
[INFO]   org.codehaus.mojo:build-helper-maven-plugin .......... 3.0.0 -> 1.5
[INFO]   org.codehaus.mojo:build-helper-maven-plugin .......... 3.0.0 -> 1.9
[INFO]   org.codehaus.mojo:findbugs-maven-plugin ............ 2.4.0 -> 1.0.0
[INFO]   org.codehaus.mojo:findbugs-maven-plugin ............ 2.4.0 -> 2.3.1
[INFO]   org.codehaus.mojo:findbugs-maven-plugin ............ 2.4.0 -> 2.3.3
[INFO]   org.codehaus.mojo:findbugs-maven-plugin ............ 2.4.0 -> 2.5.5
[INFO]   org.codehaus.mojo:findbugs-maven-plugin ............ 2.4.0 -> 3.0.5
[INFO]   org.codehaus.mojo:findbugs-maven-plugin .............. 2.4.0 -> 1.2
[INFO]   org.codehaus.mojo:findbugs-maven-plugin .............. 2.4.0 -> 2.1
[INFO]   org.codehaus.mojo:javacc-maven-plugin ................ 2.3 -> 3.0.1
[INFO]   org.codehaus.mojo:javacc-maven-plugin ................ 2.3 -> 3.1.0
[INFO]   org.codehaus.mojo:javacc-maven-plugin .................. 2.3 -> 2.5
[INFO]   org.codehaus.mojo:taglist-maven-plugin ............... 2.4 -> 3.0.0
[INFO]   org.codehaus.mojo:taglist-maven-plugin ............... 2.4 -> 3.2.1
[INFO]   org.codehaus.mojo:taglist-maven-plugin ................. 2.4 -> 2.2
[INFO]   org.jacoco:jacoco-maven-plugin ........ 0.8.6 -> 0.6.3.201306030806
[INFO]   org.jacoco:jacoco-maven-plugin .................... 0.8.6 -> 0.8.12
[INFO]   org.jacoco:jacoco-maven-plugin ..................... 0.8.6 -> 0.8.2
[INFO]   org.owasp:dependency-check-maven .................. 7.1.1 -> 10.0.4
[INFO]   org.owasp:dependency-check-maven .................. 7.1.1 -> 12.0.2
[INFO]   org.owasp:dependency-check-maven ................... 7.1.1 -> 5.0.0
```

versus after this change:

```shell
mvn versions:display-plugin-updates -Prelease | grep "\->" | sort -u | grep -Ev "beta|-M|jetty"
[INFO]   com.diffplug.spotless:spotless-maven-plugin ...... 2.43.0 -> 2.44.2
[INFO]   com.github.ekryd.sortpom:sortpom-maven-plugin ..... 2.15.0 -> 4.0.0
[INFO]   com.github.spotbugs:spotbugs-maven-plugin ...... 4.7.3.4 -> 4.8.6.6
[INFO]   com.ruleoftech:markdown-page-generator-plugin ...... 2.4.0 -> 2.4.2
[INFO]   maven-assembly-plugin .............................. 3.2.0 -> 3.7.1
[INFO]   maven-checkstyle-plugin ............................ 3.1.1 -> 3.6.0
[INFO]   maven-compiler-plugin ............................ 3.10.1 -> 3.13.0
[INFO]   maven-dependency-plugin ............................ 3.3.0 -> 3.8.1
[INFO]   maven-jar-plugin ................................... 3.0.2 -> 3.4.2
[INFO]   maven-jar-plugin ..................................... 2.4 -> 3.4.2
[INFO]   maven-javadoc-plugin ............................. 2.10.3 -> 3.11.2
[INFO]   maven-jxr-plugin ..................................... 2.1 -> 3.6.0
[INFO]   maven-pmd-plugin ................................. 3.24.0 -> 3.26.0
[INFO]   maven-project-info-reports-plugin .................... 2.4 -> 3.8.0
[INFO]   maven-resources-plugin ............................. 3.3.0 -> 3.3.1
[INFO]   maven-resources-plugin ............................... 2.4 -> 3.3.1
[INFO]   maven-source-plugin ................................ 2.2.1 -> 3.3.1
[INFO]   maven-surefire-plugin ............................. 2.22.2 -> 3.5.2
[INFO]   maven-surefire-report-plugin ........................ 2.12 -> 3.5.2
[INFO]   org.codehaus.mojo:build-helper-maven-plugin ........ 3.0.0 -> 3.6.0
[INFO]   org.codehaus.mojo:findbugs-maven-plugin ............ 2.4.0 -> 3.0.5
[INFO]   org.codehaus.mojo:javacc-maven-plugin ................ 2.3 -> 3.1.0
[INFO]   org.codehaus.mojo:taglist-maven-plugin ............... 2.4 -> 3.2.1
[INFO]   org.jacoco:jacoco-maven-plugin .................... 0.8.6 -> 0.8.12
[INFO]   org.owasp:dependency-check-maven .................. 7.1.1 -> 12.0.2
```

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->