### PR TITLE
Refactor catalog proxy resolution into dedicated utility class

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogFacade.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/AbstractCatalogFacade.java
@@ -7,27 +7,20 @@ package org.geoserver.catalog.impl;
 
 import java.lang.reflect.Proxy;
 import java.rmi.server.UID;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.geoserver.catalog.CatalogFacade;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.MapInfo;
 import org.geoserver.catalog.NamespaceInfo;
-import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.ows.util.OwsUtils;
-import org.geotools.util.logging.Logging;
 
 public abstract class AbstractCatalogFacade implements CatalogFacade {
-
-    private static final Logger LOGGER = Logging.getLogger(AbstractCatalogFacade.class);
 
     //
     // Utilities
@@ -68,167 +61,42 @@ public abstract class AbstractCatalogFacade implements CatalogFacade {
 
     protected void resolve(LayerInfo layer) {
         setId(layer);
-
-        ResourceInfo resource = ResolvingProxy.resolve(getCatalog(), layer.getResource());
-        if (resource != null) {
-            resource = unwrap(resource);
-            layer.setResource(resource);
-        }
-
-        StyleInfo style = ResolvingProxy.resolve(getCatalog(), layer.getDefaultStyle());
-        if (style != null) {
-            style = unwrap(style);
-            layer.setDefaultStyle(style);
-        }
-
-        LinkedHashSet<StyleInfo> styles = new LinkedHashSet<>();
-        for (StyleInfo s : layer.getStyles()) {
-            s = ResolvingProxy.resolve(getCatalog(), s);
-            s = unwrap(s);
-            styles.add(s);
-        }
-        ((LayerInfoImpl) layer).setStyles(styles);
+        ResolvingProxyResolver.resolve(layer, getCatalog());
     }
 
     protected void resolve(LayerGroupInfo layerGroup) {
         setId(layerGroup);
-
-        LayerGroupInfoImpl lg = (LayerGroupInfoImpl) layerGroup;
-
-        resolveLayerGroupLayers(lg.getLayers());
-        resolveLayerGroupStyles(lg.getLayers(), lg.getStyles());
-        // now resolves layers and styles defined in layer group styles
-        for (LayerGroupStyle groupStyle : lg.getLayerGroupStyles()) {
-            resolveLayerGroupLayers(groupStyle.getLayers());
-            resolveLayerGroupStyles(groupStyle.getLayers(), groupStyle.getStyles());
-        }
-    }
-
-    private void resolveLayerGroupStyles(List<PublishedInfo> assignedLayers, List<StyleInfo> styles) {
-        for (int i = 0; i < styles.size(); i++) {
-            StyleInfo s = styles.get(i);
-            if (s != null) {
-                PublishedInfo assignedLayer = assignedLayers.get(i);
-                StyleInfo resolved = null;
-                if (assignedLayer instanceof LayerGroupInfo) {
-                    // special case we might have a StyleInfo representing
-                    // only the name of a LayerGroupStyle thus not present in Catalog.
-                    // We take the ref and create a new object
-                    // without searching in catalog.
-                    String ref = ResolvingProxy.getRef(s);
-                    if (ref != null) {
-                        StyleInfo styleInfo = new StyleInfoImpl(getCatalog());
-                        styleInfo.setName(ref);
-                        resolved = styleInfo;
-                    }
-                }
-                if (resolved == null) resolved = unwrap(ResolvingProxy.resolve(getCatalog(), s));
-
-                styles.set(i, resolved);
-            }
-        }
-    }
-
-    private void resolveLayerGroupLayers(List<PublishedInfo> layers) {
-        for (int i = 0; i < layers.size(); i++) {
-            PublishedInfo l = layers.get(i);
-
-            if (l != null) {
-                PublishedInfo resolved;
-                if (l instanceof LayerGroupInfo) {
-                    resolved = unwrap(ResolvingProxy.resolve(getCatalog(), (LayerGroupInfo) l));
-                    // special case to handle catalog loading, when nested publishibles might not be
-                    // loaded.
-                    if (resolved == null) {
-                        resolved = l;
-                    }
-                } else if (l instanceof LayerInfo) {
-                    resolved = unwrap(ResolvingProxy.resolve(getCatalog(), (LayerInfo) l));
-                    // special case to handle catalog loading, when nested publishibles might not be
-                    // loaded.
-                    if (resolved == null) {
-                        resolved = l;
-                    }
-                } else {
-                    // Special case for null layer (style group)
-                    resolved = unwrap(ResolvingProxy.resolve(getCatalog(), l));
-                }
-                layers.set(i, resolved);
-            }
-        }
+        ResolvingProxyResolver.resolve(layerGroup, getCatalog());
     }
 
     protected void resolve(StyleInfo style) {
         setId(style);
-        StyleInfoImpl s = (StyleInfoImpl) style;
-        s.setCatalog(getCatalog());
-
-        // resolve the workspace
-        WorkspaceInfo ws = s.getWorkspace();
-        if (ws != null) {
-            WorkspaceInfo resolved = ResolvingProxy.resolve(getCatalog(), ws);
-            if (resolved != null) {
-                resolved = unwrap(resolved);
-                s.setWorkspace(resolved);
-            } else {
-                LOGGER.log(
-                        Level.INFO,
-                        "Failed to resolve workspace for style \""
-                                + style.getName()
-                                + "\". This means the workspace has not yet been added to the catalog, keep the proxy around");
-            }
-        }
+        ResolvingProxyResolver.resolve(style, getCatalog());
     }
 
     protected void resolve(MapInfo map) {
         setId(map);
+        ResolvingProxyResolver.resolve(map, getCatalog());
     }
 
     protected void resolve(WorkspaceInfo workspace) {
         setId(workspace);
+        ResolvingProxyResolver.resolve(workspace, getCatalog());
     }
 
     protected void resolve(NamespaceInfo namespace) {
         setId(namespace);
+        ResolvingProxyResolver.resolve(namespace, getCatalog());
     }
 
     protected void resolve(StoreInfo store) {
         setId(store);
-        StoreInfoImpl s = (StoreInfoImpl) store;
-        s.setCatalog(getCatalog());
-
-        // resolve the workspace
-        WorkspaceInfo resolved = ResolvingProxy.resolve(getCatalog(), s.getWorkspace());
-        if (resolved != null) {
-            resolved = unwrap(resolved);
-            s.setWorkspace(resolved);
-        } else {
-            LOGGER.log(
-                    Level.INFO,
-                    "Failed to resolve workspace for store \""
-                            + store.getName()
-                            + "\". This means the workspace has not yet been added to the catalog, keep the proxy around");
-        }
+        ResolvingProxyResolver.resolve(store, getCatalog());
     }
 
     protected void resolve(ResourceInfo resource) {
         setId(resource);
-        ResourceInfoImpl r = (ResourceInfoImpl) resource;
-        r.setCatalog(getCatalog());
-
-        // resolve the store
-        StoreInfo store = ResolvingProxy.resolve(getCatalog(), r.getStore());
-        if (store != null) {
-            store = unwrap(store);
-            r.setStore(store);
-        }
-
-        // resolve the namespace
-        NamespaceInfo namespace = ResolvingProxy.resolve(getCatalog(), r.getNamespace());
-        if (namespace != null) {
-            namespace = unwrap(namespace);
-            r.setNamespace(namespace);
-        }
+        ResolvingProxyResolver.resolve(resource, getCatalog());
     }
 
     protected void setId(Object o) {

--- a/src/main/src/main/java/org/geoserver/catalog/impl/ResolvingProxyResolver.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ResolvingProxyResolver.java
@@ -1,0 +1,283 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog.impl;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.MapInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geotools.util.logging.Logging;
+
+/**
+ * Utility class for resolving proxied catalog objects.
+ *
+ * <p>This class provides methods to replace proxy references in catalog objects with actual instances from the catalog.
+ * It recursively resolves references within complex catalog objects such as layers, layer groups, and resources to
+ * ensure all nested objects are properly instantiated.
+ *
+ * <p>The resolver handles special cases during catalog loading where certain references may not yet be available,
+ * maintaining proxies when resolution isn't possible. It also unwraps modification proxies to ensure direct object
+ * references are used.
+ *
+ * <p>Use this class when:
+ *
+ * <ul>
+ *   <li>Loading objects from persistent storage
+ *   <li>Preparing objects for serialization
+ *   <li>Ensuring consistent object references throughout the catalog
+ * </ul>
+ *
+ * <p>Each catalog object type has a specialized resolution method to handle its specific reference structure.
+ */
+public class ResolvingProxyResolver {
+
+    private static final Logger LOGGER = Logging.getLogger(ResolvingProxyResolver.class);
+
+    /**
+     * Private constructor to prevent instantiation.
+     *
+     * <p>This is a utility class that provides only static methods and should not be instantiated.
+     */
+    private ResolvingProxyResolver() {
+        // private constructor, this is an utility class
+    }
+
+    /**
+     * Unwraps a modification proxy to access the underlying object.
+     *
+     * <p>This helper method delegates to {@link ModificationProxy#unwrap(Object)} to ensure we're working with the
+     * actual object instances rather than their proxy wrappers.
+     *
+     * @param <T> the type of the object being unwrapped
+     * @param obj the potentially proxied object
+     * @return the unwrapped object, or the original object if not a proxy
+     */
+    private static <T> T unwrap(T obj) {
+        return ModificationProxy.unwrap(obj);
+    }
+
+    /**
+     * Resolves all proxy references in a catalog object.
+     *
+     * <p>This method dispatches to type-specific resolvers based on the actual type of the provided catalog info
+     * object. It handles all known catalog object types and logs a warning for unknown types.
+     *
+     * @param info the catalog object containing proxy references to resolve
+     * @param catalog the catalog to use for resolution
+     */
+    public static void resolve(CatalogInfo info, Catalog catalog) {
+        if (info instanceof WorkspaceInfo) {
+            resolve((WorkspaceInfo) info, catalog);
+        } else if (info instanceof NamespaceInfo) {
+            resolve((NamespaceInfo) info, catalog);
+        } else if (info instanceof StoreInfo) {
+            resolve((StoreInfo) info, catalog);
+        } else if (info instanceof ResourceInfo) {
+            resolve((ResourceInfo) info, catalog);
+        } else if (info instanceof LayerInfo) {
+            resolve((LayerInfo) info, catalog);
+        } else if (info instanceof LayerGroupInfo) {
+            resolve((LayerGroupInfo) info, catalog);
+        } else if (info instanceof StyleInfo) {
+            resolve((StyleInfo) info, catalog);
+        } else if (info instanceof MapInfo) {
+            resolve((MapInfo) info, catalog);
+        } else {
+            LOGGER.warning("Unknown CatalogInfo: " + info);
+        }
+    }
+
+    private static void resolve(LayerInfo layer, Catalog catalog) {
+
+        ResourceInfo resource = ResolvingProxy.resolve(catalog, layer.getResource());
+        if (resource != null) {
+            resource = unwrap(resource);
+            layer.setResource(resource);
+        }
+
+        StyleInfo style = ResolvingProxy.resolve(catalog, layer.getDefaultStyle());
+        if (style != null) {
+            style = unwrap(style);
+            layer.setDefaultStyle(style);
+        }
+
+        LinkedHashSet<StyleInfo> styles = new LinkedHashSet<>();
+        for (StyleInfo s : layer.getStyles()) {
+            s = ResolvingProxy.resolve(catalog, s);
+            s = unwrap(s);
+            styles.add(s);
+        }
+        ((LayerInfoImpl) layer).setStyles(styles);
+    }
+
+    private static void resolve(LayerGroupInfo layerGroup, Catalog catalog) {
+
+        LayerGroupInfoImpl lg = (LayerGroupInfoImpl) layerGroup;
+        // resolve the workspace
+        WorkspaceInfo ws = lg.getWorkspace();
+        if (ws != null) {
+            WorkspaceInfo resolved = ResolvingProxy.resolve(catalog, ws);
+            if (resolved != null) {
+                resolved = unwrap(resolved);
+                lg.setWorkspace(resolved);
+            } else {
+                LOGGER.log(
+                        Level.INFO,
+                        "Failed to resolve workspace for layer group \""
+                                + lg.getName()
+                                + "\". This means the workspace has not yet been added to the catalog, keep the proxy around");
+            }
+        }
+
+        lg.setRootLayer(ResolvingProxy.resolve(catalog, lg.getRootLayer()));
+        lg.setRootLayerStyle(ResolvingProxy.resolve(catalog, lg.getRootLayerStyle()));
+
+        resolveLayerGroupLayers(lg.getLayers(), catalog);
+        resolveLayerGroupStyles(lg.getLayers(), lg.getStyles(), catalog);
+        // now resolves layers and styles defined in layer group styles
+        for (LayerGroupStyle groupStyle : lg.getLayerGroupStyles()) {
+            resolveLayerGroupLayers(groupStyle.getLayers(), catalog);
+            resolveLayerGroupStyles(groupStyle.getLayers(), groupStyle.getStyles(), catalog);
+        }
+    }
+
+    private static void resolveLayerGroupStyles(
+            List<PublishedInfo> assignedLayers, List<StyleInfo> styles, Catalog catalog) {
+        for (int i = 0; i < styles.size(); i++) {
+            StyleInfo s = styles.get(i);
+            if (s != null) {
+                PublishedInfo assignedLayer = assignedLayers.get(i);
+                StyleInfo resolved = null;
+                if (assignedLayer instanceof LayerGroupInfo) {
+                    // special case we might have a StyleInfo representing
+                    // only the name of a LayerGroupStyle thus not present in Catalog.
+                    // We take the ref and create a new object
+                    // without searching in catalog.
+                    String ref = ResolvingProxy.getRef(s);
+                    if (ref != null) {
+                        StyleInfo styleInfo = new StyleInfoImpl(catalog);
+                        styleInfo.setName(ref);
+                        resolved = styleInfo;
+                    }
+                }
+                if (resolved == null) resolved = unwrap(ResolvingProxy.resolve(catalog, s));
+
+                styles.set(i, resolved);
+            }
+        }
+    }
+
+    private static void resolveLayerGroupLayers(List<PublishedInfo> layers, Catalog catalog) {
+        for (int i = 0; i < layers.size(); i++) {
+            PublishedInfo l = layers.get(i);
+
+            if (l != null) {
+                PublishedInfo resolved;
+                if (l instanceof LayerGroupInfo) {
+                    resolved = unwrap(ResolvingProxy.resolve(catalog, (LayerGroupInfo) l));
+                    // special case to handle catalog loading, when nested publishibles might not be
+                    // loaded.
+                    if (resolved == null) {
+                        resolved = l;
+                    }
+                } else if (l instanceof LayerInfo) {
+                    resolved = unwrap(ResolvingProxy.resolve(catalog, (LayerInfo) l));
+                    // special case to handle catalog loading, when nested publishibles might not be
+                    // loaded.
+                    if (resolved == null) {
+                        resolved = l;
+                    }
+                } else {
+                    // Special case for null layer (style group)
+                    resolved = unwrap(ResolvingProxy.resolve(catalog, l));
+                }
+                layers.set(i, resolved);
+            }
+        }
+    }
+
+    private static void resolve(StyleInfo style, Catalog catalog) {
+        StyleInfoImpl s = (StyleInfoImpl) style;
+        s.setCatalog(catalog);
+
+        // resolve the workspace
+        WorkspaceInfo ws = s.getWorkspace();
+        if (ws != null) {
+            WorkspaceInfo resolved = ResolvingProxy.resolve(catalog, ws);
+            if (resolved != null) {
+                resolved = unwrap(resolved);
+                s.setWorkspace(resolved);
+            } else {
+                LOGGER.log(
+                        Level.INFO,
+                        "Failed to resolve workspace for style \""
+                                + style.getName()
+                                + "\". This means the workspace has not yet been added to the catalog, keep the proxy around");
+            }
+        }
+    }
+
+    private static void resolve(MapInfo map, Catalog catalog) {
+        // no-op
+    }
+
+    private static void resolve(WorkspaceInfo workspace, Catalog catalog) {
+        // no-op
+    }
+
+    private static void resolve(NamespaceInfo namespace, Catalog catalog) {
+        // no-op
+    }
+
+    private static void resolve(StoreInfo store, Catalog catalog) {
+        StoreInfoImpl s = (StoreInfoImpl) store;
+        s.setCatalog(catalog);
+
+        // resolve the workspace
+        WorkspaceInfo resolved = ResolvingProxy.resolve(catalog, s.getWorkspace());
+        if (resolved != null) {
+            resolved = unwrap(resolved);
+            s.setWorkspace(resolved);
+        } else {
+            LOGGER.log(
+                    Level.INFO,
+                    "Failed to resolve workspace for store \""
+                            + store.getName()
+                            + "\". This means the workspace has not yet been added to the catalog, keep the proxy around");
+        }
+    }
+
+    private static void resolve(ResourceInfo resource, Catalog catalog) {
+        ResourceInfoImpl r = (ResourceInfoImpl) resource;
+        r.setCatalog(catalog);
+
+        // resolve the store
+        // note, gotta use ResourceInfoImpl.rawStore() cause the subclasses will override getStore() with a cast to
+        // their concrete store types that will fail when the store is a ResolvingProxy
+        StoreInfo store = ResolvingProxy.resolve(catalog, r.rawStore());
+        if (store != null) {
+            store = unwrap(store);
+            r.setStore(store);
+        }
+
+        // resolve the namespace
+        NamespaceInfo namespace = ResolvingProxy.resolve(catalog, r.getNamespace());
+        if (namespace != null) {
+            namespace = unwrap(namespace);
+            r.setNamespace(namespace);
+        }
+    }
+}

--- a/src/main/src/main/java/org/geoserver/catalog/impl/ResourceInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ResourceInfoImpl.java
@@ -354,6 +354,14 @@ public abstract class ResourceInfoImpl implements ResourceInfo {
         return store;
     }
 
+    /**
+     * Allows access to the raw store property without the casting performed by subclasses. This is convenient during
+     * the catalog load process to avoid class cast exceptions when the store is a resolving proxy
+     */
+    StoreInfo rawStore() {
+        return store;
+    }
+
     @Override
     public void setStore(StoreInfo store) {
         this.store = store;

--- a/src/main/src/test/java/org/geoserver/catalog/impl/ResolvingProxyResolverTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/ResolvingProxyResolverTest.java
@@ -1,0 +1,445 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.catalog.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Unit tests for {@link ResolvingProxyResolver}. */
+public class ResolvingProxyResolverTest {
+
+    private Catalog catalog;
+    private WorkspaceInfo workspace;
+    private NamespaceInfo namespace;
+    private DataStoreInfo store;
+    private FeatureTypeInfo resource;
+    private StyleInfo style;
+    private LayerInfo layer;
+    private LayerGroupInfo layerGroup;
+
+    @Before
+    public void setUp() {
+        // Create mock catalog and catalog objects
+        catalog = mock(Catalog.class);
+
+        // Mock workspace
+        workspace = mock(WorkspaceInfo.class);
+        when(workspace.getId()).thenReturn("ws-id");
+        when(workspace.getName()).thenReturn("ws-name");
+
+        // Mock namespace
+        namespace = mock(NamespaceInfo.class);
+        when(namespace.getId()).thenReturn("ns-id");
+        when(namespace.getPrefix()).thenReturn("ns-prefix");
+        when(namespace.getURI()).thenReturn("ns-uri");
+
+        // Mock store
+        store = mock(DataStoreInfo.class);
+        when(store.getId()).thenReturn("store-id");
+        when(store.getName()).thenReturn("store-name");
+        when(store.getWorkspace()).thenReturn(workspace);
+
+        // Mock resource
+        resource = mock(FeatureTypeInfo.class);
+        when(resource.getId()).thenReturn("resource-id");
+        when(resource.getName()).thenReturn("resource-name");
+        when(resource.getStore()).thenReturn(store);
+        when(resource.getNamespace()).thenReturn(namespace);
+        if (resource instanceof ResourceInfoImpl) {
+            ((ResourceInfoImpl) resource).setCatalog(catalog);
+        }
+
+        // Mock style
+        style = mock(StyleInfo.class);
+        when(style.getId()).thenReturn("style-id");
+        when(style.getName()).thenReturn("style-name");
+        when(style.getWorkspace()).thenReturn(workspace);
+        if (style instanceof StyleInfoImpl) {
+            ((StyleInfoImpl) style).setCatalog(catalog);
+        }
+
+        // Mock layer
+        layer = mock(LayerInfo.class);
+        when(layer.getId()).thenReturn("layer-id");
+        when(layer.getName()).thenReturn("layer-name");
+        when(layer.getResource()).thenReturn(resource);
+        when(layer.getDefaultStyle()).thenReturn(style);
+        LinkedHashSet<StyleInfo> styles = new LinkedHashSet<>();
+        styles.add(style);
+        when(layer.getStyles()).thenReturn(styles);
+
+        // Mock layer group
+        layerGroup = mock(LayerGroupInfo.class);
+        when(layerGroup.getId()).thenReturn("layergroup-id");
+        when(layerGroup.getName()).thenReturn("layergroup-name");
+        when(layerGroup.getWorkspace()).thenReturn(workspace);
+        when(layerGroup.getRootLayer()).thenReturn(layer);
+        when(layerGroup.getRootLayerStyle()).thenReturn(style);
+        List<PublishedInfo> layers = Arrays.asList(layer);
+        List<StyleInfo> styles2 = Arrays.asList(style);
+        when(layerGroup.getLayers()).thenReturn(layers);
+        when(layerGroup.getStyles()).thenReturn(styles2);
+        LayerGroupStyle groupStyle = mock(LayerGroupStyle.class);
+        when(groupStyle.getLayers()).thenReturn(layers);
+        when(groupStyle.getStyles()).thenReturn(styles2);
+        when(layerGroup.getLayerGroupStyles()).thenReturn(Arrays.asList(groupStyle));
+
+        // Set up catalog
+        when(catalog.getWorkspace(workspace.getId())).thenReturn(workspace);
+        when(catalog.getNamespace(namespace.getId())).thenReturn(namespace);
+        when(catalog.getStore(store.getId(), StoreInfo.class)).thenReturn(store);
+        when(catalog.getStore(store.getId(), DataStoreInfo.class)).thenReturn(store);
+        when(catalog.getDataStore(store.getId())).thenReturn(store);
+        when(catalog.getResource(resource.getId(), ResourceInfo.class)).thenReturn(resource);
+        when(catalog.getResource(resource.getId(), FeatureTypeInfo.class)).thenReturn(resource);
+        when(catalog.getFeatureType(resource.getId())).thenReturn(resource);
+        when(catalog.getLayer(layer.getId())).thenReturn(layer);
+        when(catalog.getStyle(style.getId())).thenReturn(style);
+        when(catalog.getLayerGroup(layerGroup.getId())).thenReturn(layerGroup);
+    }
+
+    @Test
+    public void testResolveWorkspace() {
+        ResolvingProxyResolver.resolve(workspace, catalog);
+        verifyNoMoreInteractions(catalog);
+    }
+
+    @Test
+    public void testResolveNamespace() {
+        ResolvingProxyResolver.resolve(namespace, catalog);
+        verifyNoMoreInteractions(catalog);
+    }
+
+    @Test
+    public void testResolveStore() {
+        WorkspaceInfo proxy = ResolvingProxy.create(workspace.getId(), WorkspaceInfo.class);
+
+        store = new DataStoreInfoImpl();
+        store.setWorkspace(proxy);
+
+        ResolvingProxyResolver.resolve(store, catalog);
+        verify(catalog).getWorkspace(workspace.getId());
+        assertSame(workspace, store.getWorkspace());
+        assertSame(catalog, store.getCatalog());
+    }
+
+    @Test
+    public void testResolveStoreMissingWorkspacePreservesProxy() {
+        WorkspaceInfo proxy = ResolvingProxy.create("missing", WorkspaceInfo.class);
+        when(catalog.getWorkspace("missing")).thenReturn(null);
+
+        store = new DataStoreInfoImpl();
+        store.setWorkspace(proxy);
+        assertSame(proxy, store.getWorkspace());
+
+        ResolvingProxyResolver.resolve(store, catalog);
+        verify(catalog).getWorkspace("missing");
+        assertSame(proxy, store.getWorkspace());
+    }
+
+    @Test
+    public void testResolveResource() {
+        StoreInfo proxyStore = ResolvingProxy.create(store.getId(), DataStoreInfo.class);
+        NamespaceInfo proxyNamespace = ResolvingProxy.create(namespace.getId(), NamespaceInfo.class);
+
+        ResourceInfo resourceWithProxies = new FeatureTypeInfoImpl();
+        resourceWithProxies.setStore(proxyStore);
+        resourceWithProxies.setNamespace(proxyNamespace);
+
+        ResolvingProxyResolver.resolve(resourceWithProxies, catalog);
+
+        verify(catalog).getDataStore(store.getId());
+        verify(catalog).getNamespace(namespace.getId());
+        assertSame(store, resourceWithProxies.getStore());
+        assertSame(namespace, resourceWithProxies.getNamespace());
+    }
+
+    @Test
+    public void testResolveResourceMissingRefs() {
+        StoreInfo proxyStore = ResolvingProxy.create("missing-store", DataStoreInfo.class);
+        NamespaceInfo proxyNamespace = ResolvingProxy.create("missing-ns", NamespaceInfo.class);
+
+        ResourceInfo resourceWithProxies = new FeatureTypeInfoImpl();
+        resourceWithProxies.setStore(proxyStore);
+        resourceWithProxies.setNamespace(proxyNamespace);
+
+        ResolvingProxyResolver.resolve(resourceWithProxies, catalog);
+
+        verify(catalog).getDataStore("missing-store");
+        verify(catalog).getNamespace("missing-ns");
+        assertSame(proxyStore, resourceWithProxies.getStore());
+        assertSame(proxyNamespace, resourceWithProxies.getNamespace());
+    }
+
+    @Test
+    public void testResolveLayer() {
+        // Create a proxied resource and style
+        FeatureTypeInfo proxyResource = ResolvingProxy.create("resource-id", FeatureTypeInfo.class);
+        StyleInfo proxyStyle = ResolvingProxy.create("style-id", StyleInfo.class);
+
+        // Set up layer with proxies
+        LayerInfo layerWithProxies = new LayerInfoImpl();
+        layerWithProxies.setResource(proxyResource);
+        layerWithProxies.setDefaultStyle(proxyStyle);
+
+        layerWithProxies.getStyles().add(proxyStyle);
+
+        // Resolve layer
+        ResolvingProxyResolver.resolve(layerWithProxies, catalog);
+
+        // Verify that proxies are resolved
+        assertSame(resource, layerWithProxies.getResource());
+        assertSame(style, layerWithProxies.getDefaultStyle());
+        assertEquals(Set.of(style), layerWithProxies.getStyles());
+        verify(catalog).getFeatureType("resource-id");
+        verify(catalog, times(2)).getStyle("style-id");
+    }
+
+    @Test
+    public void testResolveLayerPreservesMissingResourceAndDefaultStyle() {
+        // Create a proxied resource and style
+        FeatureTypeInfo proxyResource = ResolvingProxy.create("missing-resource-id", FeatureTypeInfo.class);
+        StyleInfo proxyStyle = ResolvingProxy.create("missing-style-id", StyleInfo.class);
+
+        // Set up layer with proxies
+        LayerInfo layerWithProxies = new LayerInfoImpl();
+        layerWithProxies.setResource(proxyResource);
+        layerWithProxies.setDefaultStyle(proxyStyle);
+
+        // Resolve layer
+        ResolvingProxyResolver.resolve(layerWithProxies, catalog);
+
+        // Verify that proxies are resolved
+        assertSame(proxyResource, layerWithProxies.getResource());
+        assertSame(proxyStyle, layerWithProxies.getDefaultStyle());
+    }
+
+    @Test
+    public void testResolveLayerNullifiesMissingStyles() {
+        // Create a proxied resource and style
+        StyleInfo proxyStyle = ResolvingProxy.create("missing-style-id", StyleInfo.class);
+
+        // Set up layer with proxies
+        LayerInfo layerWithProxies = new LayerInfoImpl();
+        layerWithProxies.getStyles().add(proxyStyle);
+
+        // Resolve layer
+        ResolvingProxyResolver.resolve(layerWithProxies, catalog);
+
+        Set<StyleInfo> expected = new HashSet<>();
+        expected.add(null);
+        assertEquals(expected, layerWithProxies.getStyles());
+    }
+
+    @Test
+    public void testResolveLayerWithNullProxies() {
+        // Set up layer with null proxies
+        LayerInfo layerWithNullProxies = new LayerInfoImpl();
+        layerWithNullProxies.setResource(null);
+        layerWithNullProxies.setDefaultStyle(null);
+        layerWithNullProxies.getStyles().add(null);
+
+        // Resolve layer (should not throw exceptions)
+        ResolvingProxyResolver.resolve(layerWithNullProxies, catalog);
+        assertNull(layerWithNullProxies.getResource());
+        assertNull(layerWithNullProxies.getDefaultStyle());
+        Set<StyleInfo> expected = new HashSet<>();
+        expected.add(null);
+        assertEquals(expected, layerWithNullProxies.getStyles());
+    }
+
+    @Test
+    public void testResolveLayerGroup() {
+        // Create proxied objects
+        WorkspaceInfo proxyWorkspace = ResolvingProxy.create("ws-id", WorkspaceInfo.class);
+        LayerInfo proxyLayer = ResolvingProxy.create("layer-id", LayerInfo.class);
+        StyleInfo proxyStyle = ResolvingProxy.create("style-id", StyleInfo.class);
+
+        // Create layer group with proxies
+        LayerGroupInfoImpl layerGroupWithProxies = new LayerGroupInfoImpl();
+        layerGroupWithProxies.setWorkspace(proxyWorkspace);
+        layerGroupWithProxies.setRootLayer(proxyLayer);
+        layerGroupWithProxies.setRootLayerStyle(proxyStyle);
+
+        layerGroupWithProxies.getLayers().add(proxyLayer);
+        layerGroupWithProxies.getStyles().add(proxyStyle);
+
+        LayerGroupStyleImpl groupStyle = new LayerGroupStyleImpl();
+        groupStyle.getLayers().add(proxyLayer);
+        groupStyle.getStyles().add(proxyStyle);
+        layerGroupWithProxies.getLayerGroupStyles().add(groupStyle);
+
+        // Resolve layer group
+        ResolvingProxyResolver.resolve(layerGroupWithProxies, catalog);
+
+        assertSame(workspace, layerGroupWithProxies.getWorkspace());
+        assertSame(layer, layerGroupWithProxies.getRootLayer());
+        assertSame(style, layerGroupWithProxies.getRootLayerStyle());
+
+        assertEquals(List.of(layer), layerGroupWithProxies.getLayers());
+        assertEquals(List.of(style), layerGroupWithProxies.getStyles());
+
+        LayerGroupStyle lgs = layerGroupWithProxies.getLayerGroupStyles().get(0);
+        assertEquals(List.of(layer), lgs.getLayers());
+        assertEquals(List.of(style), lgs.getStyles());
+    }
+
+    @Test
+    public void testResolveLayerGroupPreservesMissingWorkspace() {
+        WorkspaceInfo proxyWorkspace = ResolvingProxy.create("missing-ws-id", WorkspaceInfo.class);
+
+        LayerGroupInfoImpl layerGroupWithProxies = new LayerGroupInfoImpl();
+        layerGroupWithProxies.setWorkspace(proxyWorkspace);
+
+        ResolvingProxyResolver.resolve(layerGroupWithProxies, catalog);
+
+        assertSame(proxyWorkspace, layerGroupWithProxies.getWorkspace());
+    }
+
+    @Test
+    public void testResolveLayerGroupStylesSpecialCase() {
+        // special case we might have a StyleInfo representing
+        // only the name of a LayerGroupStyle thus not present in Catalog.
+        // We take the ref and create a new object
+        // without searching in catalog.
+
+        LayerGroupInfo proxyLayerGroup = ResolvingProxy.create("missing-layergroup-id", LayerGroupInfo.class);
+        StyleInfo proxyStyle = ResolvingProxy.create("another-style-id", StyleInfo.class);
+
+        LayerGroupInfoImpl layerGroupWithProxies = new LayerGroupInfoImpl();
+
+        layerGroupWithProxies.getLayers().add(proxyLayerGroup);
+        layerGroupWithProxies.getStyles().add(proxyStyle);
+
+        ResolvingProxyResolver.resolve(layerGroupWithProxies, catalog);
+
+        StyleInfoImpl expected = new StyleInfoImpl();
+        expected.setName("another-style-id");
+
+        assertEquals(List.of(expected), layerGroupWithProxies.getStyles());
+    }
+
+    @Test
+    public void testResolveLayerGroupStylesNull() {
+        LayerGroupInfo proxyLayerGroup = ResolvingProxy.create("missing-layergroup-id", LayerGroupInfo.class);
+
+        LayerGroupInfoImpl layerGroupWithProxies = new LayerGroupInfoImpl();
+
+        layerGroupWithProxies.getLayers().add(proxyLayerGroup);
+        layerGroupWithProxies.getStyles().add(null);
+
+        ResolvingProxyResolver.resolve(layerGroupWithProxies, catalog);
+
+        List<StyleInfo> expected = new ArrayList<>();
+        expected.add(null);
+        assertEquals(expected, layerGroupWithProxies.getStyles());
+    }
+
+    @Test
+    public void testResolveStyle() {
+        // Create proxy workspace
+        WorkspaceInfo proxyWorkspace = ResolvingProxy.create("ws-id", WorkspaceInfo.class);
+
+        when(catalog.getWorkspace("missing")).thenReturn(null);
+
+        // Create style with proxy workspace
+        StyleInfoImpl styleWithProxy = new StyleInfoImpl();
+        styleWithProxy.setWorkspace(proxyWorkspace);
+
+        // Resolve style
+        ResolvingProxyResolver.resolve(styleWithProxy, catalog);
+
+        // Verify that workspace is resolved
+        verify(catalog).getWorkspace("ws-id");
+        assertSame(workspace, styleWithProxy.getWorkspace());
+        assertSame(catalog, styleWithProxy.getCatalog());
+    }
+
+    @Test
+    public void testResolveStyleKeepsMissingProxy() {
+        // Create proxy workspace
+        WorkspaceInfo proxyWorkspace = ResolvingProxy.create("missing", WorkspaceInfo.class);
+        when(catalog.getWorkspace("missing")).thenReturn(null);
+
+        // Create style with proxy workspace
+        StyleInfoImpl styleWithProxy = new StyleInfoImpl();
+        styleWithProxy.setWorkspace(proxyWorkspace);
+
+        // Resolve style
+        ResolvingProxyResolver.resolve(styleWithProxy, catalog);
+
+        // Verify that workspace is resolved
+        verify(catalog).getWorkspace("missing");
+        assertSame(proxyWorkspace, styleWithProxy.getWorkspace());
+        assertSame(catalog, styleWithProxy.getCatalog());
+    }
+
+    @Test
+    public void testResolveLayerGroupStylesWithSpecialCase() {
+        // Test for the special case in resolveLayerGroupStyles where a StyleInfo
+        // represents only the name of a LayerGroupStyle
+
+        // Create proxied layer group and style
+        LayerGroupInfo proxyLayerGroup = ResolvingProxy.create("layergroup-id", LayerGroupInfo.class);
+        StyleInfo proxyStyle = ResolvingProxy.create("layergroup-style-name", StyleInfo.class);
+
+        // Create layer group and style list
+        List<PublishedInfo> layers = Arrays.asList(proxyLayerGroup);
+        List<StyleInfo> styles = Arrays.asList(proxyStyle);
+
+        // Call the private method through the public resolve method
+        LayerGroupInfoImpl testLayerGroup = new LayerGroupInfoImpl();
+        testLayerGroup.setLayers(layers);
+        testLayerGroup.setStyles(styles);
+
+        ResolvingProxyResolver.resolve(testLayerGroup, catalog);
+
+        // The styles should now contain a newly created style with the reference name
+        StyleInfo resolvedStyle = testLayerGroup.getStyles().get(0);
+        assertNotNull(resolvedStyle);
+        // In a real scenario, this would be the name of the layer group style
+        assertEquals("layergroup-style-name", resolvedStyle.getName());
+    }
+
+    @Test
+    public void testResolveMapInfo() {
+        ResolvingProxyResolver.resolve(new MapInfoImpl(), catalog);
+        verifyNoMoreInteractions(catalog);
+    }
+
+    @Test
+    public void testUnknownCatalognfo() {
+        ResolvingProxyResolver.resolve(mock(CatalogInfo.class), catalog);
+        verifyNoMoreInteractions(catalog);
+    }
+}


### PR DESCRIPTION
Extract proxy resolution logic from AbstractCatalogFacade into ResolvingProxyResolver to centralize this functionality and make it reusable across the codebase. This change:

- Creates a new `ResolvingProxyResolver` utility with comprehensive documentation
- `ResolvingProxyResolver` is only dedicated to resolve proxies, while `AbstractCatalogFacade`'s `resolve()` methods call `setId()` and `ResolvingProxyResolver.resolve()`.
- Avoids code duplication by moving proxy resolution to an utility class
- Simplifies `AbstractCatalogFacade` by delegating to the specialized resolver
- Adds test suite for `ResolvingProxyResolver` with 97.3% coverage


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.