### PR TITLE
[GEOS-11769] Race conditions in LayerGroupHelper when the default catalog is not fully initialized

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -1584,7 +1584,7 @@ public class CatalogBuilder {
 
     /** Calculates the bounds of a layer group specifying a particular crs. */
     public void calculateLayerGroupBounds(LayerGroupInfo layerGroup, CoordinateReferenceSystem crs) throws Exception {
-        LayerGroupHelper helper = new LayerGroupHelper(layerGroup);
+        LayerGroupHelper helper = new LayerGroupHelper(catalog, layerGroup);
         helper.calculateBounds(crs);
     }
 
@@ -1595,13 +1595,13 @@ public class CatalogBuilder {
      * @see LayerGroupHelper#calculateBoundsFromCRS(CoordinateReferenceSystem)
      */
     public void calculateLayerGroupBoundsFromCRS(LayerGroupInfo layerGroup, CoordinateReferenceSystem crs) {
-        LayerGroupHelper helper = new LayerGroupHelper(layerGroup);
+        LayerGroupHelper helper = new LayerGroupHelper(catalog, layerGroup);
         helper.calculateBoundsFromCRS(crs);
     }
 
     /** Calculates the bounds of a layer group by aggregating the bounds of each layer. */
     public void calculateLayerGroupBounds(LayerGroupInfo layerGroup) throws Exception {
-        LayerGroupHelper helper = new LayerGroupHelper(layerGroup);
+        LayerGroupHelper helper = new LayerGroupHelper(catalog, layerGroup);
         helper.calculateBounds();
     }
 

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -992,7 +992,7 @@ public class CatalogImpl implements Catalog {
             throw new IllegalArgumentException("Layer group has different number of styles than layers");
         }
 
-        LayerGroupHelper helper = new LayerGroupHelper(layerGroup);
+        LayerGroupHelper helper = new LayerGroupHelper(this, layerGroup);
         Stack<LayerGroupInfo> loopPath = helper.checkLoops();
         if (loopPath != null) {
             throw new IllegalArgumentException("Layer group is in a loop: " + helper.getLoopAsString(loopPath));

--- a/src/main/src/test/java/org/geoserver/catalog/LayerGroupHelperTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/LayerGroupHelperTest.java
@@ -7,7 +7,9 @@ package org.geoserver.catalog;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,6 +19,7 @@ import org.geoserver.catalog.LayerGroupInfo.Mode;
 import org.geoserver.catalog.impl.LayerGroupInfoImpl;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.MockTestData;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geoserver.test.GeoServerMockTestSupport;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.NoSuchAuthorityCodeException;
@@ -327,6 +330,25 @@ public class LayerGroupHelperTest extends GeoServerMockTestSupport {
         // null CRS should get null bounds
         helper.calculateBoundsFromCRS(null);
         assertNull(nested.getBounds());
+    }
+
+    @Test
+    public void testUseProvidedCatalog() {
+        Catalog catalog = mock(Catalog.class);
+        LayerGroupHelper helper = new LayerGroupHelper(catalog, container);
+        assertSame(catalog, helper.catalog);
+    }
+
+    @Test
+    public void testDefaultsToCatalogBean() {
+        Catalog catalog = mock(Catalog.class);
+        GeoServerExtensionsHelper.singleton("catalog", catalog, Catalog.class);
+        try {
+            LayerGroupHelper helper = new LayerGroupHelper(container);
+            assertSame(catalog, helper.catalog);
+        } finally {
+            GeoServerExtensionsHelper.init(null);
+        }
     }
 
     private ReferencedEnvelope aggregateEnvelopes(LayerInfo... layers) {


### PR DESCRIPTION
[![GEOS-11769](https://badgen.net/badge/JIRA/GEOS-11769/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11769) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Explicitly pass the correct catalog instance to LayerGroupHelper to ensure proper operation during startup and dynamic catalog modifications. This fixes potential race conditions where the helper might use a default catalog that is not fully initialized or is different from the one being used for current operations.

The changes include:
- Adding a two-arg constructor to LayerGroupHelper that takes an explicit catalog
- Converting static helper methods to instance methods using the instance catalog
- Updating all call sites to pass the current catalog explicitly
- Adding comprehensive javadocs explaining the class purpose and behavior


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.