### PR TITLE
[GEOS-11757] Optimize ConfigurationPasswordEncryptionHelper to cache encrypted fields by store type

### DIFF
--- a/src/main/src/test/java/org/geoserver/security/password/ConfigurationPasswordEncryptionHelperTest.java
+++ b/src/main/src/test/java/org/geoserver/security/password/ConfigurationPasswordEncryptionHelperTest.java
@@ -1,0 +1,154 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.password;
+
+import static org.geoserver.security.password.ConfigurationPasswordEncryptionHelper.CACHE;
+import static org.geoserver.security.password.ConfigurationPasswordEncryptionHelper.STORE_INFO_TYPE_CACHE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.ResourcePool;
+import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.catalog.impl.DataStoreInfoImpl;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geotools.data.postgis.PostgisNGDataStoreFactory;
+import org.geotools.data.shapefile.ShapefileDataStoreFactory;
+import org.geotools.jdbc.JDBCDataStoreFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConfigurationPasswordEncryptionHelperTest {
+
+    private Catalog catalog;
+    private GeoServerSecurityManager mockSecurityManager;
+    private ConfigurationPasswordEncryptionHelper helper;
+
+    @Before
+    public void setUp() {
+        catalog = new CatalogImpl();
+        GeoServerExtensionsHelper.singleton("rawCatalog", catalog, Catalog.class);
+        mockSecurityManager = mock(GeoServerSecurityManager.class);
+        helper = new ConfigurationPasswordEncryptionHelper(mockSecurityManager);
+        CACHE.clear();
+        STORE_INFO_TYPE_CACHE.clear();
+    }
+
+    @Test
+    public void getEncryptedFieldsNullFactory() throws IOException {
+        DataStoreInfo info = new DataStoreInfoImpl(catalog);
+        // preflight
+        assertNull(helper.getCatalog().getResourcePool().getDataStoreFactory(info));
+
+        helper.getEncryptedFields(info);
+        assertTrue(CACHE.isEmpty());
+        assertTrue(STORE_INFO_TYPE_CACHE.isEmpty());
+    }
+
+    @Test
+    public void getEncryptedFieldsStoreInfoTypeCacheOnFactoryFound() throws IOException {
+        DataStoreInfo info = new DataStoreInfoImpl(catalog);
+        Map<String, Serializable> params = info.getConnectionParameters();
+        params.put(PostgisNGDataStoreFactory.DBTYPE.key, (String) PostgisNGDataStoreFactory.DBTYPE.getDefaultValue());
+        info.setType(new PostgisNGDataStoreFactory().getDisplayName());
+
+        // preflight
+        assertThat(
+                helper.getCatalog().getResourcePool().getDataStoreFactory(info),
+                instanceOf(PostgisNGDataStoreFactory.class));
+
+        helper.getEncryptedFields(info);
+        Set<String> expected = CACHE.get(PostgisNGDataStoreFactory.class);
+        assertThat(expected, equalTo(Set.of(JDBCDataStoreFactory.PASSWD.key)));
+
+        assertEquals(expected, STORE_INFO_TYPE_CACHE.get(info.getType()));
+    }
+
+    /**
+     * Some old data directories have DataStoreInfo configs with no type property set, which causes
+     * {@link ConfigurationPasswordEncryptionHelper#getEncryptedFields()} to return immediately once it found a hit on
+     * the CACHE by factory class, but then it'll keep calling
+     * {@code getCatalog().getResourcePool().getDataStoreFactory(info)} for all the stores, which drains performance due
+     * to the cost of {@link ResourcePool} cloning the info using serialization and deserialization, beside the cost of
+     * the factory lookup itself
+     */
+    @Test
+    public void getEncryptedFieldsStoreInfoTypeCacheOnFactoryGet() throws IOException {
+        DataStoreInfo infoWithNoType = new DataStoreInfoImpl(catalog);
+        Map<String, Serializable> params = infoWithNoType.getConnectionParameters();
+        params.put(PostgisNGDataStoreFactory.DBTYPE.key, (String) PostgisNGDataStoreFactory.DBTYPE.getDefaultValue());
+        params.put(JDBCDataStoreFactory.HOST.key, "localhost");
+        params.put(JDBCDataStoreFactory.DATABASE.key, "test");
+        params.put(PostgisNGDataStoreFactory.PORT.key, 54329);
+        params.put(JDBCDataStoreFactory.USER.key, "geo");
+        params.put(JDBCDataStoreFactory.PASSWD.key, "123");
+
+        // preflight
+        assertThat(
+                helper.getCatalog().getResourcePool().getDataStoreFactory(infoWithNoType),
+                instanceOf(PostgisNGDataStoreFactory.class));
+
+        DataStoreInfo infoWithType = new DataStoreInfoImpl(catalog);
+        infoWithType.getConnectionParameters().putAll(infoWithNoType.getConnectionParameters());
+        infoWithType.setType(new PostgisNGDataStoreFactory().getDisplayName());
+
+        helper.getEncryptedFields(infoWithNoType);
+        assertNotNull(CACHE.get(PostgisNGDataStoreFactory.class));
+
+        assertTrue("infoWithNoType can't get a hit on the info type cache", STORE_INFO_TYPE_CACHE.isEmpty());
+
+        // now call it with a DataStoreInfo of the same factory but with type set
+        helper.getEncryptedFields(infoWithType);
+
+        Set<String> expected = Set.of(JDBCDataStoreFactory.PASSWD.key);
+        assertEquals(expected, STORE_INFO_TYPE_CACHE.get(infoWithType.getType()));
+    }
+
+    @Test
+    public void testDecodeWontCallSecurityManagerLoadPasswordEncodersIfNotNeeded() {
+        DataStoreInfo info = new DataStoreInfoImpl(catalog);
+        Map<String, Serializable> params = info.getConnectionParameters();
+        params.put(ShapefileDataStoreFactory.FILE_TYPE.key, (String)
+                ShapefileDataStoreFactory.FILE_TYPE.getDefaultValue());
+        info.setType(new ShapefileDataStoreFactory().getDisplayName());
+
+        // preflight
+        assertTrue(helper.getEncryptedFields(info).isEmpty());
+
+        helper.decode(info);
+        verify(mockSecurityManager, never()).loadPasswordEncoders(any(), any(), any());
+
+        // now check it does call it when there's something to decode
+        params.put(PostgisNGDataStoreFactory.DBTYPE.key, (String) PostgisNGDataStoreFactory.DBTYPE.getDefaultValue());
+        params.put(JDBCDataStoreFactory.HOST.key, "localhost");
+        params.put(JDBCDataStoreFactory.DATABASE.key, "test");
+        params.put(PostgisNGDataStoreFactory.PORT.key, 54329);
+        params.put(JDBCDataStoreFactory.USER.key, "geo");
+        params.put(JDBCDataStoreFactory.PASSWD.key, "123");
+        info.setType(new PostgisNGDataStoreFactory().getDisplayName());
+
+        when(mockSecurityManager.loadPasswordEncoders(any(), any(), any())).thenReturn(List.of());
+        helper.decode(info);
+        verify(mockSecurityManager, times(1)).loadPasswordEncoders(any(), any(), any());
+    }
+}


### PR DESCRIPTION
[![GEOS-11757](https://badgen.net/badge/JIRA/GEOS-11757/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11757) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The `ConfigurationPasswordEncryptionHelper` class has been updated to improve performance by caching encrypted fields based on the StoreInfo type when the class cache is hit.

Previously, when a DataStoreInfo object lacked a type property, the method would repeatedly invoke `getCatalog().getResourcePool().getDataStoreFactory(info)`, causing unnecessary factory lookups and expensive serialization/deserialization operations within `ResourcePool`.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.