### PR TITLE
[Backport 2.26.x][GEOS-11769] Race conditions in LayerGroupHelper when the default catalog is not fully initialized

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CatalogBuilder.java
@@ -1584,7 +1584,7 @@ public class CatalogBuilder {
 
     /** Calculates the bounds of a layer group specifying a particular crs. */
     public void calculateLayerGroupBounds(LayerGroupInfo layerGroup, CoordinateReferenceSystem crs) throws Exception {
-        LayerGroupHelper helper = new LayerGroupHelper(layerGroup);
+        LayerGroupHelper helper = new LayerGroupHelper(catalog, layerGroup);
         helper.calculateBounds(crs);
     }
 
@@ -1595,13 +1595,13 @@ public class CatalogBuilder {
      * @see LayerGroupHelper#calculateBoundsFromCRS(CoordinateReferenceSystem)
      */
     public void calculateLayerGroupBoundsFromCRS(LayerGroupInfo layerGroup, CoordinateReferenceSystem crs) {
-        LayerGroupHelper helper = new LayerGroupHelper(layerGroup);
+        LayerGroupHelper helper = new LayerGroupHelper(catalog, layerGroup);
         helper.calculateBoundsFromCRS(crs);
     }
 
     /** Calculates the bounds of a layer group by aggregating the bounds of each layer. */
     public void calculateLayerGroupBounds(LayerGroupInfo layerGroup) throws Exception {
-        LayerGroupHelper helper = new LayerGroupHelper(layerGroup);
+        LayerGroupHelper helper = new LayerGroupHelper(catalog, layerGroup);
         helper.calculateBounds();
     }
 

--- a/src/main/src/main/java/org/geoserver/catalog/LayerGroupHelper.java
+++ b/src/main/src/main/java/org/geoserver/catalog/LayerGroupHelper.java
@@ -30,16 +30,65 @@ import org.geotools.api.style.StyledLayerDescriptor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 
-/** Utility class to work with nested layer groups and extract selected sub-parts of it */
+/**
+ * Utility class to work with nested layer groups and extract selected sub-parts of it.
+ *
+ * <p>This helper provides methods to:
+ *
+ * <ul>
+ *   <li>Navigate through nested layer group structures
+ *   <li>Retrieve all layers, styles, and groups contained within a layer group
+ *   <li>Calculate bounding boxes for layer groups based on their contained layers
+ *   <li>Handle layer group styles and style groups
+ *   <li>Detect recursive references and loops in layer group structures
+ *   <li>Process layer groups for rendering
+ * </ul>
+ *
+ * <p>The helper accommodates different layer group modes (EO, SINGLE, CONTAINER, etc.) and handles special cases such
+ * as null layers with style groups and WMS remote layers.
+ */
 public class LayerGroupHelper {
 
     protected static Logger LOGGER = org.geotools.util.logging.Logging.getLogger("org.geoserver.catalog");
 
     private LayerGroupInfo group;
 
-    /** @param group */
+    final Catalog catalog;
+
+    /**
+     * Constructs a new helper for the specified layer group.
+     *
+     * <p>This constructor uses the default GeoServer catalog obtained via {@link #catalog()}.
+     */
     public LayerGroupHelper(LayerGroupInfo group) {
+        this(catalog(), group);
+    }
+
+    /**
+     * Constructs a new helper for the specified layer group with a specific catalog.
+     *
+     * <p>This constructor allows specifying an explicit catalog instance instead of using the default one. This is
+     * useful to ensure the proper catalog instance is used, for example during startup, when a temporary catalog is
+     * populated from the data directory.
+     *
+     * @param catalog the catalog to use for resolving references, must not be null
+     * @param group the layer group to be worked with, must not be null
+     */
+    public LayerGroupHelper(Catalog catalog, LayerGroupInfo group) {
+        this.catalog = catalog;
         this.group = group;
+    }
+
+    /**
+     * Retrieves the default GeoServer catalog from the application context.
+     *
+     * <p>This method uses {@link GeoServerExtensions} to look up the catalog bean from the application context. It's
+     * used by the default constructor to obtain the catalog when none is explicitly provided.
+     *
+     * @return the default GeoServer catalog instance
+     */
+    private static Catalog catalog() {
+        return (Catalog) GeoServerExtensions.bean("catalog");
     }
 
     /** */
@@ -49,7 +98,7 @@ public class LayerGroupHelper {
         return layers;
     }
 
-    private static void allLayers(LayerGroupInfo group, List<LayerInfo> layers) {
+    private void allLayers(LayerGroupInfo group, List<LayerInfo> layers) {
         if (LayerGroupInfo.Mode.EO.equals(group.getMode())) {
             layers.add(group.getRootLayer());
         }
@@ -90,7 +139,7 @@ public class LayerGroupHelper {
         return layerInfos;
     }
 
-    private static void allLayers(CoordinateReferenceSystem crs, LayerGroupStyle groupStyle, List<LayerInfo> layers) {
+    private void allLayers(CoordinateReferenceSystem crs, LayerGroupStyle groupStyle, List<LayerInfo> layers) {
         List<PublishedInfo> published = groupStyle.getLayers();
         List<StyleInfo> styles = groupStyle.getStyles();
         int pSize = published.size();
@@ -186,7 +235,7 @@ public class LayerGroupHelper {
         return styles;
     }
 
-    private static void allStyles(LayerGroupInfo group, List<StyleInfo> styles) {
+    private void allStyles(LayerGroupInfo group, List<StyleInfo> styles) {
         if (LayerGroupInfo.Mode.EO.equals(group.getMode())) {
             styles.add(group.getRootLayerStyle());
         }
@@ -225,7 +274,7 @@ public class LayerGroupHelper {
         return layers;
     }
 
-    private static void allLayersForRendering(
+    private void allLayersForRendering(
             LayerGroupInfo group, LayerGroupStyle groupStyle, List<LayerInfo> layers, boolean root) {
         switch (group.getMode()) {
             case EO:
@@ -282,7 +331,7 @@ public class LayerGroupHelper {
         return styles;
     }
 
-    private static void allStylesForRendering(
+    private void allStylesForRendering(
             LayerGroupInfo group, LayerGroupStyle groupStyle, List<StyleInfo> styles, boolean root) {
         switch (group.getMode()) {
             case EO:
@@ -484,8 +533,7 @@ public class LayerGroupHelper {
      * @param path Stack of each visited/parent LayerGroup
      * @return true if the LayerGroup contains itself, or another LayerGroup contains itself
      */
-    private static boolean checkLoops(
-            LayerGroupInfo group, List<LayerGroupStyle> groupStyles, Stack<LayerGroupInfo> path) {
+    private boolean checkLoops(LayerGroupInfo group, List<LayerGroupStyle> groupStyles, Stack<LayerGroupInfo> path) {
         if (groupStyles != null) {
             for (LayerGroupStyle groupStyle : groupStyles) {
                 if (checkLoops(group, groupStyle.getLayers(), groupStyle.getStyles(), path)) {
@@ -505,7 +553,7 @@ public class LayerGroupHelper {
      * @param path Stack of each visited/parent LayerGroup
      * @return true if the LayerGroup contains itself, or another LayerGroup contains itself
      */
-    private static boolean checkLoops(
+    private boolean checkLoops(
             LayerGroupInfo group, List<PublishedInfo> layers, List<StyleInfo> styles, Stack<LayerGroupInfo> path) {
         path.push(group);
         if (layers != null) {
@@ -548,15 +596,14 @@ public class LayerGroupHelper {
      * @param path Stack of each visited/parent LayerGroup
      * @return true if the style group contains itself, or another LayerGroup contains itself
      */
-    private static boolean checkStyleGroupLoops(
-            StyleInfo styleGroup, LayerGroupInfo group, Stack<LayerGroupInfo> path) {
+    private boolean checkStyleGroupLoops(StyleInfo styleGroup, LayerGroupInfo group, Stack<LayerGroupInfo> path) {
         try {
             StyledLayerDescriptor sld = styleGroup.getSLD();
 
             final boolean[] hasLoop = {false};
             sld.accept(
                     new GeoServerSLDVisitorAdapter(
-                            (Catalog) GeoServerExtensions.bean("catalog"),
+                            catalog,
                             group.getBounds() == null ? null : group.getBounds().getCoordinateReferenceSystem()) {
 
                         private final IllegalStateException recursionException =
@@ -620,7 +667,7 @@ public class LayerGroupHelper {
         return false;
     }
 
-    private static void expandStyleGroup(
+    private void expandStyleGroup(
             StyleInfo styleGroup, CoordinateReferenceSystem crs, List<LayerInfo> layers, List<StyleInfo> styles) {
         if (layers == null) {
             layers = new ArrayList<>();
@@ -631,7 +678,7 @@ public class LayerGroupHelper {
 
         try {
             StyledLayerDescriptor sld = styleGroup.getSLD();
-            StyleGroupHelper helper = new StyleGroupHelper((Catalog) GeoServerExtensions.bean("catalog"), crs);
+            StyleGroupHelper helper = new StyleGroupHelper(catalog, crs);
             sld.accept(helper);
             layers.addAll(helper.getLayers());
             styles.addAll(helper.getStyles());

--- a/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/CatalogImpl.java
@@ -991,7 +991,7 @@ public class CatalogImpl implements Catalog {
             throw new IllegalArgumentException("Layer group has different number of styles than layers");
         }
 
-        LayerGroupHelper helper = new LayerGroupHelper(layerGroup);
+        LayerGroupHelper helper = new LayerGroupHelper(this, layerGroup);
         Stack<LayerGroupInfo> loopPath = helper.checkLoops();
         if (loopPath != null) {
             throw new IllegalArgumentException("Layer group is in a loop: " + helper.getLoopAsString(loopPath));

--- a/src/main/src/test/java/org/geoserver/catalog/LayerGroupHelperTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/LayerGroupHelperTest.java
@@ -7,7 +7,9 @@ package org.geoserver.catalog;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,6 +19,7 @@ import org.geoserver.catalog.LayerGroupInfo.Mode;
 import org.geoserver.catalog.impl.LayerGroupInfoImpl;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.MockTestData;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geoserver.test.GeoServerMockTestSupport;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.NoSuchAuthorityCodeException;
@@ -325,6 +328,25 @@ public class LayerGroupHelperTest extends GeoServerMockTestSupport {
         // null CRS should get null bounds
         helper.calculateBoundsFromCRS(null);
         assertNull(nested.getBounds());
+    }
+
+    @Test
+    public void testUseProvidedCatalog() {
+        Catalog catalog = mock(Catalog.class);
+        LayerGroupHelper helper = new LayerGroupHelper(catalog, container);
+        assertSame(catalog, helper.catalog);
+    }
+
+    @Test
+    public void testDefaultsToCatalogBean() {
+        Catalog catalog = mock(Catalog.class);
+        GeoServerExtensionsHelper.singleton("catalog", catalog, Catalog.class);
+        try {
+            LayerGroupHelper helper = new LayerGroupHelper(container);
+            assertSame(catalog, helper.catalog);
+        } finally {
+            GeoServerExtensionsHelper.init(null);
+        }
     }
 
     private ReferencedEnvelope aggregateEnvelopes(LayerInfo... layers) {


### PR DESCRIPTION
[![GEOS-11769](https://badgen.net/badge/JIRA/GEOS-11769/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11769) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport #8414

Explicitly pass the correct catalog instance to LayerGroupHelper to ensure proper operation during startup and dynamic catalog modifications. This fixes potential race conditions where the helper might use a default catalog that is not fully initialized or is different from the one being used for current operations.

The changes include:
- Adding a two-arg constructor to LayerGroupHelper that takes an explicit catalog
- Converting static helper methods to instance methods using the instance catalog
- Updating all call sites to pass the current catalog explicitly
- Adding comprehensive javadocs explaining the class purpose and behavior


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.