### PR TITLE
[GEOS-11762] Templates can not be listed via GeoServer Rest API

### DIFF
--- a/src/community/features-templating/features-templating-rest/src/main/java/org/geoserver/featurestemplating/rest/TemplateRestController.java
+++ b/src/community/features-templating/features-templating-rest/src/main/java/org/geoserver/featurestemplating/rest/TemplateRestController.java
@@ -86,7 +86,7 @@ public class TemplateRestController extends AbstractCatalogController {
     @PostMapping(
             value = {
                 "/featurestemplates",
-                "/workspaces/{workspace}/featuretypes/{featuretype}/featurestemplates",
+                "/workspaces/{ws}/featuretypes/{featureType}/featurestemplates",
                 "/workspaces/{ws}/featurestemplates"
             },
             consumes = {
@@ -161,7 +161,7 @@ public class TemplateRestController extends AbstractCatalogController {
     @PostMapping(
             value = {
                 "/featurestemplates",
-                "/workspaces/{workspace}/featuretypes/{featuretype}/featurestemplates",
+                "/workspaces/{ws}/featuretypes/{featureType}/featurestemplates",
                 "/workspaces/{ws}/featurestemplates"
             },
             consumes = {MediaTypeExtensions.APPLICATION_ZIP_VALUE})
@@ -218,7 +218,7 @@ public class TemplateRestController extends AbstractCatalogController {
     @PutMapping(
             value = {
                 "/featurestemplates/{templateName}",
-                "/workspaces/{workspace}/featuretypes/{featuretype}/featurestemplates/{templateName}",
+                "/workspaces/{ws}/featuretypes/{featureType}/featurestemplates/{templateName}",
                 "/workspaces/{ws}/featurestemplates/{templateName}"
             },
             consumes = {
@@ -262,7 +262,7 @@ public class TemplateRestController extends AbstractCatalogController {
     @PutMapping(
             value = {
                 "/featurestemplates/{templateName}",
-                "/workspaces/{workspace}/featuretypes/{featuretype}/featurestemplates/{templateName}",
+                "/workspaces/{ws}/featuretypes/{featureType}/featurestemplates/{templateName}",
                 "/workspaces/{ws}/featurestemplates/{templateName}"
             },
             consumes = {MediaTypeExtensions.APPLICATION_ZIP_VALUE})
@@ -317,8 +317,7 @@ public class TemplateRestController extends AbstractCatalogController {
         UriComponents uriComponents;
         builder = builder.cloneBuilder();
         if (featureType != null) {
-            uriComponents = builder.path(
-                            "/workspaces/{workspace}/featuretypes/{featuretype}/featurestemplates/{templateName}")
+            uriComponents = builder.path("/workspaces/{ws}/featuretypes/{featureType}/featurestemplates/{templateName}")
                     .buildAndExpand(workspace, featureType, name);
         } else if (workspace != null) {
             uriComponents = builder.path("/workspaces/{ws}/featurestemplates/{templateName}")
@@ -342,7 +341,7 @@ public class TemplateRestController extends AbstractCatalogController {
     @DeleteMapping(
             value = {
                 "/featurestemplates/{templateName}",
-                "/workspaces/{workspace}/featuretypes/{featuretype}/featurestemplates/{templateName}",
+                "/workspaces/{ws}/featuretypes/{featureType}/featurestemplates/{templateName}",
                 "/workspaces/{ws}/featurestemplates/{templateName}"
             },
             produces = MediaType.TEXT_PLAIN_VALUE)
@@ -372,7 +371,7 @@ public class TemplateRestController extends AbstractCatalogController {
     @GetMapping(
             value = {
                 "/featurestemplates/{templateName}",
-                "/workspaces/{workspace}/featuretypes/{featuretype}/featurestemplates/{templateName}",
+                "/workspaces/{ws}/featuretypes/{featureType}/featurestemplates/{templateName}",
                 "/workspaces/{ws}/featurestemplates/{templateName}"
             },
             produces = {
@@ -400,7 +399,8 @@ public class TemplateRestController extends AbstractCatalogController {
         TemplateInfo info = TemplateInfoDAO.get().findByFullName(fullName);
         Resource resource = TemplateFileManager.get().getTemplateResource(info);
         if (resource.getType() != Resource.Type.RESOURCE) {
-            throw new ResourceNotFoundException("Template with fullName " + info.getFullName() + "not found");
+            throw new RestException(
+                    "Template with fullName " + info.getFullName() + " not found", HttpStatus.NOT_FOUND);
         }
         byte[] bytes;
         try {
@@ -420,7 +420,7 @@ public class TemplateRestController extends AbstractCatalogController {
     @GetMapping(
             value = {
                 "/featurestemplates",
-                "/workspaces/{workspace}/featuretypes/{featuretype}/featurestemplates",
+                "/workspaces/{ws}/featuretypes/{featureType}/featurestemplates",
                 "/workspaces/{ws}/featurestemplates"
             },
             produces = {

--- a/src/community/features-templating/features-templating-rest/src/test/java/org/geoserver/featurestemplating/rest/TemplateRestControllerTest.java
+++ b/src/community/features-templating/features-templating-rest/src/test/java/org/geoserver/featurestemplating/rest/TemplateRestControllerTest.java
@@ -184,6 +184,7 @@ public class TemplateRestControllerTest extends CatalogRESTTestSupport {
             + "  \t<topp:wkt_geom>$${toWKT(the_geom)}</topp:wkt_geom>\n"
             + "  </topp:states>\n"
             + "</gft:Template>";
+    public static final String XHTMLTEMPLATE_NAME = "xhtmltemplate";
 
     @Test
     public void testPostGetPutGetDeleteJson() throws Exception {
@@ -236,6 +237,21 @@ public class TemplateRestControllerTest extends CatalogRESTTestSupport {
             response = deleteAsServletResponse(RestBaseController.ROOT_PATH + "/workspaces/cdf/featurestemplates/foo2");
             assertEquals(HttpStatus.NO_CONTENT.value(), response.getStatus());
             assertNull(TemplateInfoDAO.get().findByFullName("cdf:foo2"));
+        } finally {
+            TemplateInfoDAO.get().deleteAll();
+        }
+    }
+
+    @Test
+    public void testPostErrorMessage() throws Exception {
+        try {
+            MockHttpServletResponse response = postAsServletResponse(
+                    RestBaseController.ROOT_PATH
+                            + "/workspaces/cdf/featuretypes/stations/featurestemplates?templateName=foo2",
+                    GML_TEMPLATE,
+                    MediaType.APPLICATION_XML_VALUE);
+            assertEquals(404, response.getStatus());
+            assertEquals("FeatureType stations not found", response.getContentAsString());
         } finally {
             TemplateInfoDAO.get().deleteAll();
         }
@@ -331,7 +347,7 @@ public class TemplateRestControllerTest extends CatalogRESTTestSupport {
     public void testFindAll() throws Exception {
         newTemplateInfo("jsontemplate", "json", null, null, JSON_TEMPLATE);
         newTemplateInfo("gmltemplate", "xml", "cdf", null, GML_TEMPLATE);
-        newTemplateInfo("xhtmltemplate", "xhtml", "cdf", "Fifteen", XHTML_TEMPLATE);
+        newTemplateInfo(XHTMLTEMPLATE_NAME, "xhtml", "cdf", "Fifteen", XHTML_TEMPLATE);
 
         newTemplateInfo("jsontemplate2", "json", "cdf", "Fifteen", JSON_TEMPLATE_2);
         newTemplateInfo("gmltemplate2", "xml", null, null, GML_TEMPLATE_2);
@@ -422,6 +438,21 @@ public class TemplateRestControllerTest extends CatalogRESTTestSupport {
             deleteAsServletResponse(RestBaseController.ROOT_PATH + "/featurestemplates/testJsonTemplateCache");
         } finally {
             Dispatcher.REQUEST.set(null);
+        }
+    }
+
+    @Test
+    public void testGetByFeatureType() throws Exception {
+        try {
+            newTemplateInfo("jsontemplate", "json", null, null, JSON_TEMPLATE);
+            newTemplateInfo("gmltemplate", "xml", "cdf", null, GML_TEMPLATE);
+            newTemplateInfo(XHTMLTEMPLATE_NAME, "xhtml", "cdf", "Fifteen", XHTML_TEMPLATE);
+            MockHttpServletResponse response = getAsServletResponse(RestBaseController.ROOT_PATH
+                    + "/workspaces/cdf/featuretypes/Fifteen/featurestemplates/" + XHTMLTEMPLATE_NAME + ".xml");
+            assertEquals(200, response.getStatus());
+            assertEquals(XHTML_TEMPLATE.trim(), response.getContentAsString());
+        } finally {
+            TemplateInfoDAO.get().deleteAll();
         }
     }
 }


### PR DESCRIPTION
[![GEOS-11762](https://badgen.net/badge/JIRA/GEOS-11762/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11762) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOS-11762
  
This PR purpose is to fix the Features Template bug on REST API making it unable to list the templates by feature type as described on the issue.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.