### PR TITLE
[GEOS-11756] GeoServerDataDirectory's defatul workspace location is wrong

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
@@ -255,7 +255,7 @@ public class GeoServerDataDirectory {
      * @return A {@link Resource}
      */
     public @Nonnull Resource defaultWorkspaceConfig() {
-        Resource r = getRoot("default.xml");
+        Resource r = getWorkspaces("default.xml");
         assert r != null;
         return r;
     }

--- a/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
+++ b/src/main/src/test/java/org/geoserver/config/GeoServerDataDirectoryTest.java
@@ -17,6 +17,7 @@ import org.geoserver.catalog.impl.CatalogFactoryImpl;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.platform.resource.Resource;
 import org.geotools.api.style.ExternalGraphic;
 import org.geotools.api.style.GraphicalSymbol;
 import org.geotools.api.style.PointSymbolizer;
@@ -74,6 +75,12 @@ public class GeoServerDataDirectoryTest {
         assertEquals(
                 dataDir.getLayerGroups((WorkspaceInfo) null, "test").path(),
                 dataDir.getLayerGroups("test").path());
+    }
+
+    @Test
+    public void testDefaultWorkspaceConfig() {
+        Resource resource = dataDir.defaultWorkspaceConfig();
+        assertEquals(dataDir.getRoot().get("workspaces").get("default.xml").path(), resource.path());
     }
 
     @Test


### PR DESCRIPTION
`GeoServerDataDirectory.defaultWorkspaceConfig()` should lead to the `workspaces/default.xml` file but leads to `default.xml` in the root data directory.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.
