### PR TITLE
[GEOS-11620] Fix JDBC URL parsing issue on Smart data loader

### DIFF
--- a/src/community/smart-data-loader/src/main/java/org/geoserver/smartdataloader/metadata/jdbc/utils/JdbcUrlSplitter.java
+++ b/src/community/smart-data-loader/src/main/java/org/geoserver/smartdataloader/metadata/jdbc/utils/JdbcUrlSplitter.java
@@ -20,7 +20,7 @@ public class JdbcUrlSplitter {
             throw new IllegalArgumentException("Invalid JDBC url.");
 
         driverName = jdbcUrl.substring(5, pos1);
-        if ((pos2 = jdbcUrl.indexOf(';', pos1)) == -1) {
+        if ((pos2 = firstParamsSeparatorPosition(jdbcUrl)) == -1) {
             connUri = jdbcUrl.substring(pos1 + 1);
         } else {
             connUri = jdbcUrl.substring(pos1 + 1, pos2);
@@ -40,5 +40,11 @@ public class JdbcUrlSplitter {
         } else {
             database = connUri;
         }
+    }
+
+    private int firstParamsSeparatorPosition(String URL) {
+        int pos1 = URL.indexOf(';', 5);
+        int pos2 = URL.indexOf('?', 5);
+        return pos1 == -1 ? pos2 : pos2 == -1 ? pos1 : Math.min(pos1, pos2);
     }
 }

--- a/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/metadata/jdbc/utils/JdbcUrlSplitterTest.java
+++ b/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/metadata/jdbc/utils/JdbcUrlSplitterTest.java
@@ -1,0 +1,43 @@
+package org.geoserver.smartdataloader.metadata.jdbc.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JdbcUrlSplitterTest {
+
+    @Test
+    public void testJdbcUrlSplitter() {
+        JdbcUrlSplitter jdbcUrlSplitter = new JdbcUrlSplitter("jdbc:postgresql://localhost:5432/geoserver");
+        Assert.assertEquals("postgresql", jdbcUrlSplitter.driverName);
+        Assert.assertEquals("localhost", jdbcUrlSplitter.host);
+        Assert.assertEquals("5432", jdbcUrlSplitter.port);
+        Assert.assertEquals("geoserver", jdbcUrlSplitter.database);
+        Assert.assertNull(jdbcUrlSplitter.params);
+    }
+
+    @Test
+    public void testJdbcUrlSplitterWithParams() {
+        String jdbcUrl =
+                "jdbc:postgresql://localhost:5432/mydatabase?reWriteBatchedInserts=false&amp;sslmode=DISABLE&amp;binaryTransferEnable=bytea";
+        JdbcUrlSplitter splitter = new JdbcUrlSplitter(jdbcUrl);
+
+        Assert.assertEquals("postgresql", splitter.driverName);
+        Assert.assertEquals("localhost", splitter.host);
+        Assert.assertEquals("5432", splitter.port);
+        Assert.assertEquals("mydatabase", splitter.database);
+        Assert.assertNotNull(splitter.params);
+    }
+
+    @Test
+    public void testJdbcUrlSplitterWithParams2() {
+        String jdbcUrl =
+                "jdbc:postgresql://localhost:5432/mydatabase;reWriteBatchedInserts=false&amp;sslmode=DISABLE&amp;binaryTransferEnable=bytea";
+        JdbcUrlSplitter splitter = new JdbcUrlSplitter(jdbcUrl);
+
+        Assert.assertEquals("postgresql", splitter.driverName);
+        Assert.assertEquals("localhost", splitter.host);
+        Assert.assertEquals("5432", splitter.port);
+        Assert.assertEquals("mydatabase", splitter.database);
+        Assert.assertNotNull(splitter.params);
+    }
+}


### PR DESCRIPTION
[![GEOS-11620](https://badgen.net/badge/JIRA/GEOS-11620/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11620) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-11620
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

This PR solves the problem between smart data loader and the new postgres store JDBC URL parameters.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.