### PR TITLE
[GEOS-11722] Coverage view reader partially ignores multithreaded loading

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CoverageViewPamResourceInfo.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageViewPamResourceInfo.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.geotools.api.coverage.grid.GridCoverageReader;
 import org.geotools.api.data.ResourceInfo;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.coverage.grid.io.PAMResourceInfo;
@@ -46,26 +45,23 @@ public class CoverageViewPamResourceInfo extends DefaultResourceInfo implements 
      * @param viewPam the PAM dataset to populate
      */
     private void populatePAMFromViewBands(CoverageViewReader.ViewInputs info, PAMDataset viewPam) {
-        Map<String, GridCoverageReader> readers = info.getInputReaders();
+        Map<String, GridCoverage2DReader> readers = info.getInputReaders();
         // iterate over the view bands and populate the PAM dataset
         for (CoverageView.CoverageBand band : info.getBands()) {
             for (CoverageView.InputCoverageBand inputCoverageBand : band.getInputCoverageBands()) {
                 // get the reader for the coverage associated with this input coverage band
-                GridCoverageReader reader = readers.get(inputCoverageBand.getCoverageName());
-                if (reader instanceof GridCoverage2DReader) {
-                    GridCoverage2DReader bandReader = (GridCoverage2DReader) reader;
-                    ResourceInfo resourceInfoBand = bandReader.getInfo(inputCoverageBand.getCoverageName());
-                    // reader is associated with a PAM
-                    if (resourceInfoBand instanceof PAMResourceInfo) {
-                        PAMDataset bandPam = ((PAMResourceInfo) resourceInfoBand).getPAMDataset();
-                        if (bandPam != null) {
-                            List<PAMDataset.PAMRasterBand> pamRasterBands = bandPam.getPAMRasterBand();
-                            // find the PAMRasterBand for the given band index and put in the output
-                            Optional<PAMDataset.PAMRasterBand> pamRasterBandOptional =
-                                    getPAMRasterBandByBandIndex(pamRasterBands, inputCoverageBand.getBand());
-                            pamRasterBandOptional.ifPresent(
-                                    pamRasterBand -> viewPam.getPAMRasterBand().add(pamRasterBand));
-                        }
+                GridCoverage2DReader bandReader = readers.get(inputCoverageBand.getCoverageName());
+                ResourceInfo resourceInfoBand = bandReader.getInfo(inputCoverageBand.getCoverageName());
+                // reader is associated with a PAM
+                if (resourceInfoBand instanceof PAMResourceInfo) {
+                    PAMDataset bandPam = ((PAMResourceInfo) resourceInfoBand).getPAMDataset();
+                    if (bandPam != null) {
+                        List<PAMDataset.PAMRasterBand> pamRasterBands = bandPam.getPAMRasterBand();
+                        // find the PAMRasterBand for the given band index and put in the output
+                        Optional<PAMDataset.PAMRasterBand> pamRasterBandOptional =
+                                getPAMRasterBandByBandIndex(pamRasterBands, inputCoverageBand.getBand());
+                        pamRasterBandOptional.ifPresent(
+                                pamRasterBand -> viewPam.getPAMRasterBand().add(pamRasterBand));
                     }
                 }
             }

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
@@ -5,6 +5,8 @@
  */
 package org.geoserver.catalog;
 
+import static org.geoserver.catalog.CoverageView.EnvelopeCompositionType.INTERSECTION;
+
 import com.sun.media.imageioimpl.common.BogusColorSpace;
 import it.geosolutions.imageio.maskband.DatasetLayout;
 import it.geosolutions.imageio.utilities.ImageIOUtilities;
@@ -27,6 +29,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.media.jai.ColorModelFactory;
@@ -36,7 +41,6 @@ import javax.media.jai.RasterFactory;
 import javax.media.jai.operator.ConstantDescriptor;
 import org.apache.commons.lang3.ArrayUtils;
 import org.geoserver.catalog.CoverageView.CoverageBand;
-import org.geoserver.catalog.CoverageView.EnvelopeCompositionType;
 import org.geoserver.catalog.CoverageView.InputCoverageBand;
 import org.geoserver.catalog.CoverageViewHandler.CoveragesConsistencyChecker;
 import org.geotools.api.coverage.grid.Format;
@@ -73,10 +77,10 @@ import org.geotools.coverage.grid.io.imageio.GeoToolsWriteParams;
 import org.geotools.coverage.processing.CoverageProcessor;
 import org.geotools.data.DefaultResourceInfo;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.gce.imagemosaic.ImageMosaicFormat;
 import org.geotools.geometry.GeneralBounds;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.image.ImageWorker;
-import org.geotools.parameter.DefaultParameterDescriptor;
 import org.geotools.parameter.DefaultParameterDescriptorGroup;
 import org.geotools.parameter.ParameterGroup;
 import org.geotools.referencing.CRS;
@@ -98,6 +102,15 @@ public class CoverageViewReader implements GridCoverage2DReader {
     private static final CoverageProcessor PROCESSOR = CoverageProcessor.getInstance();
 
     private static final Logger LOGGER = Logging.getLogger(CoverageViewReader.class);
+
+    /**
+     * Executor for parallel loading of coverages that do support multithreaded loading to start with (e.g., image
+     * msoaic). It's not limiting the number of threads, because when MT loading is one, that's already limited in the
+     * readers. It cannot be the same executor used by the image mosaic (ResourcePool#getCoverageExecutor) because that
+     * would cause deadlock (each read would use at least 2 threads, one inside the image mosaic and one inside the
+     * coverage view). Should we switch to allow parlale
+     */
+    private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool();
 
     /** The CoverageView containing definition */
     CoverageView coverageView;
@@ -382,9 +395,27 @@ public class CoverageViewReader implements GridCoverage2DReader {
             Boolean includeCoverages)
             throws IOException {
         HashMap<String, GridCoverage2D> inputCoverages = new HashMap<>();
-        HashMap<String, GridCoverageReader> inputReaders = new HashMap<>();
+        HashMap<String, GridCoverage2DReader> inputReaders = new HashMap<>();
         GridCoverage2D dynamicAlphaSource = null;
         int nonNullCoverages = 0;
+        // bands selection parameter inside on final bands so they should not be propagated
+        // to the delegate reader
+        final GeneralParameterValue[] filteredParameters;
+        boolean multiThreadedLoading = false;
+        if (parameters != null) {
+            // creating a copy of parameters excluding the bands parameter
+            filteredParameters = Arrays.stream(parameters)
+                    .filter(parameter -> !matches(parameter, AbstractGridFormat.BANDS))
+                    .toArray(GeneralParameterValue[]::new);
+            // check if multi-threaded loading is enabled
+            multiThreadedLoading = Arrays.stream(parameters)
+                    .filter(parameter -> matches(parameter, ImageMosaicFormat.ALLOW_MULTITHREADING))
+                    .map(p -> Boolean.TRUE.equals(((ParameterValue) p).getValue()))
+                    .findFirst()
+                    .orElse(false);
+        } else {
+            filteredParameters = null;
+        }
         for (int bIdx : selectedBandIndices) {
             CoverageBand band = bands.get(bIdx);
             List<InputCoverageBand> selectedBands = band.getInputCoverageBands();
@@ -400,20 +431,15 @@ public class CoverageViewReader implements GridCoverage2DReader {
                 } else {
                     checker.checkConsistency(reader);
                 }
-                // bands selection parameter inside on final bands so they should not be propagated
-                // to the delegate reader
-                GeneralParameterValue[] filteredParameters = parameters;
-                if (parameters != null) {
-                    // creating a copy of parameters excluding the bands parameter
-                    filteredParameters = Arrays.stream(parameters)
-                            .filter(parameter -> !matches(parameter, AbstractGridFormat.BANDS))
-                            .toArray(GeneralParameterValue[]::new);
-                }
-                if (Boolean.TRUE.equals(includeCoverages)) {
+            }
+        }
+        if (Boolean.TRUE.equals(includeCoverages)) {
+            if (!multiThreadedLoading || EXECUTOR == null) {
+                for (String coverageName : inputReaders.keySet()) {
+                    GridCoverage2DReader reader = inputReaders.get(coverageName);
                     GridCoverage2D coverage = reader.read(filteredParameters);
                     if (coverage == null) {
-                        if (handler.isHomogeneousCoverages()
-                                || handler.getEnvelopeCompositionType() == EnvelopeCompositionType.INTERSECTION) {
+                        if (handler.isHomogeneousCoverages() || handler.getEnvelopeCompositionType() == INTERSECTION) {
                             return null;
                         }
                     } else {
@@ -424,23 +450,69 @@ public class CoverageViewReader implements GridCoverage2DReader {
                     }
                     inputCoverages.put(coverageName, coverage);
                 }
+            } else {
+                // parallel read
+                List<Future<ParallelLoadingResult>> futures = new ArrayList<>();
+                for (String coverageName : inputReaders.keySet()) {
+                    Future<ParallelLoadingResult> future = EXECUTOR.submit(() -> {
+                        GridCoverage2DReader reader = inputReaders.get(coverageName);
+                        GridCoverage2D coverage = reader.read(filteredParameters);
+                        return new ParallelLoadingResult(coverageName, reader, coverage);
+                    });
+                    futures.add(future);
+                }
+
+                // sequential post-processing
+                for (Future<ParallelLoadingResult> future : futures) {
+                    try {
+                        ParallelLoadingResult result = future.get();
+                        GridCoverage2D coverage = result.coverage;
+                        if (coverage == null) {
+                            if (handler.isHomogeneousCoverages()
+                                    || handler.getEnvelopeCompositionType() == INTERSECTION) {
+                                return null;
+                            }
+                        } else {
+                            nonNullCoverages++;
+                        }
+                        if (dynamicAlphaSource == null && hasDynamicAlpha(coverage, result.reader)) {
+                            dynamicAlphaSource = coverage;
+                        }
+                        inputCoverages.put(result.coverageName, coverage);
+                    } catch (Exception e) {
+                        throw new IOException(e);
+                    }
+                }
             }
         }
+
         ViewInputs inputAlphaNonNull =
                 new ViewInputs(bands, inputReaders, inputCoverages, dynamicAlphaSource, nonNullCoverages);
         return inputAlphaNonNull;
     }
 
+    static class ParallelLoadingResult {
+        String coverageName;
+        GridCoverage2DReader reader;
+        GridCoverage2D coverage;
+
+        public ParallelLoadingResult(String coverageName, GridCoverage2DReader reader, GridCoverage2D coverage) {
+            this.coverageName = coverageName;
+            this.reader = reader;
+            this.coverage = coverage;
+        }
+    }
+
     static class ViewInputs {
         private final List<CoverageBand> bands;
-        private final HashMap<String, GridCoverageReader> inputReaders;
+        private final HashMap<String, GridCoverage2DReader> inputReaders;
         private final HashMap<String, GridCoverage2D> inputCoverages;
         private final GridCoverage2D dynamicAlphaSource;
         private final int nonNullCoverages;
 
         public ViewInputs(
                 List<CoverageBand> bands,
-                HashMap<String, GridCoverageReader> inputReaders,
+                HashMap<String, GridCoverage2DReader> inputReaders,
                 HashMap<String, GridCoverage2D> inputCoverages,
                 GridCoverage2D dynamicAlphaSource,
                 int nonNullCoverages) {
@@ -467,7 +539,7 @@ public class CoverageViewReader implements GridCoverage2DReader {
             return nonNullCoverages;
         }
 
-        public HashMap<String, GridCoverageReader> getInputReaders() {
+        public HashMap<String, GridCoverage2DReader> getInputReaders() {
             return inputReaders;
         }
     }
@@ -558,7 +630,7 @@ public class CoverageViewReader implements GridCoverage2DReader {
         return mergedBands;
     }
 
-    private boolean matches(GeneralParameterValue parameter, DefaultParameterDescriptor<?> expected) {
+    private boolean matches(GeneralParameterValue parameter, ParameterDescriptor<?> expected) {
         return parameter.getDescriptor().getName().equals(expected.getName());
     }
 
@@ -948,7 +1020,7 @@ public class CoverageViewReader implements GridCoverage2DReader {
     }
 
     private boolean viewHasPAM(ViewInputs info) {
-        Map<String, GridCoverageReader> readers = info.getInputReaders();
+        Map<String, GridCoverage2DReader> readers = info.getInputReaders();
         // iterate over the view bands and check for PAMs
         for (CoverageView.CoverageBand band : info.getBands()) {
             for (CoverageView.InputCoverageBand inputCoverageBand : band.getInputCoverageBands()) {

--- a/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CoverageViewReader.java
@@ -105,10 +105,11 @@ public class CoverageViewReader implements GridCoverage2DReader {
 
     /**
      * Executor for parallel loading of coverages that do support multithreaded loading to start with (e.g., image
-     * msoaic). It's not limiting the number of threads, because when MT loading is one, that's already limited in the
+     * mosaic). It's not limiting the number of threads, because when MT loading is one, that's already limited in the
      * readers. It cannot be the same executor used by the image mosaic (ResourcePool#getCoverageExecutor) because that
      * would cause deadlock (each read would use at least 2 threads, one inside the image mosaic and one inside the
-     * coverage view). Should we switch to allow parlale
+     * coverage view). Should we switch to allow parellel loading of coverages that do not support MT natively, a
+     * separate executor should be used.
      */
     private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool();
 

--- a/src/main/src/test/java/org/geoserver/catalog/CoverageViewTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/CoverageViewTest.java
@@ -46,6 +46,7 @@ import org.geotools.coverage.grid.io.footprint.FootprintBehavior;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.feature.visitor.MinVisitor;
+import org.geotools.gce.imagemosaic.ImageMosaicFormat;
 import org.geotools.geometry.GeneralBounds;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.image.util.ImageUtilities;
@@ -410,6 +411,18 @@ public class CoverageViewTest extends GeoServerSystemTestSupport {
     /** Tests a heterogeneous view without setting any extra configuration (falling back on defaults) */
     @Test
     public void testHeterogeneousViewDefaults() throws Exception {
+        assertHeterogeneousViewDefaults(null);
+    }
+
+    /** Same as {@link #testHeterogeneousViewDefaults()} but with multithraeded reading */
+    @Test
+    public void testHeterogeneousViewDefaultsMT() throws Exception {
+        ParameterValue<Boolean> mtParameter = ImageMosaicFormat.ALLOW_MULTITHREADING.createValue();
+        mtParameter.setValue(true);
+        assertHeterogeneousViewDefaults(new GeneralParameterValue[] {mtParameter});
+    }
+
+    private void assertHeterogeneousViewDefaults(GeneralParameterValue[] readParams) throws Exception {
         CoverageInfo info = buildHeterogeneousResolutionView(
                 "s2AllBandsDefaults",
                 cv -> {},
@@ -440,7 +453,7 @@ public class CoverageViewTest extends GeoServerSystemTestSupport {
             assertEquals(5300040, envelope.getMaximum(1), 1);
 
             // read the full coverage to verify it's consistent
-            coverage = reader.read(null);
+            coverage = reader.read(readParams);
             assertCoverageResolution(coverage, 1007, 1007);
 
             assertEquals(coverage.getEnvelope(), envelope);


### PR DESCRIPTION
[![GEOS-11722](https://badgen.net/badge/JIRA/GEOS-11722/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11722) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details.
Testing wise, I've verified that enabling MT does not change the result, and checked with debugging that full MT loading is happening. I don't see a reasonable and clean way to actually test full MT loading is happening.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.