### PR TITLE
[GEOS-11755] AbstractCatalogFacade leaves dangling references to temporary Catalog

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogFacade.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogFacade.java
@@ -160,14 +160,16 @@ public abstract class AbstractCatalogFacade implements CatalogFacade {
 
     protected void resolve(StyleInfo style) {
         setId(style);
+        StyleInfoImpl s = (StyleInfoImpl) style;
+        s.setCatalog(getCatalog());
 
         // resolve the workspace
-        WorkspaceInfo ws = style.getWorkspace();
+        WorkspaceInfo ws = s.getWorkspace();
         if (ws != null) {
             WorkspaceInfo resolved = ResolvingProxy.resolve(getCatalog(), ws);
             if (resolved != null) {
                 resolved = unwrap(resolved);
-                style.setWorkspace(resolved);
+                s.setWorkspace(resolved);
             } else {
                 LOGGER.log(
                         Level.INFO,
@@ -193,6 +195,7 @@ public abstract class AbstractCatalogFacade implements CatalogFacade {
     protected void resolve(StoreInfo store) {
         setId(store);
         StoreInfoImpl s = (StoreInfoImpl) store;
+        s.setCatalog(getCatalog());
 
         // resolve the workspace
         WorkspaceInfo resolved = ResolvingProxy.resolve(getCatalog(), s.getWorkspace());
@@ -211,6 +214,7 @@ public abstract class AbstractCatalogFacade implements CatalogFacade {
     protected void resolve(ResourceInfo resource) {
         setId(resource);
         ResourceInfoImpl r = (ResourceInfoImpl) resource;
+        r.setCatalog(getCatalog());
 
         // resolve the store
         StoreInfo store = ResolvingProxy.resolve(getCatalog(), r.getStore());


### PR DESCRIPTION
[![GEOS-11755](https://badgen.net/badge/JIRA/GEOS-11755/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11755) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The data directory loading process involves loading all catalog objects to a temporary catalog and then synchronizing the real catalog with the temporary one.

In doing so, AbstractCatalogFacade.resolve() does not replace the catalog property of `StyleInfoImpl`, `ResourceInfoImpl`, and `StoreInfoImpl`, with the real catalog reference, hence leaving all those objects with dangling references to the temporary Catalog instance. With the default implementation, things keep on working by accident due to `CatalogImpl.sync(Catalog)` taking ownership over the temporary catalog’s internals.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.