### PR TITLE
[GEOS-11747] GeoServer does not throw JAI runtime exceptions

### DIFF
--- a/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerSystemTestSupport.java
@@ -71,6 +71,7 @@ import org.apache.http.message.BasicHeaderValueParser;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.geoserver.GeoserverInitStartupListener;
 import org.geoserver.catalog.CascadeDeleteVisitor;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
@@ -334,6 +335,9 @@ public class GeoServerSystemTestSupport extends GeoServerBaseTestSupport<SystemT
 
             // Allow resolution of XSDs from local file system
             EntityResolverProvider.setEntityResolver(RESOLVE_DISABLED_PROVIDER_DEVMODE);
+
+            // Use GeoServer's JAI ImagingListener
+            GeoserverInitStartupListener.initJAIDefaultInstance();
 
             getSecurityManager().setAuthenticationCache(new TestingAuthenticationCache());
             onSetUp(testData);

--- a/src/wms/src/test/java/org/geoserver/wms/map/RenderedImageMapOutputFormatTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/RenderedImageMapOutputFormatTest.java
@@ -1680,6 +1680,29 @@ public class RenderedImageMapOutputFormatTest extends WMSTestSupport {
         assertNotNull(image);
         assertBlank("testFaultyStyleDoesntBreak", image);
     }
+
+    @Test
+    public void testJAIImagingListenerException() throws Exception {
+        // this style contains a Jiffle script that will cause a JiffleRuntimeException to be thrown and passed to the
+        // JAI ImagingListener set by org.geoserver.GeoserverInitStartupListener
+        String layer = MockData.TASMANIA_DEM.getPrefix() + ":" + MockData.TASMANIA_DEM.getLocalPart();
+        MockHttpServletResponse response = getAsServletResponse(
+                "wms?request=GetMap&format=image/png&width=256&height=256&srs=EPSG:4326&bbox=-180,-90,180,90&layers="
+                        + layer
+                        + "&sld_body=<StyledLayerDescriptor><NamedLayer><Name>"
+                        + layer
+                        + "</Name><UserStyle><FeatureTypeStyle><Transformation><Function name=\"ras:Jiffle\">"
+                        + "<Function name=\"parameter\"><Literal>coverage</Literal></Function>"
+                        + "<Function name=\"parameter\"><Literal>script</Literal><Literal>dest=src[1000,1000];</Literal>"
+                        + "</Function></Function></Transformation><Rule><RasterSymbolizer/></Rule>"
+                        + "</FeatureTypeStyle></UserStyle></NamedLayer></StyledLayerDescriptor>");
+        assertEquals("text/xml;charset=UTF-8", response.getContentType());
+        String content = response.getContentAsString();
+        assertThat(content, containsString("ServiceExceptionReport"));
+        assertThat(content, containsString("jiffle.runtime.JiffleRuntimeException"));
+        assertThat(content, containsString(" is outside bounds of image: src"));
+    }
+
     /**
      * This dummy producer adds no functionality to DefaultRasterMapOutputFormat, just implements a void
      * formatImageOutputStream to have a concrete class over which test that DefaultRasterMapOutputFormat correctly


### PR DESCRIPTION
[![GEOS-11747](https://badgen.net/badge/JIRA/GEOS-11747/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11747) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR updates GeoServer's ImagingListener to throw runtime exceptions that don't come from an OperationRegistry and don't meet the other conditions to hide an exception. It was also moved into a separate method that is called in GeoServerSystemTestSupport so that all GeoServer unit tests now use the GeoServer listener instead of the GeoTools one. The GeoTools listener has the same if statement to throw JAI runtime exceptions so there was different behavior between the behavior in unit tests and when GeoServer was deployed in a server.

This PR is related to https://github.com/geosolutions-it/jai-ext/pull/307
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.