### PR TITLE
[GEOS-11723] DGGS data store should be able to translate also intersection with multipolygon

### DIFF
--- a/src/community/ogcapi/dggs/dggs-core/src/main/java/org/geotools/dggs/h3/H3DGGSInstance.java
+++ b/src/community/ogcapi/dggs/dggs-core/src/main/java/org/geotools/dggs/h3/H3DGGSInstance.java
@@ -51,7 +51,7 @@ public class H3DGGSInstance implements DGGSInstance {
     final Set<Long> northPoleZones;
     final Set<Long> southPoleZones;
 
-    H3DGGSInstance(H3Core h3) {
+    public H3DGGSInstance(H3Core h3) {
         this.h3 = h3;
 
         int[] resolutions = getResolutions();

--- a/src/community/ogcapi/dggs/dggs-core/src/test/java/org/geotools/dggs/DGGSFilterTransformerTest.java
+++ b/src/community/ogcapi/dggs/dggs-core/src/test/java/org/geotools/dggs/DGGSFilterTransformerTest.java
@@ -1,0 +1,69 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This file is hereby placed into the Public Domain. This means anyone is
+ *    free to do whatever they wish with this file. Use it well and enjoy!
+ */
+package org.geotools.dggs;
+
+import static org.junit.Assert.*;
+
+import com.uber.h3core.H3Core;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.PropertyIsEqualTo;
+import org.geotools.api.filter.spatial.Intersects;
+import org.geotools.dggs.gstore.DGGSResolutionCalculator;
+import org.geotools.dggs.h3.H3DGGSInstance;
+import org.geotools.factory.CommonFactoryFinder;
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+public class DGGSFilterTransformerTest {
+
+    FilterFactory FF = CommonFactoryFinder.getFilterFactory();
+    DGGSFilterTransformer transformer;
+
+    @Before
+    public void setupTransformer() throws Exception {
+        H3DGGSInstance dggs = new H3DGGSInstance(H3Core.newInstance());
+        DGGSResolutionCalculator resolutionCalculator = new DGGSResolutionCalculator(dggs);
+        transformer = new DGGSFilterTransformer(dggs, resolutionCalculator, 3);
+    }
+
+    @Test
+    public void testPolygon() throws Exception {
+        Intersects intersects = FF.intersects("geom", read("POLYGON((12 45, 12 46, 13 46, 13 45, 12 45))"));
+        Filter transformed = (Filter) intersects.accept(transformer, null);
+        PropertyIsEqualTo inZone = FF.equal(
+                FF.function("in", FF.property("zoneId"), FF.literal("831ea5fffffffff")), FF.literal(true), true);
+        PropertyIsEqualTo matchResolution = FF.equal(FF.property("resolution"), FF.literal(3), true);
+        Filter expected = FF.and(inZone, matchResolution);
+        assertEquals(expected, transformed);
+    }
+
+    @Test
+    public void testMultiPolygon() throws Exception {
+        Intersects intersects = FF.intersects(
+                "geom",
+                read("MULTIPOLYGON(((11 45, 11 46, 12 46, 12 45, 11 45)), ((12 45, 12 46, 13 46, 13 45, 12 45)))"));
+        Filter transformed = (Filter) intersects.accept(transformer, null);
+        PropertyIsEqualTo inZone = FF.equal(
+                FF.function("in", FF.property("zoneId"), FF.literal("831ea4fffffffff"), FF.literal("831ea5fffffffff")),
+                FF.literal(true),
+                true);
+        PropertyIsEqualTo matchResolution = FF.equal(FF.property("resolution"), FF.literal(3), true);
+        Filter expected = FF.and(inZone, matchResolution);
+        assertEquals(transformed, expected);
+    }
+
+    private static Geometry read(String wellKnownText) throws ParseException {
+        return new WKTReader().read(wellKnownText);
+    }
+}


### PR DESCRIPTION
[![GEOS-11723](https://badgen.net/badge/JIRA/GEOS-11723/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11723) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.