### PR TITLE
Longitudinal profile process improvements (memory, stability, performance)

### DIFF
--- a/doc/en/user/source/community/wps-longitudinal-profile/index.rst
+++ b/doc/en/user/source/community/wps-longitudinal-profile/index.rst
@@ -38,6 +38,7 @@ Process accepts following parameters:
 **Required:**
 
 #. layerName - name of the raster layer (coverage) which will be used for altitude profile creation
+#. coverage - the actual raster to be used for altitude profile creation. This is an alternative to layerName, allows for process chaining (a chained process might have computed the input coverage)
 #. geometry - geometry in wkt or ewkt format, along which the altitude profile will be created. If wkt is used, its CRS will be assumed as CRS of coverage.
 #. distance - maximal distance between points of altitude profile
 
@@ -80,3 +81,14 @@ The profile object contains an array of points.
 .. note::
    It's possible to set wpsLongitudinalMaxThreadPoolSize (integer value) environment variable to limit the size of the extension's thread pool.
    It's possible to set wpsLongitudinalVerticesChunkSize (integer value) environment variable to define number of vertices processed in a chunk.
+
+Tunables and safeguards
+-----------------------
+
+The WPS longitudinal profile process is designed to be used with large datasets and may extract
+many points from the input geometry. To avoid performance issues, the process has a number of tunables and safeguards,
+that the system administrator can specify as system or environement variables:
+
+* ``wpsLongitudinalMaxPoints``: maximum number of points to be extracted from the input geometry. The default value is 50000 (amounts to a memory usage of a few megabytes).
+* ``wpsLongitudinalMaxThreadPoolSize``: size of the background thread pool used by the process to speed up calculations (all calls use the same pool). The default value matches the numbers of CPU threads.
+* ``wpsLongitudinalVerticesChunkSize```: number of vertices processed in a single background thread call. The default value is 5000.

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/AltitudeReaderThread.java
@@ -27,7 +27,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 
-public class AltitudeReaderThread implements Callable<List<ProfileVertice>> {
+class AltitudeReaderThread implements Callable<List<ProfileVertice>> {
     static final Logger LOGGER = Logging.getLogger(AltitudeReaderThread.class);
 
     private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/CoverageSampler.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/CoverageSampler.java
@@ -1,0 +1,66 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wps.longitudinal;
+
+import java.awt.Rectangle;
+import java.awt.image.Raster;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.media.jai.PlanarImage;
+import org.geotools.api.coverage.PointOutsideCoverageException;
+import org.geotools.api.referencing.operation.MathTransform2D;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.util.logging.Logging;
+import org.locationtech.jts.geom.Coordinate;
+
+/**
+ * Samples a grid coverage at a given point, returning a single pixel value. Meant to be used for repeated sampling of a
+ * coverage along various points. Avoids the overhead of calling
+ * {@link org.geotools.coverage.grid.GridCoverage2D#evaluate(org.locationtech.jts.geom.Coordinate, double[])} for each
+ * point.
+ */
+class CoverageSampler {
+    static final Logger LOGGER = Logging.getLogger(CoverageSampler.class);
+
+    private final MathTransform2D modelToPixel;
+    private final int band;
+    private final ReferencedEnvelope coverageBounds;
+    private final PlanarImage pi;
+    private Raster lastTile;
+    private Rectangle lastTileBounds;
+    private final double[] position = new double[2];
+
+    public CoverageSampler(GridCoverage2D coverage, int band) {
+        this.pi = PlanarImage.wrapRenderedImage(coverage.getRenderedImage());
+        this.coverageBounds = coverage.getEnvelope2D();
+        this.modelToPixel = coverage.getGridGeometry().getCRSToGrid2D();
+        this.band = band;
+    }
+
+    public double sample(Coordinate coordinate) throws TransformException {
+        if (!coverageBounds.contains(coordinate.x, coordinate.y))
+            throw new PointOutsideCoverageException("Point " + coordinate + " is outside coverage bounds");
+        position[0] = coordinate.x;
+        position[1] = coordinate.y;
+        modelToPixel.transform(position, 0, position, 0, 1);
+        final int col = (int) Math.round(position[0]);
+        final int row = (int) Math.round(position[1]);
+        if (lastTile == null || !lastTileBounds.contains(col, row)) {
+            LOGGER.log(Level.FINE, () -> Thread.currentThread().getName() + " loading tile at " + col + "/" + row);
+            lastTile = pi.getTile(pi.XToTileX(col), pi.YToTileY(row));
+            lastTileBounds = lastTile.getBounds();
+        }
+        try {
+            return lastTile.getSampleDouble(col, row, band);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new RuntimeException(
+                    "Failed to get sample at " + coordinate + " with " + row + "/" + col + " on tile with bounds "
+                            + lastTileBounds,
+                    e);
+        }
+    }
+}

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/DistanceSlopeCalculator.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/DistanceSlopeCalculator.java
@@ -1,0 +1,57 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wps.longitudinal;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.crs.GeographicCRS;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.GeodeticCalculator;
+import org.locationtech.jts.geom.Point;
+
+class DistanceSlopeCalculator {
+
+    private GeodeticCalculator gc;
+    private Point current;
+    private Point previous;
+    private final CoordinateReferenceSystem projection;
+    private double distance;
+    private double slope;
+
+    public DistanceSlopeCalculator(CoordinateReferenceSystem projection) {
+        this.projection = projection;
+        if (projection instanceof GeographicCRS) gc = new GeodeticCalculator(projection);
+    }
+
+    public void next(Point next, double altitude) throws TransformException {
+        if (current != null) previous = current;
+        current = next;
+
+        if (previous != null) {
+            if (gc != null) {
+                gc.setStartingPosition(JTS.toDirectPosition(previous.getCoordinate(), projection));
+                gc.setDestinationPosition(JTS.toDirectPosition(current.getCoordinate(), projection));
+                distance = gc.getOrthodromicDistance();
+            } else {
+                distance = previous.distance(current);
+            }
+
+            // calculate slope percentage
+            slope = altitude * 100 / distance;
+        }
+    }
+
+    public double getDistance() {
+        return distance;
+    }
+
+    public double getSlope() {
+        return slope;
+    }
+
+    public CoordinateReferenceSystem getProjection() {
+        return projection;
+    }
+}

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcessResultsPPIO.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcessResultsPPIO.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.wps.longitudinal;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -11,7 +13,9 @@ import org.geoserver.wps.ppio.CDataPPIO;
 
 public class LongitudinalProfileProcessResultsPPIO extends CDataPPIO {
 
-    static final ObjectMapper MAPPER = new ObjectMapper();
+    static final ObjectMapper MAPPER = new ObjectMapper(JsonFactory.builder()
+            .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+            .build());
 
     public LongitudinalProfileProcessResultsPPIO() {
         super(

--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/ProfileVertice.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/ProfileVertice.java
@@ -7,24 +7,27 @@ package org.geoserver.wps.longitudinal;
 import org.locationtech.jts.geom.Coordinate;
 
 public class ProfileVertice {
-    Integer number;
+    public static final int UNSET = -1;
+    int number;
     Coordinate coordinate;
-    Double altitude;
+    double altitude;
+    double distancePrevious = UNSET;
+    double slope = 0;
 
     public ProfileVertice() {}
 
-    public ProfileVertice(Integer number, Coordinate coordinate, Double altitude) {
+    public ProfileVertice(int number, Coordinate coordinate, double altitude) {
         super();
         this.number = number;
         this.coordinate = coordinate;
         this.altitude = altitude;
     }
 
-    public Integer getNumber() {
+    public int getNumber() {
         return number;
     }
 
-    public void setNumber(Integer number) {
+    public void setNumber(int number) {
         this.number = number;
     }
 
@@ -36,11 +39,27 @@ public class ProfileVertice {
         this.coordinate = coordinate;
     }
 
-    public Double getAltitude() {
+    public double getAltitude() {
         return altitude;
     }
 
-    public void setAltitude(Double altitude) {
+    public void setAltitude(double altitude) {
         this.altitude = altitude;
+    }
+
+    public double getDistancePrevious() {
+        return distancePrevious;
+    }
+
+    public void setDistancePrevious(double distancePrevious) {
+        this.distancePrevious = distancePrevious;
+    }
+
+    public double getSlope() {
+        return slope;
+    }
+
+    public void setSlope(double slope) {
+        this.slope = slope;
     }
 }

--- a/src/community/wps-longitudinal-profile/src/test/java/org/geoserver/wps/longitudinal/test/LongitudinalProfileProcessTest.java
+++ b/src/community/wps-longitudinal-profile/src/test/java/org/geoserver/wps/longitudinal/test/LongitudinalProfileProcessTest.java
@@ -4,58 +4,37 @@
  */
 package org.geoserver.wps.longitudinal.test;
 
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.xml.namespace.QName;
 import net.sf.json.JSONArray;
+import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wps.WPSTestSupport;
-import org.junit.Assert;
 import org.junit.Test;
+import org.w3c.dom.Document;
 
 public class LongitudinalProfileProcessTest extends WPSTestSupport {
-
     private static final QName PROFILE = new QName(MockData.DEFAULT_URI, "dataProfile", MockData.DEFAULT_PREFIX);
     private static final QName ADJ_LAYER = new QName(MockData.DEFAULT_URI, "AdjustmentLayer", MockData.DEFAULT_PREFIX);
-    private static final String LAYER_NAME = "<wps:Input>\n"
-            + "      <ows:Identifier>layerName</ows:Identifier>\n"
-            + "      <wps:Data>\n"
-            + "        <wps:LiteralData>dataProfile</wps:LiteralData>\n"
-            + "      </wps:Data>\n"
-            + "    </wps:Input>\n";
-    private static final String RESPONSE_FORM = "<wps:ResponseForm>\n"
-            + "    <wps:RawDataOutput mimeType=\"application/json\">\n"
-            + "      <ows:Identifier>result</ows:Identifier>\n"
-            + "    </wps:RawDataOutput>\n"
-            + "  </wps:ResponseForm>\n";
-    private static final String LINESTRING_FOR_2154 = "<wps:Input>\n"
-            + "  <ows:Identifier>geometry</ows:Identifier>\n"
-            + "      <wps:Data>\n"
-            + "        <wps:ComplexData mimeType=\"application/ewkt\"><![CDATA[SRID=2154;LINESTRING(843478.269971218 6420348.7621933, 843797.900998497 6420021.75658605, 844490.474212848 6420187.03857354, 844102.691178047 6420613.93854596)]]></wps:ComplexData>\n"
-            + "      </wps:Data>\n"
-            + "    </wps:Input>\n";
 
-    private static final String WKT_LINESTRING_FOR_2154 = "<wps:Input>\n"
-            + "  <ows:Identifier>geometry</ows:Identifier>\n"
-            + "      <wps:Data>\n"
-            + "        <wps:ComplexData mimeType=\"application/wkt\"><![CDATA[LINESTRING(843478.269971218 6420348.7621933, 843797.900998497 6420021.75658605, 844490.474212848 6420187.03857354, 844102.691178047 6420613.93854596)]]></wps:ComplexData>\n"
-            + "      </wps:Data>\n"
-            + "    </wps:Input>\n";
-
-    private static final String LINESTRING_FOR_4326 = "<wps:Input>\n"
-            + "  <ows:Identifier>geometry</ows:Identifier>\n"
-            + "      <wps:Data>\n"
-            + "        <wps:ComplexData mimeType=\"application/ewkt\"><![CDATA[SRID=4326;LINESTRING(4.816667349546753 44.86746046117114, 4.820617515841021 44.86445081066109, 4.829431492334357 44.86579440463876, 4.82464829777395 44.869717699053616)]]></wps:ComplexData>\n"
-            + "      </wps:Data>\n"
-            + "    </wps:Input>\n";
-    private static final String HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<wps:Execute version=\"1.0.0\" service=\"WPS\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.opengis.net/wps/1.0.0\" xmlns:wfs=\"http://www.opengis.net/wfs\" xmlns:wps=\"http://www.opengis.net/wps/1.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:gml=\"http://www.opengis.net/gml\" xmlns:ogc=\"http://www.opengis.net/ogc\" xmlns:wcs=\"http://www.opengis.net/wcs/1.1.1\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xsi:schemaLocation=\"http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd\">\n"
-            + "  <ows:Identifier>gs:LongitudinalProfile</ows:Identifier>\n"
-            + "  <wps:DataInputs>\n"
-            + "    ";
+    private static final String LINESTRING_2154_WKT =
+            "LINESTRING(843478.269971218 6420348.7621933, 843797.900998497 6420021.75658605, 844490.474212848 6420187.03857354, 844102.691178047 6420613.93854596)";
+    private static final String LINESTRING_2154_EWKT = "SRID=2154;" + LINESTRING_2154_WKT;
+    private static final String LINESTRING_4326_EWKT =
+            "SRID=4326;LINESTRING(4.816667349546753 44.86746046117114, 4.820617515841021 44.86445081066109, 4.829431492334357 44.86579440463876, 4.82464829777395 44.869717699053616)";
 
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
@@ -76,217 +55,165 @@ public class LongitudinalProfileProcessTest extends WPSTestSupport {
                 getCatalog());
     }
 
-    @Test
-    public void testRequiredParams() throws Exception {
-        String requestXml = HEADER
-                + LAYER_NAME
-                + "   <wps:Input>\n"
-                + "      <ows:Identifier>distance</ows:Identifier>\n"
-                + "      <wps:Data>\n"
-                + "        <wps:LiteralData>300</wps:LiteralData>\n"
-                + "      </wps:Data>\n"
-                + "    </wps:Input>"
-                + LINESTRING_FOR_2154
-                + "  </wps:DataInputs>\n"
-                + "  "
-                + RESPONSE_FORM
-                + "</wps:Execute>\n"
-                + "\n"
-                + "";
-
-        JSONObject response = (JSONObject) postAsJSON(root(), requestXml, "application/xml");
-        JSONObject infos = response.getJSONObject("infos");
-        Assert.assertEquals(214.94, infos.get("altitudePositive"));
-        Assert.assertEquals(-64.28, infos.get("altitudeNegative"));
-        Assert.assertEquals(1746.0248, infos.get("totalDistance"));
-        Assert.assertEquals(843478.25, infos.get("firstPointX"));
-        Assert.assertEquals(6420349.0, infos.get("firstPointY"));
-        Assert.assertEquals(844102.7, infos.get("lastPointX"));
-        Assert.assertEquals(6420614.0, infos.get("lastPointY"));
-        Assert.assertEquals("dataProfile", infos.get("layer"));
-        Assert.assertEquals(8, infos.get("processedPoints"));
-        Assert.assertNotNull(infos.get("executedTime"));
-        JSONArray profile = response.getJSONArray("profile");
-        Assert.assertEquals(8, profile.size());
-        JSONObject profile3 = (JSONObject) profile.get(3);
-        Assert.assertEquals(694.61163, profile3.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(164.11, profile3.get("altitude"));
-        Assert.assertEquals(69.1453, profile3.get("slope"));
-        Assert.assertEquals(844028.75, profile3.get("x"));
-        Assert.assertEquals(6420077.0, profile3.get("y"));
-
-        JSONObject profile5 = (JSONObject) profile.get(5);
-        Assert.assertEquals(1169.2932, profile5.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(178.82, profile5.get("altitude"));
-        Assert.assertEquals(75.34314, profile5.get("slope"));
-        Assert.assertEquals(844490.5, profile5.get("x"));
-        Assert.assertEquals(6420187.0, profile5.get("y"));
-
-        JSONObject profile7 = (JSONObject) profile.get(7);
-        Assert.assertEquals(1746.0248, profile7.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(150.66, profile7.get("altitude"));
-        Assert.assertEquals(52.246147, profile7.get("slope"));
-        Assert.assertEquals(844102.7, profile7.get("x"));
-        Assert.assertEquals(6420614.0, profile7.get("y"));
+    private String loadTemplate(String templateName, Map<String, String> values) throws IOException {
+        String template = new String(Files.readAllBytes(Paths.get("src/test/resources/" + templateName)));
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            template = template.replace("${" + entry.getKey() + "}", entry.getValue());
+        }
+        return template;
     }
 
     @Test
-    public void testWktWithCrsOfTheLayer() throws Exception {
-        String requestXml = HEADER
-                + LAYER_NAME
-                + "   <wps:Input>\n"
-                + "      <ows:Identifier>distance</ows:Identifier>\n"
-                + "      <wps:Data>\n"
-                + "        <wps:LiteralData>300</wps:LiteralData>\n"
-                + "      </wps:Data>\n"
-                + "    </wps:Input>"
-                + WKT_LINESTRING_FOR_2154
-                + "  </wps:DataInputs>\n"
-                + "  "
-                + RESPONSE_FORM
-                + "</wps:Execute>\n"
-                + "\n"
-                + "";
+    public void testNoInputLayer() throws Exception {
+        String requestXml =
+                loadTemplate("templateNoInputLayer.xml", Map.of("GEOMETRY", LINESTRING_2154_WKT, "DISTANCE", "300"));
 
+        Document d = postAsDOM(root(), requestXml);
+        assertEquals("wps:ExecuteResponse", d.getDocumentElement().getNodeName());
+
+        assertXpathExists("/wps:ExecuteResponse/wps:Status/wps:ProcessFailed", d);
+        String msg = xp.evaluate(
+                "/wps:ExecuteResponse/wps:Status/wps:ProcessFailed/ows:ExceptionReport/ows:Exception/ows:ExceptionText",
+                d);
+        assertThat(msg, containsString("Either layerName or coverage must be provided"));
+    }
+
+    @Test
+    public void testBasicProfileLayer() throws Exception {
+        String requestXml = loadTemplate(
+                "templateBasic.xml",
+                Map.of(
+                        "LAYER_NAME", "dataProfile",
+                        "GEOMETRY", LINESTRING_2154_WKT,
+                        "DISTANCE", "300"));
+
+        checkBasicProfile(requestXml, "dataProfile");
+    }
+
+    @Test
+    public void testBasicProfileCoverage() throws Exception {
+        String requestXml = loadTemplate(
+                "templateChaining.xml",
+                Map.of(
+                        "COVERAGE_ID", "gs__dataProfile",
+                        "GEOMETRY", LINESTRING_2154_WKT,
+                        "DISTANCE", "300"));
+
+        checkBasicProfile(requestXml, null);
+    }
+
+    private void checkBasicProfile(String requestXml, String expctedLayer) throws Exception {
         JSONObject response = (JSONObject) postAsJSON(root(), requestXml, "application/xml");
         JSONObject infos = response.getJSONObject("infos");
-        Assert.assertEquals(214.94, infos.get("altitudePositive"));
-        Assert.assertEquals(-64.28, infos.get("altitudeNegative"));
-        Assert.assertEquals(1746.0248, infos.get("totalDistance"));
-        Assert.assertEquals(843478.25, infos.get("firstPointX"));
-        Assert.assertEquals(6420349.0, infos.get("firstPointY"));
-        Assert.assertEquals(844102.7, infos.get("lastPointX"));
-        Assert.assertEquals(6420614.0, infos.get("lastPointY"));
-        Assert.assertEquals("dataProfile", infos.get("layer"));
-        Assert.assertEquals(8, infos.get("processedPoints"));
-        Assert.assertNotNull(infos.get("executedTime"));
+        assertEquals(214.94, infos.get("altitudePositive"));
+        assertEquals(-64.28, infos.get("altitudeNegative"));
+        assertEquals(1746.0248, infos.get("totalDistance"));
+        assertEquals(843478.25, infos.get("firstPointX"));
+        assertEquals(6420349.0, infos.get("firstPointY"));
+        assertEquals(844102.7, infos.get("lastPointX"));
+        assertEquals(6420614.0, infos.get("lastPointY"));
+        if (expctedLayer != null) {
+            assertEquals(expctedLayer, infos.get("layer"));
+        } else {
+            assertEquals(JSONNull.getInstance(), infos.get("layer"));
+        }
+        assertEquals(8, infos.get("processedPoints"));
+        assertNotNull(infos.get("executedTime"));
         JSONArray profile = response.getJSONArray("profile");
-        Assert.assertEquals(8, profile.size());
+        assertEquals(8, profile.size());
         JSONObject profile3 = (JSONObject) profile.get(3);
-        Assert.assertEquals(694.61163, profile3.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(164.11, profile3.get("altitude"));
-        Assert.assertEquals(69.1453, profile3.get("slope"));
-        Assert.assertEquals(844028.75, profile3.get("x"));
-        Assert.assertEquals(6420077.0, profile3.get("y"));
+        assertEquals(694.61163, profile3.get("totalDistanceToThisPoint"));
+        assertEquals(164.11, profile3.get("altitude"));
+        assertEquals(69.1453, profile3.get("slope"));
+        assertEquals(844028.75, profile3.get("x"));
+        assertEquals(6420077.0, profile3.get("y"));
 
         JSONObject profile5 = (JSONObject) profile.get(5);
-        Assert.assertEquals(1169.2932, profile5.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(178.82, profile5.get("altitude"));
-        Assert.assertEquals(75.34314, profile5.get("slope"));
-        Assert.assertEquals(844490.5, profile5.get("x"));
-        Assert.assertEquals(6420187.0, profile5.get("y"));
+        assertEquals(1169.2932, profile5.get("totalDistanceToThisPoint"));
+        assertEquals(178.82, profile5.get("altitude"));
+        assertEquals(75.34314, profile5.get("slope"));
+        assertEquals(844490.5, profile5.get("x"));
+        assertEquals(6420187.0, profile5.get("y"));
 
         JSONObject profile7 = (JSONObject) profile.get(7);
-        Assert.assertEquals(1746.0248, profile7.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(150.66, profile7.get("altitude"));
-        Assert.assertEquals(52.246147, profile7.get("slope"));
-        Assert.assertEquals(844102.7, profile7.get("x"));
-        Assert.assertEquals(6420614.0, profile7.get("y"));
+        assertEquals(1746.0248, profile7.get("totalDistanceToThisPoint"));
+        assertEquals(150.66, profile7.get("altitude"));
+        assertEquals(52.246147, profile7.get("slope"));
+        assertEquals(844102.7, profile7.get("x"));
+        assertEquals(6420614.0, profile7.get("y"));
     }
 
     @Test
     public void testReprojectCRS() throws Exception {
-        String requestXml = HEADER
-                + LAYER_NAME
-                + "   <wps:Input>\n"
-                + "      <ows:Identifier>distance</ows:Identifier>\n"
-                + "      <wps:Data>\n"
-                + "        <wps:LiteralData>300</wps:LiteralData>\n"
-                + "      </wps:Data>\n"
-                + "    </wps:Input>"
-                + LINESTRING_FOR_2154
-                + "   <wps:Input>\n"
-                + "       <ows:Identifier>targetProjection</ows:Identifier>\n"
-                + "           <wps:Data>\n"
-                + "               <wps:LiteralData>EPSG:3857</wps:LiteralData>\n"
-                + "           </wps:Data>\n"
-                + "   </wps:Input>"
-                + "  </wps:DataInputs>\n"
-                + "  "
-                + RESPONSE_FORM
-                + "</wps:Execute>\n"
-                + "\n"
-                + "";
+        String requestXml = loadTemplate(
+                "templateTargetProjection.xml",
+                Map.of(
+                        "LAYER_NAME", "dataProfile",
+                        "GEOMETRY", LINESTRING_2154_WKT,
+                        "DISTANCE", "300",
+                        "TARGET_PROJECTION", "EPSG:3857"));
 
         JSONObject response = (JSONObject) postAsJSON(root(), requestXml, "application/xml");
         JSONObject infos = response.getJSONObject("infos");
-        Assert.assertEquals(214.94, infos.get("altitudePositive"));
-        Assert.assertEquals(-64.28, infos.get("altitudeNegative"));
-        Assert.assertEquals(2463.6123, infos.get("totalDistance"));
-        Assert.assertEquals(536188.94, infos.get("firstPointX"));
-        Assert.assertEquals(5600680.0, infos.get("firstPointY"));
-        Assert.assertEquals(537077.4, infos.get("lastPointX"));
-        Assert.assertEquals(5601034.5, infos.get("lastPointY"));
-        Assert.assertEquals("dataProfile", infos.get("layer"));
-        Assert.assertEquals(8, infos.get("processedPoints"));
-        Assert.assertNotNull(infos.get("executedTime"));
+        assertEquals(214.94, infos.get("altitudePositive"));
+        assertEquals(-64.28, infos.get("altitudeNegative"));
+        assertEquals(2463.6123, infos.get("totalDistance"));
+        assertEquals(536188.94, infos.get("firstPointX"));
+        assertEquals(5600680.0, infos.get("firstPointY"));
+        assertEquals(537077.4, infos.get("lastPointX"));
+        assertEquals(5601034.5, infos.get("lastPointY"));
+        assertEquals("dataProfile", infos.get("layer"));
+        assertEquals(8, infos.get("processedPoints"));
+        assertNotNull(infos.get("executedTime"));
         JSONArray profile = response.getJSONArray("profile");
-        Assert.assertEquals(8, profile.size());
+        assertEquals(8, profile.size());
         // Since checking all profiles will be excessive we will check only some in the middle
         JSONObject profile3 = (JSONObject) profile.get(3);
-        Assert.assertEquals(980.1413, profile3.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(164.11, profile3.get("altitude"));
-        Assert.assertEquals(49.056587, profile3.get("slope"));
-        Assert.assertEquals(536955.75, profile3.get("x"));
-        Assert.assertEquals(5600277.5, profile3.get("y"));
+        assertEquals(980.1413, profile3.get("totalDistanceToThisPoint"));
+        assertEquals(164.11, profile3.get("altitude"));
+        assertEquals(49.056587, profile3.get("slope"));
+        assertEquals(536955.75, profile3.get("x"));
+        assertEquals(5600277.5, profile3.get("y"));
 
         JSONObject profile5 = (JSONObject) profile.get(5);
-        Assert.assertEquals(1649.2133, profile5.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(178.82, profile5.get("altitude"));
-        Assert.assertEquals(53.45293, profile5.get("slope"));
-        Assert.assertEquals(537609.9, profile5.get("x"));
-        Assert.assertEquals(5600418.0, profile5.get("y"));
+        assertEquals(1649.2133, profile5.get("totalDistanceToThisPoint"));
+        assertEquals(178.82, profile5.get("altitude"));
+        assertEquals(53.45293, profile5.get("slope"));
+        assertEquals(537609.9, profile5.get("x"));
+        assertEquals(5600418.0, profile5.get("y"));
 
         JSONObject profile7 = (JSONObject) profile.get(7);
-        Assert.assertEquals(2463.6123, profile7.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(150.66, profile7.get("altitude"));
-        Assert.assertEquals(36.998417, profile7.get("slope"));
-        Assert.assertEquals(537077.4, profile7.get("x"));
-        Assert.assertEquals(5601034.5, profile7.get("y"));
+        assertEquals(2463.6123, profile7.get("totalDistanceToThisPoint"));
+        assertEquals(150.66, profile7.get("altitude"));
+        assertEquals(36.998417, profile7.get("slope"));
+        assertEquals(537077.4, profile7.get("x"));
+        assertEquals(5601034.5, profile7.get("y"));
     }
 
     @Test
     public void testCorrectReprojection() throws Exception {
-        String request2154 = HEADER
-                + LAYER_NAME
-                + "   <wps:Input>\n"
-                + "      <ows:Identifier>distance</ows:Identifier>\n"
-                + "      <wps:Data>\n"
-                + "        <wps:LiteralData>300</wps:LiteralData>\n"
-                + "      </wps:Data>\n"
-                + "    </wps:Input>"
-                + LINESTRING_FOR_2154
-                + "  </wps:DataInputs>\n"
-                + "  "
-                + RESPONSE_FORM
-                + "</wps:Execute>\n"
-                + "\n"
-                + "";
+        String request2154 = loadTemplate(
+                "templateBasic.xml",
+                Map.of(
+                        "LAYER_NAME", "dataProfile",
+                        "GEOMETRY", LINESTRING_2154_EWKT,
+                        "DISTANCE", "300"));
 
-        String request4326 = HEADER
-                + LAYER_NAME
-                + "   <wps:Input>\n"
-                + "      <ows:Identifier>distance</ows:Identifier>\n"
-                + "      <wps:Data>\n"
-                + "        <wps:LiteralData>300</wps:LiteralData>\n"
-                + "      </wps:Data>\n"
-                + "    </wps:Input>"
-                + LINESTRING_FOR_4326
-                + "  </wps:DataInputs>\n"
-                + "  "
-                + RESPONSE_FORM
-                + "</wps:Execute>\n"
-                + "\n"
-                + "";
+        String request4326 = loadTemplate(
+                "templateBasic.xml",
+                Map.of(
+                        "LAYER_NAME", "dataProfile",
+                        "GEOMETRY", LINESTRING_4326_EWKT,
+                        "DISTANCE", "300"));
 
         JSONObject response2154 = (JSONObject) postAsJSON(root(), request2154, "application/xml");
         JSONObject response4326 = (JSONObject) postAsJSON(root(), request4326, "application/xml");
         JSONObject infos2154 = response2154.getJSONObject("infos");
         JSONObject infos4326 = response4326.getJSONObject("infos");
 
-        Assert.assertEquals(infos2154.get("altitudePositive"), infos4326.get("altitudePositive"));
-        Assert.assertEquals(infos2154.get("altitudeNegative"), infos4326.get("altitudeNegative"));
-        Assert.assertEquals(infos2154.get("processedPoints"), infos4326.get("processedPoints"));
+        assertEquals(infos2154.get("altitudePositive"), infos4326.get("altitudePositive"));
+        assertEquals(infos2154.get("altitudeNegative"), infos4326.get("altitudeNegative"));
+        assertEquals(infos2154.get("processedPoints"), infos4326.get("processedPoints"));
 
         JSONArray profiles2154 = (JSONArray) response2154.get("profile");
         JSONArray profiles4326 = (JSONArray) response4326.get("profile");
@@ -294,79 +221,54 @@ public class LongitudinalProfileProcessTest extends WPSTestSupport {
         for (int i = 0; i < profiles2154.size(); i++) {
             JSONObject p1 = (JSONObject) profiles2154.get(i);
             JSONObject p2 = (JSONObject) profiles4326.get(i);
-            Assert.assertEquals(p1.get("altitude"), p2.get("altitude"));
+            assertEquals(p1.get("altitude"), p2.get("altitude"));
         }
     }
 
     @Test
     public void testAllParams() throws Exception {
-        String requestXml = HEADER
-                + LAYER_NAME
-                + "    <wps:Input>\n"
-                + "         <ows:Identifier>adjustmentLayerName</ows:Identifier>\n"
-                + "             <wps:Data>\n"
-                + "         <wps:LiteralData>AdjustmentLayer</wps:LiteralData>\n"
-                + "      </wps:Data>\n"
-                + "    </wps:Input>"
-                + "   <wps:Input>\n"
-                + "     <ows:Identifier>altitudeName</ows:Identifier>\n"
-                + "         <wps:Data>\n"
-                + "             <wps:LiteralData>altitude</wps:LiteralData>\n"
-                + "         </wps:Data>\n"
-                + "     </wps:Input>"
-                + "   <wps:Input>\n"
-                + "      <ows:Identifier>distance</ows:Identifier>\n"
-                + "      <wps:Data>\n"
-                + "        <wps:LiteralData>200</wps:LiteralData>\n"
-                + "      </wps:Data>\n"
-                + "    </wps:Input>"
-                + LINESTRING_FOR_2154
-                + "   <wps:Input>\n"
-                + "       <ows:Identifier>targetProjection</ows:Identifier>\n"
-                + "           <wps:Data>\n"
-                + "               <wps:LiteralData>EPSG:4326</wps:LiteralData>\n"
-                + "           </wps:Data>\n"
-                + "   </wps:Input>"
-                + "  </wps:DataInputs>\n"
-                + RESPONSE_FORM
-                + "</wps:Execute>\n"
-                + "\n"
-                + "";
+        String requestXml = loadTemplate(
+                "templateAllParameters.xml",
+                Map.of(
+                        "LAYER_NAME", "dataProfile",
+                        "GEOMETRY", LINESTRING_2154_WKT,
+                        "DISTANCE", "200",
+                        "TARGET_PROJECTION", "EPSG:4326"));
 
         JSONObject response = (JSONObject) postAsJSON(root(), requestXml, "application/xml");
         JSONObject infos = response.getJSONObject("infos");
-        Assert.assertEquals(195.69, infos.get("altitudePositive"));
-        Assert.assertEquals(-67.03, infos.get("altitudeNegative"));
-        Assert.assertEquals(0.020068234, infos.get("totalDistance"));
-        Assert.assertEquals(4.8166676, infos.get("firstPointX"));
-        Assert.assertEquals(44.867462, infos.get("firstPointY"));
-        Assert.assertEquals(4.8246484, infos.get("lastPointX"));
-        Assert.assertEquals(44.869717, infos.get("lastPointY"));
-        Assert.assertEquals("dataProfile", infos.get("layer"));
-        Assert.assertEquals(11, infos.get("processedPoints"));
-        Assert.assertNotNull(infos.get("executedTime"));
+        assertEquals(195.69, infos.get("altitudePositive"));
+        assertEquals(-67.03, infos.get("altitudeNegative"));
+        assertEquals(0.020068234, infos.get("totalDistance"));
+        assertEquals(4.8166676, infos.get("firstPointX"));
+        assertEquals(44.867462, infos.get("firstPointY"));
+        assertEquals(4.8246484, infos.get("lastPointX"));
+        assertEquals(44.869717, infos.get("lastPointY"));
+        assertEquals("dataProfile", infos.get("layer"));
+        assertEquals(11, infos.get("processedPoints"));
+        assertNotNull(infos.get("executedTime"));
         JSONArray profile = response.getJSONArray("profile");
-        Assert.assertEquals(11, profile.size());
+        assertEquals(11, profile.size());
 
         JSONObject profile3 = (JSONObject) profile.get(3);
-        Assert.assertEquals(0.0049660658, profile3.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(155.56, profile3.get("altitude"));
-        Assert.assertEquals(102.00278, profile3.get("slope"));
-        Assert.assertEquals(4.8206177, profile3.get("x"));
-        Assert.assertEquals(44.864452, profile3.get("y"));
+        assertEquals(0.0049660658, profile3.get("totalDistanceToThisPoint"));
+        assertEquals(155.56, profile3.get("altitude"));
+        assertEquals(102.00278, profile3.get("slope"));
+        assertEquals(4.8206177, profile3.get("x"));
+        assertEquals(44.864452, profile3.get("y"));
 
         JSONObject profile6 = (JSONObject) profile.get(6);
-        Assert.assertEquals(0.011652884, profile6.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(144.7, profile6.get("altitude"));
-        Assert.assertEquals(81.24586, profile6.get("slope"));
-        Assert.assertEquals(4.827228, profile6.get("x"));
-        Assert.assertEquals(44.86546, profile6.get("y"));
+        assertEquals(0.011652884, profile6.get("totalDistanceToThisPoint"));
+        assertEquals(144.7, profile6.get("altitude"));
+        assertEquals(81.24586, profile6.get("slope"));
+        assertEquals(4.827228, profile6.get("x"));
+        assertEquals(44.86546, profile6.get("y"));
 
         JSONObject profile9 = (JSONObject) profile.get(9);
-        Assert.assertEquals(0.018006066, profile9.get("totalDistanceToThisPoint"));
-        Assert.assertEquals(127.35, profile9.get("altitude"));
-        Assert.assertEquals(66.208275, profile9.get("slope"));
-        Assert.assertEquals(4.826243, profile9.get("x"));
-        Assert.assertEquals(44.86841, profile9.get("y"));
+        assertEquals(0.018006066, profile9.get("totalDistanceToThisPoint"));
+        assertEquals(127.35, profile9.get("altitude"));
+        assertEquals(66.208275, profile9.get("slope"));
+        assertEquals(4.826243, profile9.get("x"));
+        assertEquals(44.86841, profile9.get("y"));
     }
 }

--- a/src/community/wps-longitudinal-profile/src/test/resources/templateAllParameters.xml
+++ b/src/community/wps-longitudinal-profile/src/test/resources/templateAllParameters.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:Execute version="1.0.0" service="WPS"
+             xmlns:wps="http://www.opengis.net/wps/1.0.0"
+             xmlns:ows="http://www.opengis.net/ows/1.1"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 wpsAll.xsd">
+    <ows:Identifier>gs:LongitudinalProfile</ows:Identifier>
+    <wps:DataInputs>
+        <wps:Input>
+            <ows:Identifier>layerName</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${LAYER_NAME}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>geometry</ows:Identifier>
+            <wps:Data>
+                <wps:ComplexData mimeType="application/ewkt">
+                    <![CDATA[${GEOMETRY}]]></wps:ComplexData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>distance</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${DISTANCE}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>adjustmentLayerName</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>AdjustmentLayer</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>altitudeName</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>altitude</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>targetProjection</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${TARGET_PROJECTION}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+    </wps:DataInputs>
+    <wps:ResponseForm>
+        <wps:RawDataOutput mimeType="application/json">
+            <ows:Identifier>result</ows:Identifier>
+        </wps:RawDataOutput>
+    </wps:ResponseForm>
+</wps:Execute>

--- a/src/community/wps-longitudinal-profile/src/test/resources/templateBasic.xml
+++ b/src/community/wps-longitudinal-profile/src/test/resources/templateBasic.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:Execute version="1.0.0" service="WPS"
+             xmlns:wps="http://www.opengis.net/wps/1.0.0"
+             xmlns:ows="http://www.opengis.net/ows/1.1"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 wpsAll.xsd">
+    <ows:Identifier>gs:LongitudinalProfile</ows:Identifier>
+    <wps:DataInputs>
+        <wps:Input>
+            <ows:Identifier>layerName</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${LAYER_NAME}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>geometry</ows:Identifier>
+            <wps:Data>
+                <wps:ComplexData mimeType="application/ewkt"><![CDATA[${GEOMETRY}]]></wps:ComplexData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>distance</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${DISTANCE}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+    </wps:DataInputs>
+    <wps:ResponseForm>
+        <wps:RawDataOutput mimeType="application/json">
+            <ows:Identifier>result</ows:Identifier>
+        </wps:RawDataOutput>
+    </wps:ResponseForm>
+</wps:Execute>

--- a/src/community/wps-longitudinal-profile/src/test/resources/templateChaining.xml
+++ b/src/community/wps-longitudinal-profile/src/test/resources/templateChaining.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:Execute version="1.0.0" service="WPS"
+             xmlns:wps="http://www.opengis.net/wps/1.0.0"
+             xmlns:ows="http://www.opengis.net/ows/1.1"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xlink="http://www.w3.org/1999/xlink"
+             xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 wpsAll.xsd">
+    <ows:Identifier>gs:LongitudinalProfile</ows:Identifier>
+    <wps:DataInputs>
+        <wps:Input>
+            <ows:Identifier>coverage</ows:Identifier>
+            <wps:Reference mimeType="image/tiff"
+                           xlink:href="http://geoserver/wcs?service=WCS&amp;request=GetCoverage&amp;version=2.0.1&amp;coverageId=${COVERAGE_ID}"
+                           method="GET" />
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>geometry</ows:Identifier>
+            <wps:Data>
+                <wps:ComplexData mimeType="application/ewkt"><![CDATA[${GEOMETRY}]]></wps:ComplexData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>distance</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${DISTANCE}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+    </wps:DataInputs>
+    <wps:ResponseForm>
+        <wps:RawDataOutput mimeType="application/json">
+            <ows:Identifier>result</ows:Identifier>
+        </wps:RawDataOutput>
+    </wps:ResponseForm>
+</wps:Execute>

--- a/src/community/wps-longitudinal-profile/src/test/resources/templateNoInputLayer.xml
+++ b/src/community/wps-longitudinal-profile/src/test/resources/templateNoInputLayer.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:Execute version="1.0.0" service="WPS"
+             xmlns:wps="http://www.opengis.net/wps/1.0.0"
+             xmlns:ows="http://www.opengis.net/ows/1.1"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 wpsAll.xsd">
+    <ows:Identifier>gs:LongitudinalProfile</ows:Identifier>
+    <wps:DataInputs>
+        <wps:Input>
+            <ows:Identifier>geometry</ows:Identifier>
+            <wps:Data>
+                <wps:ComplexData mimeType="application/ewkt"><![CDATA[${GEOMETRY}]]></wps:ComplexData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>distance</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${DISTANCE}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+    </wps:DataInputs>
+    <wps:ResponseForm>
+        <wps:RawDataOutput mimeType="application/json">
+            <ows:Identifier>result</ows:Identifier>
+        </wps:RawDataOutput>
+    </wps:ResponseForm>
+</wps:Execute>

--- a/src/community/wps-longitudinal-profile/src/test/resources/templateTargetProjection.xml
+++ b/src/community/wps-longitudinal-profile/src/test/resources/templateTargetProjection.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:Execute version="1.0.0" service="WPS"
+             xmlns:wps="http://www.opengis.net/wps/1.0.0"
+             xmlns:ows="http://www.opengis.net/ows/1.1"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 wpsAll.xsd">
+    <ows:Identifier>gs:LongitudinalProfile</ows:Identifier>
+    <wps:DataInputs>
+        <wps:Input>
+            <ows:Identifier>layerName</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${LAYER_NAME}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>geometry</ows:Identifier>
+            <wps:Data>
+                <wps:ComplexData mimeType="application/ewkt"><![CDATA[${GEOMETRY}]]></wps:ComplexData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>distance</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${DISTANCE}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+        <wps:Input>
+            <ows:Identifier>targetProjection</ows:Identifier>
+            <wps:Data>
+                <wps:LiteralData>${TARGET_PROJECTION}</wps:LiteralData>
+            </wps:Data>
+        </wps:Input>
+    </wps:DataInputs>
+    <wps:ResponseForm>
+        <wps:RawDataOutput mimeType="application/json">
+            <ows:Identifier>result</ows:Identifier>
+        </wps:RawDataOutput>
+    </wps:ResponseForm>
+</wps:Execute>


### PR DESCRIPTION
A bunch of clean ups on the longitudinal profile process. Before the fixes it was easy to make it go OOM, was twice as slow, could not be chained with other processes on the raster input, was not checking for cancellation/timeout.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.