### PR TITLE
Make StatusPageTest.ExtraTabDefinition serializable

### DIFF
--- a/src/web/core/src/test/java/org/geoserver/web/admin/StatusPageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/admin/StatusPageTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.wicket.Component;
@@ -212,7 +213,8 @@ public class StatusPageTest extends GeoServerWicketTestSupport {
     }
 
     /** Extra tab definition that will be added to GeoServer status page. */
-    public static final class ExtraTabDefinition implements StatusPage.TabDefinition {
+    @SuppressWarnings("serial")
+    public static final class ExtraTabDefinition implements StatusPage.TabDefinition, Serializable {
 
         @Override
         public String getTitleKey() {


### PR DESCRIPTION
Avoids stack exception stack traces due to wicket storing the page in the session while running web-app's Start during development


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.