### PR TITLE
DRAFT: Add health check endpoint to GeoServer

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/CatalogTimeStampUpdater.java
+++ b/src/main/src/main/java/org/geoserver/config/CatalogTimeStampUpdater.java
@@ -31,6 +31,7 @@ public class CatalogTimeStampUpdater implements CatalogListener {
     static final Logger LOGGER = Logging.getLogger(CatalogTimeStampUpdater.class);
 
     Catalog catalog;
+    private boolean catalogLoading;
 
     public CatalogTimeStampUpdater(Catalog catalog) {
 
@@ -56,10 +57,14 @@ public class CatalogTimeStampUpdater implements CatalogListener {
     }
 
     @Override
-    public void handleAddEvent(CatalogAddEvent event) throws CatalogException {}
+    public void handleAddEvent(CatalogAddEvent event) throws CatalogException {
+        catalogLoading = true;
+    }
 
     @Override
-    public void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {}
+    public void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {
+        catalogLoading = true;
+    }
 
     @Override
     public void handleModifyEvent(CatalogModifyEvent event) throws CatalogException {
@@ -74,12 +79,21 @@ public class CatalogTimeStampUpdater implements CatalogListener {
             Date dateModified = new Date();
             info.setDateModified(dateModified);
         }
+        catalogLoading = true;
         LOGGER.finest(event.toString() + " :handleModifyEvent");
     }
 
     @Override
-    public void handlePostModifyEvent(CatalogPostModifyEvent event) throws CatalogException {}
+    public void handlePostModifyEvent(CatalogPostModifyEvent event) throws CatalogException {
+        catalogLoading = false;
+    }
 
     @Override
-    public void reloaded() {}
+    public void reloaded() {
+        catalogLoading = false;
+    }
+
+    public boolean isCatalogLoading() {
+        return catalogLoading;
+    }
 }

--- a/src/main/src/main/java/org/geoserver/config/GeoServer.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServer.java
@@ -250,4 +250,7 @@ public interface GeoServer {
      * new one
      */
     void reload(Catalog catalog) throws Exception;
+
+    /** Checks if the catalog is currently loading or reloading. */
+    boolean isCatalogLoading();
 }

--- a/src/main/src/main/java/org/geoserver/config/GeoServerConfigPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerConfigPersister.java
@@ -50,6 +50,8 @@ public class GeoServerConfigPersister implements CatalogListener, ConfigurationL
     GeoServerDataDirectory dd;
     XStreamPersister xp;
 
+    private boolean catalogLoading;
+
     public GeoServerConfigPersister(GeoServerResourceLoader rl, XStreamPersister xp) {
         this.rl = rl;
         this.dd = new GeoServerDataDirectory(rl);
@@ -58,6 +60,7 @@ public class GeoServerConfigPersister implements CatalogListener, ConfigurationL
 
     @Override
     public void handleAddEvent(CatalogAddEvent event) {
+        catalogLoading = true;
         Object source = event.getSource();
         try {
             if (source instanceof WorkspaceInfo) {
@@ -94,6 +97,7 @@ public class GeoServerConfigPersister implements CatalogListener, ConfigurationL
 
     @Override
     public void handleModifyEvent(CatalogModifyEvent event) {
+        catalogLoading = true;
         Object source = event.getSource();
 
         try {
@@ -169,6 +173,7 @@ public class GeoServerConfigPersister implements CatalogListener, ConfigurationL
 
     @Override
     public void handlePostModifyEvent(CatalogPostModifyEvent event) {
+        catalogLoading = false;
         Object source = event.getSource();
         try {
             if (source instanceof WorkspaceInfo) {
@@ -205,6 +210,7 @@ public class GeoServerConfigPersister implements CatalogListener, ConfigurationL
 
     @Override
     public void handleRemoveEvent(CatalogRemoveEvent event) {
+        catalogLoading = true;
         Object source = event.getSource();
         try {
             if (source instanceof WorkspaceInfo) {
@@ -650,5 +656,9 @@ public class GeoServerConfigPersister implements CatalogListener, ConfigurationL
     @Override
     public int getPriority() {
         return ExtensionPriority.HIGHEST;
+    }
+
+    public boolean isCatalogLoading() {
+        return catalogLoading;
     }
 }

--- a/src/main/src/main/java/org/geoserver/config/HealthCheckEndpoint.java
+++ b/src/main/src/main/java/org/geoserver/config/HealthCheckEndpoint.java
@@ -1,0 +1,19 @@
+package org.geoserver.config;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckEndpoint {
+
+    private final GeoServer geoServer;
+
+    public HealthCheckEndpoint(GeoServer geoServer) {
+        this.geoServer = geoServer;
+    }
+
+    @GetMapping("/health")
+    public boolean isCatalogLoading() {
+        return !geoServer.isCatalogLoading();
+    }
+}

--- a/src/main/src/main/java/org/geoserver/config/HealthCheckEndpoint.java
+++ b/src/main/src/main/java/org/geoserver/config/HealthCheckEndpoint.java
@@ -1,3 +1,8 @@
+/* (c) 2014 - 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
 package org.geoserver.config;
 
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/src/main/java/org/geoserver/config/impl/GeoServerImpl.java
+++ b/src/main/src/main/java/org/geoserver/config/impl/GeoServerImpl.java
@@ -51,6 +51,8 @@ public class GeoServerImpl implements GeoServer, ApplicationContextAware {
     /** listeners */
     List<ConfigurationListener> listeners = new ArrayList<>();
 
+    private boolean catalogLoading;
+
     public GeoServerImpl() {
         this.facade = new DefaultGeoServerFacade(this);
     }
@@ -520,6 +522,6 @@ public class GeoServerImpl implements GeoServer, ApplicationContextAware {
 
     @Override
     public boolean isCatalogLoading() {
-        return catalog.isLoading();
+        return catalogLoading;
     }
 }

--- a/src/main/src/main/java/org/geoserver/config/impl/GeoServerImpl.java
+++ b/src/main/src/main/java/org/geoserver/config/impl/GeoServerImpl.java
@@ -517,4 +517,9 @@ public class GeoServerImpl implements GeoServer, ApplicationContextAware {
             }
         }
     }
+
+    @Override
+    public boolean isCatalogLoading() {
+        return catalog.isLoading();
+    }
 }


### PR DESCRIPTION
Add an HTTP endpoint to perform a health check http://localhost:8080/geoserver/health-check and return 503 Service Unavailable when the catalog is being loaded or reloaded, otherwise 200 Success.

* **HealthCheckEndpoint.java**: Create a new class `HealthCheckEndpoint` to handle the HTTP endpoint for health checks. Implement a method `isCatalogLoading` to return the catalog loading status. Use `@RestController` and `@GetMapping` annotations to define the endpoint.
* **GeoServer.java**: Add a new method `isCatalogLoading` to check the catalog loading status.
* **GeoServerConfigPersister.java**: Update the `handleAddEvent`, `handleModifyEvent`, and `handleRemoveEvent` methods to set the catalog loading status. Add a field to track the catalog loading status.