### PR TITLE
Re-enable sec-jdbc module's JNDI tests without requiring jndi.properties file

### DIFF
--- a/src/security/jdbc/pom.xml
+++ b/src/security/jdbc/pom.xml
@@ -18,10 +18,6 @@
   <packaging>jar</packaging>
   <name>GeoServer JDBC Security Module</name>
 
-  <properties>
-    <test.exclude.pattern>**/*JNDI*Test*</test.exclude.pattern>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.geoserver</groupId>
@@ -50,6 +46,12 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.h-thurow</groupId>
+      <artifactId>simple-jndi</artifactId>
+      <version>0.25.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -68,22 +70,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <!-- placing this in a profile since it interfers with running from the
-           development environemtn with the startup of the jdbc datastores -->
-      <id>secJdbcJndiTest</id>
-      <properties>
-        <test.exclude.pattern>none</test.exclude.pattern>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>simple-jndi</groupId>
-          <artifactId>simple-jndi</artifactId>
-          <version>0.11.4.1</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/H2JNDIRoleServiceTest.java
+++ b/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/H2JNDIRoleServiceTest.java
@@ -7,8 +7,12 @@
 package org.geoserver.security.jdbc;
 
 import org.geoserver.security.GeoServerRoleService;
+import org.junit.ClassRule;
 
 public class H2JNDIRoleServiceTest extends JDBCRoleServiceTest {
+
+    @ClassRule
+    public static final H2JNDITestConfig jndiConfig = new H2JNDITestConfig();
 
     @Override
     protected String getFixtureId() {

--- a/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/H2JNDITestConfig.java
+++ b/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/H2JNDITestConfig.java
@@ -1,0 +1,37 @@
+package org.geoserver.security.jdbc;
+
+import org.junit.rules.ExternalResource;
+
+/**
+ * A JUnit4 {@link org.junit.ClassRule} to configure JNDI properties for H2 database testing.
+ *
+ * <p>This rule sets up the required JNDI system properties before test execution and clears them afterward, ensuring a
+ * clean test environment.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ * &#64;ClassRule
+ * public static final H2JNDITestConfig jndiConfig = new H2JNDITestConfig();
+ * </pre>
+ */
+class H2JNDITestConfig extends ExternalResource {
+
+    /** Configures the system properties required for JNDI setup before test execution. */
+    @Override
+    protected void before() {
+        System.setProperty("java.naming.factory.initial", "org.osjava.sj.SimpleContextFactory");
+        System.setProperty("org.osjava.sj.root", "target/test-classes/config");
+        System.setProperty("org.osjava.jndi.delimiter", "/");
+        System.setProperty("org.osjava.sj.jndi.shared", "true");
+    }
+
+    /** Clears the JNDI-related system properties after test execution to ensure a clean state for subsequent tests. */
+    @Override
+    protected void after() {
+        System.clearProperty("java.naming.factory.initial");
+        System.clearProperty("org.osjava.sj.root");
+        System.clearProperty("org.osjava.jndi.delimiter");
+        System.clearProperty("org.osjava.sj.jndi.shared");
+    }
+}

--- a/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/H2JNDIUserDetailsServiceTest.java
+++ b/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/H2JNDIUserDetailsServiceTest.java
@@ -8,8 +8,12 @@ package org.geoserver.security.jdbc;
 
 import org.geoserver.security.GeoServerRoleService;
 import org.geoserver.security.GeoServerUserGroupService;
+import org.junit.ClassRule;
 
 public class H2JNDIUserDetailsServiceTest extends JDBCUserDetailsServiceTest {
+
+    @ClassRule
+    public static final H2JNDITestConfig jndiConfig = new H2JNDITestConfig();
 
     @Override
     protected String getFixtureId() {

--- a/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/H2JNDIUserGroupServiceTest.java
+++ b/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/H2JNDIUserGroupServiceTest.java
@@ -8,8 +8,12 @@ package org.geoserver.security.jdbc;
 
 import org.geoserver.security.GeoServerUserGroupService;
 import org.geoserver.security.jdbc.config.JDBCUserGroupServiceConfig;
+import org.junit.ClassRule;
 
 public class H2JNDIUserGroupServiceTest extends JDBCUserGroupServiceTest {
+
+    @ClassRule
+    public static final H2JNDITestConfig jndiConfig = new H2JNDITestConfig();
 
     @Override
     protected String getFixtureId() {

--- a/src/security/jdbc/src/test/resources/jndi.properties
+++ b/src/security/jdbc/src/test/resources/jndi.properties
@@ -1,4 +1,0 @@
-java.naming.factory.initial=org.osjava.sj.SimpleContextFactory
-org.osjava.sj.root=target/test-classes/config
-org.osjava.jndi.delimiter=/
-org.osjava.sj.jndi.shared=true


### PR DESCRIPTION
Re-enabled `sec-jdbc` JNDI tests by replacing the `jndi.properties` file with an in-code JNDI configuration to prevent interference when running GeoServer from `Start.java` in the `web-app` module. The presence of `jndi.properties` caused errors due to `org.osjava.sj.SimpleContextFactory` not being in the classpath during application startup, once per `DataStoreInfo`.

To resolve this, `H2JNDITestConfig` was introduced as a JUnit4 `@ClassRule` to dynamically configure JNDI properties only during test execution.

The new rule has been applied to `H2JNDIRoleServiceTest`, `H2JNDIUserDetailsServiceTest`, and `H2JNDIUserGroupServiceTest`.

Additionally, `pom.xml` has been updated to remove the `test.exclude.pattern`, allowing JNDI tests to run again, and the `simple-jndi` dependency has been added directly under the test scope instead of using a separate Maven profile.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.