### PR TITLE
[GEOS-11790] Data Directory Loader Consistency Issues

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
@@ -476,7 +476,7 @@ public abstract class GeoServerLoader {
         }
     }
 
-    boolean checkStoresOnStartup(XStreamPersister xp) {
+    protected boolean checkStoresOnStartup(XStreamPersister xp) {
         Resource f = resourceLoader.get("global.xml");
         if (Resources.exists(f)) {
             try {

--- a/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
@@ -39,6 +39,8 @@ import org.geoserver.config.datadir.DataDirectoryWalker.WorkspaceDirectory;
 import org.geoserver.config.util.XStreamPersister;
 import org.geotools.util.logging.Logging;
 import org.springframework.lang.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Specialized loader for GeoServer catalog objects that supports parallel loading.
@@ -112,7 +114,9 @@ class CatalogLoader {
         final boolean extendedValidation = this.catalog.isExtendedValidation();
         this.catalog.setExtendedValidation(false);
 
-        ForkJoinPool executor = ExecutorFactory.createExecutor();
+        // admin auth set by GeoServerLoader and propagated to the ForkJoinPool threads
+        Authentication admin = SecurityContextHolder.getContext().getAuthentication();
+        ForkJoinPool executor = ExecutorFactory.createExecutor(admin);
         try {
             addAll(executor, this::loadGlobalStyles);
             // This is the best place where to initialize default styles since the sanitization during loading might

--- a/src/main/src/main/java/org/geoserver/config/datadir/MinimalConfigLoaderSupport.java
+++ b/src/main/src/main/java/org/geoserver/config/datadir/MinimalConfigLoaderSupport.java
@@ -1,0 +1,270 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.config.datadir;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.config.ConfigurationListenerAdapter;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerConfigPersister;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.LoggingInfo;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.config.ServicePersister;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.config.util.XStreamServiceLoader;
+import org.geoserver.platform.GeoServerResourceLoader;
+
+/**
+ * Support class for ensuring configuration consistency in GeoServer across all deployment scenarios.
+ *
+ * <p>This class addresses a specific issue that affects both standalone and clustered GeoServer deployments: when
+ * starting with an empty or incomplete data directory, essential configuration elements (global settings, logging
+ * configuration, and root services) may only exist in memory but not be persisted to the data directory. This leads to
+ * different GeoServer instances generating different object IDs for the same logical configuration elements.
+ *
+ * <p>Example scenario using a file-based data directory:
+ *
+ * <ol>
+ *   <li>A new GeoServer instance starts with an empty data directory
+ *   <li>Default services are created in memory but not persisted (historically)
+ *   <li>If the instance restarts, or another instance starts using the same data directory, new service objects with
+ *       different IDs are created
+ *   <li>This class ensures these essential configuration elements are consistently persisted and shared
+ * </ol>
+ *
+ * <p>This consistency is particularly important for clustered deployments (using any configuration synchronization
+ * mechanism), where all nodes need to share the same object IDs to properly synchronize configuration changes. However,
+ * it also benefits standalone GeoServer by ensuring configuration stability across restarts.
+ *
+ * <p>For typical vanilla GeoServer installations that start with a pre-populated data directory, this class effectively
+ * becomes a no-op, as all essential configuration elements already exist.
+ *
+ * <p>Note: This class focuses specifically on global, logging, and service configurations. Catalog objects (like
+ * workspaces, stores, layers) already have more robust persistence handling during their creation. This approach is
+ * similar to how default styles are initialized when loading the catalog, where consistent IDs are also essential
+ * across GeoServer instances and/or restarts.
+ */
+class MinimalConfigLoaderSupport {
+
+    private ConfigLoader loader;
+    private final GeoServer geoServer;
+    private final DataDirectoryWalker fileWalk;
+
+    /**
+     * Constructs a new InitialConfigLoaderSupport instance.
+     *
+     * @param loader The ConfigLoader instance that provides access to configuration loading methods and resources
+     */
+    public MinimalConfigLoaderSupport(ConfigLoader loader) {
+        this.loader = loader;
+        geoServer = loader.geoServer;
+        fileWalk = loader.fileWalk;
+    }
+
+    /**
+     * Ensures a minimum configuration when GeoServer starts with an empty or incomplete data directory.
+     *
+     * <p>This method ensures essential configuration components (global, logging, root services) are present. If
+     * they're missing, it creates default versions with appropriate settings.
+     *
+     * <p>The implementation is thread-safe and cluster-aware, using file locks to coordinate when multiple GeoServer
+     * instances might be starting concurrently with the same data directory. Cluster-awarness is delegated to
+     * {@link GeoServerConfigurationLock} as per {@link DataDirectoryWalker#lock()}.
+     */
+    public void initializeEmptyConfig() {
+
+        fileWalk.lock();
+        try {
+            XStreamPersister xp =
+                    fileWalk.getXStreamLoader().getPersisterFactory().createXMLPersister();
+            RootConfigPersister persister = RootConfigPersister.valueOf(geoServer, fileWalk.getServiceLoaders(), xp);
+            if (isGlobalMissing()) {
+                addMissingGlobalConfig(persister);
+            }
+            if (isLoggingMissing()) {
+                addMissingLoggingConfig(persister);
+            }
+            synchronizeRootServices(persister);
+        } finally {
+            fileWalk.unlock();
+        }
+    }
+
+    private boolean isLoggingMissing() {
+        LoggingInfo logging = geoServer.getLogging();
+        return logging == null
+                || logging.getLevel() == null
+                || fileWalk.gsLogging().isEmpty();
+    }
+
+    private boolean isGlobalMissing() {
+        GeoServerInfo global = geoServer.getGlobal();
+        return global == null || fileWalk.gsGlobal().isEmpty();
+    }
+
+    /**
+     * Adds global configuration if it's missing.
+     *
+     * <p>First attempts to load from disk in case another instance has already created it. If not found, creates a
+     * default global configuration and persists it.
+     *
+     * @param persister The configuration persister to use when creating new config
+     */
+    private void addMissingGlobalConfig(RootConfigPersister persister) {
+        Optional<GeoServerInfo> global = loader.loadGlobal();
+        if (global.isPresent()) { // someone else created it already?
+            geoServer.setGlobal(global.orElseThrow());
+        } else {
+            geoServer.addListener(persister);
+            GeoServerInfo config = geoServer.getFactory().createGlobal();
+            geoServer.setGlobal(config);
+            geoServer.removeListener(persister);
+        }
+    }
+
+    /**
+     * Adds logging configuration if it's missing.
+     *
+     * <p>First attempts to load from disk in case another instance has already created it. If not found, creates a
+     * default logging configuration with level set to "DEFAULT_LOGGING" and persists it.
+     *
+     * @param persister The configuration persister to use when creating new config
+     */
+    private void addMissingLoggingConfig(RootConfigPersister persister) {
+        Optional<LoggingInfo> logging = loader.loadLogging();
+        if (logging.isPresent()) { // someone else created it already?
+            geoServer.setLogging(logging.orElseThrow());
+        } else {
+            LoggingInfo config = geoServer.getFactory().createLogging();
+            config.setLevel("DEFAULT_LOGGING");
+            config.setLocation("logs/geoserver.log");
+            config.setStdOutLogging(true);
+
+            geoServer.addListener(persister);
+            geoServer.setLogging(config);
+            geoServer.removeListener(persister);
+        }
+    }
+
+    /**
+     * Synchronizes root services. When starting multiple instances and there are missing service xml files,
+     * {@link XStreamServiceLoader} will create a default one, and each instance will have different copies (with
+     * different ids) of the same, non-persisted, service.
+     */
+    private void synchronizeRootServices(RootConfigPersister persister) {
+
+        List<XStreamServiceLoader<ServiceInfo>> loaders = fileWalk.getServiceLoaders();
+        // ensure we have a service configuration for every service we know about
+        for (XStreamServiceLoader<ServiceInfo> sloader : loaders) {
+            synchronizeRootService(sloader, persister);
+        }
+    }
+
+    /**
+     * If the service already exists, makes sure the local copy is the same, otherwise persists the local copy. This
+     * method is called within a {@link GeoServerConfigurationLock}.
+     */
+    private void synchronizeRootService(XStreamServiceLoader<ServiceInfo> sloader, RootConfigPersister persister) {
+        final Path root = fileWalk.getRoot();
+        final boolean exists = Files.exists(root.resolve(sloader.getFilename()));
+
+        // should never be null in a real world situation, since XStreamServiceLoader creates a new instance, but we'll
+        // check for null-ness for the sake of ServicePersisterTest
+        final ServiceInfo inMemory = geoServer.getService(sloader.getServiceClass());
+        if (null != inMemory) requireNonNull(inMemory.getId());
+
+        if (exists) {
+            // someone else created it already, just replace it
+            ServiceInfo persisted = loader.loadRootService(sloader);
+            // replace with the persisted one
+            if (inMemory != null) {
+                geoServer.remove(inMemory);
+            }
+            if (persisted != null) {
+                geoServer.remove(persisted);
+                geoServer.add(persisted);
+            }
+        } else {
+            // we hold the lock and the file doesn't exist, persist it
+            // remove it to add it back with a persisting listener
+            if (inMemory != null) {
+                geoServer.remove(inMemory);
+                geoServer.addListener(persister);
+                geoServer.add(inMemory);
+                geoServer.removeListener(persister);
+            }
+        }
+    }
+
+    /**
+     * Helper class that combines service persistence and configuration persistence into a single listener that can be
+     * temporarily attached when making configuration changes.
+     */
+    private static class RootConfigPersister extends ConfigurationListenerAdapter {
+
+        private ServicePersister servicePeristerListener;
+        private GeoServerConfigPersister configPersisterListener;
+
+        /**
+         * Factory method to create a RootConfigPersister instance.
+         *
+         * @param geoServer The GeoServer instance
+         * @param serviceLoaders List of service loaders to be used for service persistence
+         * @param xp The XStream persister to use for configuration persistence
+         * @return A new RootConfigPersister instance
+         */
+        public static RootConfigPersister valueOf(
+                GeoServer geoServer, List<XStreamServiceLoader<ServiceInfo>> serviceLoaders, XStreamPersister xp) {
+
+            RootConfigPersister rp = new RootConfigPersister();
+            rp.servicePeristerListener = new ServicePersister(serviceLoaders, geoServer);
+
+            GeoServerResourceLoader resourceLoader = geoServer.getCatalog().getResourceLoader();
+            xp.setCatalog(geoServer.getCatalog());
+            rp.configPersisterListener = new GeoServerConfigPersister(resourceLoader, xp);
+            return rp;
+        }
+
+        /**
+         * Overrides equals to ensure a listener is only added once. Identity comparison is used since we only care
+         * about this exact instance.
+         */
+        @Override
+        public boolean equals(Object o) {
+            return this == o;
+        }
+
+        /** Unused, added to avoid errorprone failures */
+        @Override
+        public int hashCode() {
+            return Objects.hash(getClass());
+        }
+
+        /** Handles changes to global configuration by delegating to the config persister. */
+        @Override
+        public void handlePostGlobalChange(GeoServerInfo global) {
+            configPersisterListener.handlePostGlobalChange(global);
+        }
+
+        /** Handles changes to logging configuration by delegating to the config persister. */
+        @Override
+        public void handlePostLoggingChange(LoggingInfo logging) {
+            configPersisterListener.handlePostLoggingChange(logging);
+        }
+
+        /** Handles changes to service configuration by delegating to the service persister. */
+        @Override
+        public void handlePostServiceChange(ServiceInfo service) {
+            servicePeristerListener.handlePostServiceChange(service);
+        }
+    }
+}

--- a/src/main/src/main/java/org/geoserver/config/datadir/XStreamLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/datadir/XStreamLoader.java
@@ -70,6 +70,22 @@ class XStreamLoader {
     }
 
     /**
+     * Returns the XStreamPersisterFactory used by this loader.
+     *
+     * <p>This factory is used to create XStreamPersister instances for XML serialization and deserialization of
+     * GeoServer configuration objects. Each thread gets its own persister instance to avoid contention when multiple
+     * threads are processing XML files concurrently.
+     *
+     * <p>The factory can be used by clients that need to create additional persisters with the same configuration as
+     * those used by this loader, ensuring consistent XML handling across the application.
+     *
+     * @return the XStreamPersisterFactory used by this loader
+     */
+    XStreamPersisterFactory getPersisterFactory() {
+        return xpf;
+    }
+
+    /**
      * Deserializes a GeoServer configuration or catalog object from an XML file.
      *
      * <p>This method performs both the file I/O and XML deserialization steps while ensuring thread safety and proper
@@ -77,14 +93,17 @@ class XStreamLoader {
      * performance:
      *
      * <ol>
-     *   <li>First, the file contents are loaded using a {@link ForkJoinPool.ManagedBlocker}
-     *   <li>Then, the XML content is parsed using a thread-local {@link XStreamPersister}
+     *   <li>The method opens an input stream to the file and passes it directly to the parse method
+     *   <li>The parse method uses a thread-local {@link XStreamPersister} to deserialize the XML
      *   <li>The {@link XStreamPersister} has no {@code Catalog} set, hence it won't resolve {@link ResolvingProxy
      *       proxies}. That's to be done by the caller in a thread-safe way.
      * </ol>
      *
      * <p>Any errors during loading or parsing are properly logged, and an empty Optional is returned in case of
      * failure.
+     *
+     * <p>This method is safe to call from multiple threads concurrently, as it uses thread-local resources and has no
+     * shared mutable state.
      *
      * @param <C> the type of the configuration or catalog object to deserialize
      * @param file the path to the XML file to deserialize

--- a/src/main/src/test/java/org/geoserver/config/datadir/DataDirectoryGeoServerLoaderTest.java
+++ b/src/main/src/test/java/org/geoserver/config/datadir/DataDirectoryGeoServerLoaderTest.java
@@ -59,7 +59,6 @@ import org.geoserver.config.SettingsInfo;
 import org.geoserver.config.datadir.DataDirectoryLoaderTestSupport.TestService1;
 import org.geoserver.config.datadir.DataDirectoryLoaderTestSupport.TestService2;
 import org.geoserver.config.impl.GeoServerImpl;
-import org.geoserver.config.impl.ServiceInfoImpl;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.data.test.CiteTestData;
@@ -75,7 +74,6 @@ import org.geoserver.test.TestSetupFrequency;
 import org.geotools.api.filter.sort.SortBy;
 import org.geotools.jdbc.JDBCDataStoreFactory;
 import org.geotools.util.logging.Logging;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -95,17 +93,17 @@ public class DataDirectoryGeoServerLoaderTest extends GeoServerSystemTestSupport
                 .setLevel(Level.CONFIG);
     }
 
-    @After
-    public void after() {
-        support.tearDown();
-    }
-
     @Override
     protected void onSetUp(SystemTestData testData) throws Exception {
         Catalog catalog = getCatalog();
         GeoServer geoServer = getGeoServer();
-        support = new DataDirectoryLoaderTestSupport(catalog);
-        support.setUpServiceLoaders(geoServer);
+        support = new DataDirectoryLoaderTestSupport(catalog, geoServer);
+        support.setUpServiceLoaders();
+    }
+
+    @Override
+    protected void onTearDown(SystemTestData testData) throws Exception {
+        support.tearDown();
     }
 
     @Override
@@ -628,7 +626,6 @@ public class DataDirectoryGeoServerLoaderTest extends GeoServerSystemTestSupport
         support.setUpServiceLoaders(geoServer);
 
         TestService1 service = support.serviceInfo1(ws, username, geoServer);
-        ((ServiceInfoImpl) service).setId("service-null-ws");
 
         String filename = support.serviceLoader1.getFilename();
         Resource resource = getDataDirectory().getWorkspaces(ws.getName(), filename);

--- a/src/main/src/test/java/org/geoserver/config/datadir/DefaultGeoServerLoaderCompatibilityTest.java
+++ b/src/main/src/test/java/org/geoserver/config/datadir/DefaultGeoServerLoaderCompatibilityTest.java
@@ -64,8 +64,8 @@ public class DefaultGeoServerLoaderCompatibilityTest extends GeoServerSystemTest
     protected void onSetUp(SystemTestData testData) throws Exception {
         Catalog catalog = getCatalog();
         GeoServer geoServer = getGeoServer();
-        support = new DataDirectoryLoaderTestSupport(catalog);
-        support.setUpServiceLoaders(geoServer);
+        support = new DataDirectoryLoaderTestSupport(catalog, geoServer);
+        support.setUpServiceLoaders();
         geoServer.add(support.serviceInfo1(null, "service1", geoServer));
         geoServer.add(support.serviceInfo2(null, "service2", geoServer));
     }

--- a/src/main/src/test/java/org/geoserver/config/datadir/MinimalConfigLoaderSupportIntegrationTest.java
+++ b/src/main/src/test/java/org/geoserver/config/datadir/MinimalConfigLoaderSupportIntegrationTest.java
@@ -1,0 +1,354 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.config.datadir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.servlet.ServletContext;
+import org.geoserver.GeoServerConfigurationLock;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.LoggingInfo;
+import org.geoserver.config.ServiceInfo;
+import org.geoserver.config.datadir.DataDirectoryLoaderTestSupport.TestService1;
+import org.geoserver.config.datadir.DataDirectoryLoaderTestSupport.TestService1.TestService1Impl;
+import org.geoserver.config.datadir.DataDirectoryLoaderTestSupport.TestService2;
+import org.geoserver.config.datadir.DataDirectoryLoaderTestSupport.TestService2.TestService2Impl;
+import org.geoserver.config.util.XStreamPersisterFactory;
+import org.geoserver.config.util.XStreamServiceLoader;
+import org.geoserver.platform.GeoServerResourceLoader;
+import org.geoserver.platform.resource.FileSystemResourceStore;
+import org.geoserver.platform.resource.LockProvider;
+import org.geoserver.platform.resource.MemoryLockProvider;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.support.XmlWebApplicationContext;
+
+/**
+ * Integration tests for {@link MinimalConfigLoaderSupport} that validate the thread-safety and consistency mechanisms
+ * across restarts or when multiple GeoServer instances start simultaneously and share the same data directory.
+ *
+ * <p>These tests focus specifically on scenarios where:
+ *
+ * <ul>
+ *   <li>Multiple instances attempt to initialize an empty or incomplete data directory
+ *   <li>Instances need to coordinate using file locks to prevent race conditions
+ *   <li>Missing configuration elements need to be created consistently across instances
+ *   <li>Authentication needs to be properly propagated to worker threads
+ * </ul>
+ *
+ * <p>The tests use {@link XmlWebApplicationContext} directly instead of {@link GeoServerSystemTestSupport} to have
+ * precise control over the initialization sequence and avoid side effects from the test support class. This allows
+ * testing edge cases around empty data directories and concurrent initialization that would otherwise be difficult to
+ * simulate.
+ */
+public class MinimalConfigLoaderSupportIntegrationTest {
+
+    @Rule
+    public final TemporaryFolder temp = new TemporaryFolder();
+
+    private File dataDirectory;
+
+    private DataDirectoryLoaderTestSupport support;
+
+    @Before
+    public void setUp() throws IOException {
+        dataDirectory = temp.newFolder("datadir");
+        support = DataDirectoryLoaderTestSupport.withPersistence(dataDirectory);
+        System.setProperty("GEOSERVER_DATA_DIR", dataDirectory.getAbsolutePath());
+        System.setProperty("GEOSERVER_DATA_DIR_LOADER_ENABLED", "true");
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("GEOSERVER_DATA_DIR");
+        System.clearProperty("GEOSERVER_DATA_DIR_LOADER_ENABLED");
+        support.tearDown();
+    }
+
+    @Test
+    public void testEmptyGlobalXml() throws IOException {
+        Files.createFile(dataDirectory.toPath().resolve("global.xml"));
+        assertThrows(BeanCreationException.class, this::initContext);
+    }
+
+    /** Tests that when no missing configuration, initializeEmptyConfig() exits early */
+    @Test
+    public void testNoMissingConfigs() throws IOException {
+        // Pre-setup complete configuration
+        GeoServerInfo global = support.getGeoServer().getFactory().createGlobal();
+        support.setUpServiceLoaders();
+        global.getSettings().setTitle("pre-existing");
+
+        LoggingInfo logging = support.getGeoServer().getFactory().createLogging();
+        logging.setLocation("logs/gs2.log");
+
+        TestService1Impl service1 = new TestService1Impl();
+        service1.setTitle("pre-existing service 1");
+
+        TestService2Impl service2 = new TestService2Impl();
+        service2.setTitle("pre-existing service 2");
+
+        support.getGeoServer().setGlobal(global);
+        support.getGeoServer().setLogging(logging);
+        support.getGeoServer().add(service1);
+        support.getGeoServer().add(service2);
+        support.cleanUp();
+
+        // Get hold of the InitialConfigLoaderSupport through context initialization
+        ApplicationContext context = initContext();
+
+        // Verify all configs are present (directly test isMissingDefaultConfigs
+        // returning false)
+        // This is an implicit verification since if configs were missing,
+        // the test would have side effects visible in other tests
+        GeoServer gs = context.getBean(GeoServer.class);
+        assertEquals(global, gs.getGlobal());
+        assertEquals(logging, gs.getLogging());
+        assertEquals(service1, ModificationProxy.unwrap(gs.getService(TestService1.class)));
+        assertEquals(service2, ModificationProxy.unwrap(gs.getService(TestService2.class)));
+    }
+
+    /** Tests that missing global config is created */
+    @Test
+    public void testAddMissingGlobalConfig() {
+        // Setup existing logging and services but missing global
+        support.getGeoServer().setLogging(support.getGeoServer().getFactory().createLogging());
+        support.getGeoServer().add(new TestService1Impl());
+        support.getGeoServer().add(new TestService2Impl());
+        support.cleanUp();
+
+        // Initialize context which will trigger InitialConfigLoaderSupport
+        ApplicationContext context = initContext();
+
+        // Verify global config was created
+        GeoServerInfo global = context.getBean(GeoServer.class).getGlobal();
+        assertNotNull(global);
+
+        // Verify the global.xml file was created
+        assertTrue(Files.exists(dataDirectory.toPath().resolve("global.xml")));
+    }
+
+    /** Tests that missing logging config is created */
+    @Test
+    public void testAddMissingLoggingConfig() {
+        // Setup existing global and services but missing logging
+        support.getGeoServer().setGlobal(support.getGeoServer().getFactory().createGlobal());
+        support.getGeoServer().add(new TestService1Impl());
+        support.getGeoServer().add(new TestService2Impl());
+        support.cleanUp();
+
+        assertFalse(Files.exists(dataDirectory.toPath().resolve("logging.xml")));
+
+        // Initialize context which will trigger InitialConfigLoaderSupport
+        ApplicationContext context = initContext();
+
+        // Verify the logging.xml file was created
+        assertTrue(Files.exists(dataDirectory.toPath().resolve("logging.xml")));
+
+        // Verify logging config was created
+        LoggingInfo logging = context.getBean(GeoServer.class).getLogging();
+        assertNotNull(logging);
+        assertEquals("DEFAULT_LOGGING", logging.getLevel());
+        assertEquals("logs/geoserver.log", logging.getLocation());
+        assertTrue(logging.isStdOutLogging());
+    }
+
+    /** Tests that missing root services are created */
+    @Test
+    public void testAddMissingRootServices() {
+        // Setup existing global and logging but missing services
+        support.getGeoServer().setGlobal(support.getGeoServer().getFactory().createGlobal());
+        support.getGeoServer().setLogging(support.getGeoServer().getFactory().createLogging());
+        support.cleanUp();
+
+        // Initialize context which will trigger InitialConfigLoaderSupport
+        ApplicationContext context = initContext();
+
+        // Verify service configs were created
+        GeoServer gs = context.getBean(GeoServer.class);
+        assertNotNull(gs.getService(TestService1.class));
+        assertNotNull(gs.getService(TestService2.class));
+
+        // Verify the service xml files were created
+        assertTrue(Files.exists(dataDirectory.toPath().resolve("service1.xml")));
+        assertTrue(Files.exists(dataDirectory.toPath().resolve("service2.xml")));
+    }
+
+    /** Tests that a pre-existing service is preserved when loading services */
+    @Test
+    public void testPreExistingService() {
+        // Setup existing global and logging
+        support.getGeoServer().setGlobal(support.getGeoServer().getFactory().createGlobal());
+        support.getGeoServer().setLogging(support.getGeoServer().getFactory().createLogging());
+        support.setUpServiceLoaders();
+        // Add specific service with a custom property that we can check later
+        TestService1Impl customService = new TestService1Impl();
+        customService.setName("customName");
+        support.getGeoServer().add(customService);
+        support.cleanUp();
+
+        // Initialize context which will trigger InitialConfigLoaderSupport
+        ApplicationContext context = initContext();
+
+        // Verify our custom service was preserved
+        GeoServer gs = context.getBean(GeoServer.class);
+        TestService1 service1 = gs.getService(TestService1.class);
+        assertNotNull(service1);
+        assertEquals("customName", service1.getName());
+
+        // Verify service2 was created as normal
+        assertNotNull(gs.getService(TestService2.class));
+    }
+
+    /**
+     * Tests the case where the configuration is loaded from multiple processes from an empty data directory
+     *
+     * <p>This should cover all code paths in {@link MinimalConfigLoaderSupport}
+     */
+    @Test
+    public void testConcurrentLoadFromEmptyDirectoryCreatesMinimalConfig() {
+
+        // we can't really launch multiple context loads because they'll share the same
+        // GeoServerExtensions static stuff, but we can run multiple loaders
+        List<ConfigLoader> loaders = createConfigLoaders(8);
+        loadConcurrently(loaders);
+
+        // Verify the global.xml file was created
+        assertTrue(Files.exists(dataDirectory.toPath().resolve("global.xml")));
+        // Verify the logging.xml file was created
+        assertTrue(Files.exists(dataDirectory.toPath().resolve("logging.xml")));
+        // Verify the root services have been created
+        assertTrue(Files.exists(dataDirectory.toPath().resolve("service1.xml")));
+        assertTrue(Files.exists(dataDirectory.toPath().resolve("service2.xml")));
+
+        for (ConfigLoader cl : loaders) {
+            GeoServer gs = cl.geoServer;
+            // Verify our externally created logging config was loaded
+            LoggingInfo logging = gs.getLogging();
+            assertEquals("DEFAULT_LOGGING", logging.getLevel());
+            assertEquals("logs/geoserver.log", logging.getLocation());
+            assertTrue(logging.isStdOutLogging());
+        }
+
+        // verify all loaders got root services of the same type with the same id. If not, it means the
+        // XStreamServiceLoader on each "instance" created a default ServiceInfo but they didn't conflate to a common
+        // one
+        final String id =
+                loaders.get(0).geoServer.getService(TestService1.class).getId();
+        assertNotNull(id);
+
+        Set<String> service1Ids = loaders.stream()
+                .map(cl -> cl.geoServer)
+                .map(l -> l.getService(TestService1.class))
+                .map(ServiceInfo::getId)
+                .collect(Collectors.toSet());
+        assertEquals(Set.of(id), service1Ids);
+    }
+
+    private void loadConcurrently(List<ConfigLoader> loaders) {
+        List<Callable<ConfigLoader>> tasks = loaders.stream()
+                .map(l -> new Callable<ConfigLoader>() {
+                    @Override
+                    public ConfigLoader call() throws Exception {
+                        l.loadGeoServer();
+                        return l;
+                    }
+                })
+                .collect(Collectors.toList());
+        List<Future<ConfigLoader>> futures = ForkJoinPool.commonPool().invokeAll(tasks);
+        futures.forEach(f -> {
+            try {
+                f.get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private List<ConfigLoader> createConfigLoaders(int count) {
+        // they share the configLock to simulate a cluster set up
+        final GeoServerConfigurationLock configLock = new GeoServerConfigurationLock();
+        LockProvider lockProvider = new MemoryLockProvider();
+        return IntStream.range(0, count)
+                .mapToObj(i -> createConfigLoader(configLock, lockProvider))
+                .collect(Collectors.toList());
+    }
+
+    private ConfigLoader createConfigLoader(GeoServerConfigurationLock configLock, LockProvider lockProvider) {
+
+        // create without persistence listeners. On the regular call chain,
+        // GeoServerLoader would have removed them before.
+        DataDirectoryLoaderTestSupport ddlts = DataDirectoryLoaderTestSupport.withNoPersistence(dataDirectory);
+        Catalog catalog = ddlts.getCatalog();
+        GeoServer gs = ddlts.getGeoServer();
+
+        GeoServerResourceLoader resourceLoader = catalog.getResourceLoader();
+        FileSystemResourceStore resourceStore = (FileSystemResourceStore) resourceLoader.getResourceStore();
+        resourceStore.setLockProvider(lockProvider);
+
+        GeoServerDataDirectory dd = new GeoServerDataDirectory(dataDirectory);
+        XStreamPersisterFactory xpf = new XStreamPersisterFactory();
+        @SuppressWarnings("rawtypes")
+        List<XStreamServiceLoader> serviceLoaders = new ArrayList<>();
+        serviceLoaders.add(support.serviceLoader1);
+        serviceLoaders.add(support.serviceLoader2);
+
+        DataDirectoryWalker fileWalk = new DataDirectoryWalker(dd, xpf, configLock, serviceLoaders);
+
+        return new ConfigLoader(gs, fileWalk);
+    }
+
+    private XmlWebApplicationContext initContext() {
+        return initNewContext();
+    }
+
+    private XmlWebApplicationContext initNewContext() {
+        XmlWebApplicationContext webAppContext = createContext();
+        webAppContext.refresh();
+        return webAppContext;
+    }
+
+    private XmlWebApplicationContext createContext() {
+        // Simulate the servlet container
+        ServletContext servletContext = new MockServletContext();
+
+        // Load a WebApplicationContext instead of a plain ApplicationContext
+        XmlWebApplicationContext webAppContext = new XmlWebApplicationContext();
+        webAppContext.setConfigLocations(
+                "classpath*:/applicationContext.xml",
+                "classpath*:/applicationSecurityContext.xml",
+                "classpath:/org/geoserver/config/datadir/minimalConfigLoaderSupportIntegrationTestContext.xml");
+        webAppContext.setServletContext(servletContext);
+
+        return webAppContext;
+    }
+}

--- a/src/main/src/test/java/org/geoserver/config/datadir/minimalConfigLoaderSupportIntegrationTestContext.xml
+++ b/src/main/src/test/java/org/geoserver/config/datadir/minimalConfigLoaderSupportIntegrationTestContext.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ Copyright (C) 2025 - Open Source Geospatial Foundation. All rights reserved.
+ This code is licensed under the GPL 2.0 license, available at the root
+ application directory.
+ -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd">
+
+
+    <bean id="testService1Loader"
+          class="org.geoserver.config.datadir.DataDirectoryLoaderTestSupport$TestService1Loader">
+        <constructor-arg ref="resourceLoader"/>
+    </bean>
+
+    <bean id="testService2Loader"
+          class="org.geoserver.config.datadir.DataDirectoryLoaderTestSupport$TestService2Loader">
+        <constructor-arg ref="resourceLoader"/>
+    </bean>
+
+</beans>


### PR DESCRIPTION
[![GEOS-11790](https://badgen.net/badge/JIRA/GEOS-11790/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11790) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Add proper admin authentication propagation and synchronization mechanisms that prevent race conditions during startup while loading the config (not the catalog).

Improve thread safety and consistency when running multiple GeoServer instances sharing the same data directory.

Key improvements include:

1. Authentication is now properly propagated to worker threads in the ForkJoinPool, preventing permission issues when threads need to access secured resources during initialization.
2. The new MinimalConfigLoaderSupport class ensures a consistent configuration state by using GeoServerConfigurationLock to coordinate when multiple instances attempt to initialize the same data directory. It handles missing global config, logging settings, and services in a thread-safe manner, and in a cluster-safe way if GeoServerConfigurationLock is cluster-aware.
3. Improved synchronization of root services ensures that when multiple instances start with missing service XML files, they will converge on a consistent state rather than creating different in-memory copies with different IDs.
4. Improved early initialization of essential components like CRS factories and data store factories prevents deadlocks that could occur when these are accessed concurrently during startup.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.