### PR TITLE
Allow to forward options to jetty using the JETTY_OPTS env var

### DIFF
--- a/doc/en/user/source/installation/linux.rst
+++ b/doc/en/user/source/installation/linux.rst
@@ -41,6 +41,13 @@ Installation
       echo "export GEOSERVER_HOME=/usr/share/geoserver" >> ~/.profile
       . ~/.profile
 
+#. Optionally, set the environment variable ``JETTY_OPTS`` to tweak the jetty configuration upfront:
+
+   .. code-block:: bash
+
+      echo "export JETTY_OPTS='jetty.http.port=1234'" >> ~/.profile
+      . ~/.profile
+
 #. Make yourself the owner of the ``geoserver`` folder.  Type the following command in the terminal window, replacing ``USER_NAME`` with your own username :
 
    .. code-block:: bash

--- a/doc/en/user/source/installation/win_binary.rst
+++ b/doc/en/user/source/installation/win_binary.rst
@@ -47,7 +47,7 @@ You will need to set the ``JAVA_HOME`` environment variable if it is not already
 
 #. Click OK three times.
 
-.. note:: You may also want to set the ``GEOSERVER_HOME`` variable, which is the directory where GeoServer is installed, and the ``GEOSERVER_DATA_DIR`` variable, which is the location of the GeoServer data directory (which by default is :file:`%GEOSERVER_HOME\\data_dir`). The latter is mandatory if you wish to use a data directory other than the default location. The procedure for setting these variables is identical to setting the ``JAVA_HOME`` variable.
+.. note:: You may also want to set the ``GEOSERVER_HOME`` variable, which is the directory where GeoServer is installed, and the ``GEOSERVER_DATA_DIR`` variable, which is the location of the GeoServer data directory (which by default is :file:`%GEOSERVER_HOME\\data_dir`). The latter is mandatory if you wish to use a data directory other than the default location. Finally, the variable ``JETTY_OPTS`` allows to tweak the jetty configuration upfront (example: ``jetty.http.port=1234``). The procedure for setting these variables is identical to setting the ``JAVA_HOME`` variable.
 
 Running
 -------

--- a/src/release/bin/startup.bat
+++ b/src/release/bin/startup.bat
@@ -146,7 +146,7 @@ goto run
   cd "%GEOSERVER_HOME%"
   echo Please wait while loading GeoServer...
   echo.
-  "%RUN_JAVA%" %JAVA_OPTS% -DGEOSERVER_DATA_DIR="%GEOSERVER_DATA_DIR%" -Djava.awt.headless=true -DSTOP.PORT=8079 -DSTOP.KEY=geoserver -jar start.jar
+  "%RUN_JAVA%" %JAVA_OPTS% -DGEOSERVER_DATA_DIR="%GEOSERVER_DATA_DIR%" -Djava.awt.headless=true -DSTOP.PORT=8079 -DSTOP.KEY=geoserver -jar start.jar %JETTY_OPTS%
   cd bin
 goto end
 

--- a/src/release/bin/startup.sh
+++ b/src/release/bin/startup.sh
@@ -91,4 +91,4 @@ echo "GEOSERVER DATA DIR is ${GEOSERVER_DATA_DIR}"
 #added headless to true by default, if this messes anyone up let the list
 #know and we can change it back, but it seems like it won't hurt -ch
 IFS=$(printf '\n\t ')
-exec "${_RUNJAVA}" ${JAVA_OPTS:--DNoJavaOpts} ${MARLIN_ENABLER:--DMarlinDisabled} "-Djetty.base=${GEOSERVER_HOME}" "-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}" -Djava.awt.headless=true -DSTOP.PORT=8079 -DSTOP.KEY=geoserver -jar "${GEOSERVER_HOME}/start.jar"
+exec "${_RUNJAVA}" ${JAVA_OPTS:--DNoJavaOpts} ${MARLIN_ENABLER:--DMarlinDisabled} "-Djetty.base=${GEOSERVER_HOME}" "-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}" -Djava.awt.headless=true -DSTOP.PORT=8079 -DSTOP.KEY=geoserver -jar "${GEOSERVER_HOME}/start.jar" ${JETTY_OPTS:-}


### PR DESCRIPTION
This PR allows to modify the jetty configuration via the environment variable `JETTY_OPTS`. This eases configuration testing. My main motivation here is to be able to more easily use geoserver on NixOS where modifying files in `GEOSERVER_HOME` is usually not possible (if installed as a package).

I did not test the `startup.bat` file as I do not have Windows at hand. I changed that file for consistency. I do not now how batch files behave if an env var is not set (in Linux, I refer to `${JETTY_OPTS}` vs `${JETTY_OPTS:-}`).

I did not find any test involving an invocation of `startup.sh` and thus refrained changing any test. I tested with `JETTY_OPTS=jetty.http.port=1234 path/to/startup.sh`

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
   - Please let me know if this is necessary
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.