### PR TITLE
[GEOS-11738] Prevent error when oidc provider sends empty "&state="

### DIFF
--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/ValidatingOAuth2RestTemplate.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/main/java/org/geoserver/security/oauth2/ValidatingOAuth2RestTemplate.java
@@ -45,6 +45,12 @@ class ValidatingOAuth2RestTemplate extends OAuth2RestTemplate {
 
         OAuth2AccessToken result = null;
         try {
+            // prevent error in AuthorizationCodeAccessTokenProvider from spring-security-oauth2
+            // when oidc provider sends empty "&state=" parameter
+            String stateKey = oauth2Context.getAccessTokenRequest().getStateKey();
+            if (stateKey != null && stateKey.isEmpty()) {
+                oauth2Context.getAccessTokenRequest().setStateKey(null);
+            }
             result = super.acquireAccessToken(oauth2Context);
             return result;
         } finally {

--- a/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdConnectIntegrationTest.java
+++ b/src/community/security/oauth2-openid-connect/oauth2-openid-connect-core/src/test/java/org/geoserver/security/oauth2/OpenIdConnectIntegrationTest.java
@@ -278,6 +278,21 @@ public class OpenIdConnectIntegrationTest extends GeoServerSystemTestSupport {
     }
 
     @Test
+    public void testEmptyStateParameter() throws Exception {
+        // Simulate the OpenID Provider sending the user back with an empty &state parameter.
+        // This happens e.g. when using Dex IdP and not sending a state parameter in the request to the OpenID Provider.
+        MockHttpServletRequest codeRequest = createRequest("web/?code=" + CODE + "&state=");
+        MockHttpServletResponse codeResponse = executeOnSecurityFilters(codeRequest);
+
+        // should be authenticated
+        SecurityContext context = new HttpSessionSecurityContextRepository()
+                .loadContext(new HttpRequestResponseHolder(codeRequest, codeResponse));
+        Authentication auth = context.getAuthentication();
+        assertNotNull("Authentication should not be null", auth);
+        assertEquals("andrea.aime@gmail.com", auth.getPrincipal());
+    }
+
+    @Test
     public void testIdTokenHintInEndSessionURI() throws Exception {
         GeoServerSecurityManager manager = getSecurityManager();
         OpenIdConnectFilterConfig config = (OpenIdConnectFilterConfig) manager.loadFilterConfig("openidconnect", true);


### PR DESCRIPTION
This fixes the bug I described in GEOS-11738.

When using Dex IdP as OpenId Connect provider with the oauth2-openid-connect, an Exception is thrown in 
AuthorizationCodeAccessTokenProvider  from spring-security-oauth2 when logging in via the OIDC login button in the GeoServer web interface.

This occurs because the GeoServer oidc plugin does not set the (optional, protects against CSRF) state parameter in the request to the oidc provider. When using Dex IdP, it responds with an empty "&state=" parameter when redirecting the browser back to GeoServer with the "code". I am not sure whether this behavior by Dex violates some oidc spec or not.

The root cause is in [this line](https://github.com/spring-attic/spring-security-oauth/blob/0344de8cc75055742f638b1e476a646a6f5891d9/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeAccessTokenProvider.java#L255) in AuthorizationCodeAccessTokenProvider, which throws an Exception when the state parameter is present, but empty.

Everything works if we just remove the state parameter from the request back to GeoServer, if it is empty anyways. The cases "state parameter is present but empty" and "no state parameter present at all" don't need to be distinguished as far as I understand oidc.

Admittedly, this "fix" would not be needed when fully implementing actually setting the state parameter instead. But if noone has the time to do that, this is an improvement.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

