### PR TITLE
Added note to clarify that the header value should match a username

### DIFF
--- a/doc/en/user/source/security/tutorials/httpheaderproxy/index.rst
+++ b/doc/en/user/source/security/tutorials/httpheaderproxy/index.rst
@@ -47,7 +47,7 @@ Configure the HTTP header filter
 #. Fill in the fields of the settings form as follows:
 
    * Set ``Name`` to "proxy"
-   * Set ``Request header attribute to`` to "sdf09rt2s"
+   * Set ``Request header attribute`` to "sdf09rt2s"
    * Set ``Role source`` to "User group service"
    * Set the name of the user group service to "default"
 
@@ -143,3 +143,11 @@ Test a proxy login
     
    The result should be a successful authentication and contain the normal WFS capabilities response.
 
+   .. note::
+      When setting the header ``name: value`` pair, the header ``name`` should match the ``Request Header Attribute`` 
+      that was set when creating the new Authentication Filter, and the ``value`` must match the username for a user
+      who has the correct Role set. The username value is case sensitive. 
+      
+      In the above example, the ``admin`` user is assigned to the ``ADMIN`` role which is the role that was selected in 
+      the service rule we created. If you had a diferent user that was assigned to the ``ADMIN`` role, you could instead
+      use the username for that user as the ``value`` in the header and you should get the correct capabilities response.


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
In going through the process of using the http header auth for the first time, it was very unclear in the documentation what the header value was supposed to match. After doing a bunch of testing it became clear that it needed to match the username of a user, but that was not included anywhere in the documentation. This update adds a note at the end that makes it very clear what each part of the header ``name: value`` pair is associated with in the system.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).