### PR TITLE
[GEOS-11720] Fix quoting issues in AttributeTypeInfoImpl

### DIFF
--- a/src/main/src/test/java/org/geoserver/catalog/impl/AttributeTypeInfoImplTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/AttributeTypeInfoImplTest.java
@@ -1,0 +1,40 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class AttributeTypeInfoImplTest {
+    @Test
+    public void testQuoting() {
+        assertNotQuoted("foo");
+        assertNotQuoted("foo123");
+        assertNotQuoted("FOO");
+        assertNotQuoted("FOO123");
+        assertNotQuoted("foo_bar");
+        assertNotQuoted("Foo_Bar");
+
+        assertQuoted("123foo");
+        assertQuoted("foo.bar");
+        assertQuoted("point");
+        assertQuoted("POINT");
+        assertQuoted("BBOX");
+        assertQuoted("intersects");
+    }
+
+    private void assertNotQuoted(String name) {
+        AttributeTypeInfoImpl a = new AttributeTypeInfoImpl();
+        a.setName(name);
+        assertEquals(name, a.getSource());
+    }
+
+    private void assertQuoted(String name) {
+        AttributeTypeInfoImpl a = new AttributeTypeInfoImpl();
+        a.setName(name);
+        assertEquals("\"" + name + "\"", a.getSource());
+    }
+}


### PR DESCRIPTION
At least two issues found here:
1. Simply being able to parse a string as ECQL doesn't tell us if the resulting ECQL would do what we want - what we need to know, before deciding to apply quotes, is if the ECQL parser would currently parse this field name as a PropertyName (what we want) or something else.
2. Not all ECQL parsing failures are CQLException - there is also EmptyStackException and there may be more.

I found this issue by trying to create a feature type with a field called "POINT". This failed with the following stack trace:

java.util.EmptyStackException
    at java.base/java.util.Stack.peek(Unknown Source)
    at java.base/java.util.Stack.pop(Unknown Source)
    -- lots of ECQL stack trace removed for brevity --
    at org.geotools.filter.text.ecql.ECQL.toExpression(ECQL.java:125)
    at org.geoserver.catalog.impl.AttributeTypeInfoImpl.getSource(AttributeTypeInfoImpl.java:147)


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] `N/A` [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] `N/A` The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers). 
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.
