### PR TITLE
[GEOS-11274,GEOS-11751] Generate URL for graphic inside workspace

### DIFF
--- a/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
+++ b/src/kml/src/main/java/org/geoserver/kml/decorator/PlacemarkStyleDecoratorFactory.java
@@ -250,11 +250,9 @@ public class PlacemarkStyleDecoratorFactory implements KmlDecoratorFactory {
 
             WorkspaceInfo ws =
                     context.getWms().getCatalog().getStyleByName(sld.getName()).getWorkspace();
-            String wsName = null;
-            if (ws != null) wsName = ws.getName();
 
             Icon icon = is.createAndSetIcon();
-            icon.setHref(properties.href(context.getMapContent().getRequest().getBaseUrl(), wsName, sld.getName()));
+            icon.setHref(properties.href(context.getMapContent().getRequest().getBaseUrl(), ws, sld.getName()));
         }
 
         /** Encodes a transparent KML LabelStyle */

--- a/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
+++ b/src/wms/src/main/java/org/geoserver/wms/legendgraphic/JSONLegendGraphicBuilder.java
@@ -356,7 +356,7 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
                 if (l != null) {
                     for (GraphicalSymbol g : l.graphicalSymbols()) {
                         String href = IconPropertyExtractor.extractProperties(gt2Style, (SimpleFeature) feature)
-                                .href(request.getBaseUrl(), legend.getLayer(), legend.getStyleName());
+                                .href(request.getBaseUrl(), null, legend.getStyleName());
 
                         JSONObject jGraphicSymb = processGraphicalSymbol(g, href);
                         jGraphicSymb.element("url", href);
@@ -517,10 +517,9 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
         }
         Catalog catalog = wms.getCatalog();
         StyleInfo styleByName = catalog.getStyleByName(styleName);
-        String wsName = null;
+        WorkspaceInfo workspaceInfo = null;
         if (styleByName != null) {
-            WorkspaceInfo ws = styleByName.getWorkspace();
-            if (ws != null) wsName = ws.getName();
+            workspaceInfo = styleByName.getWorkspace();
         }
         List<List<MiniRule>> newStyle = new ArrayList<>();
         List<Integer> origRuleNo = new ArrayList<>();
@@ -543,7 +542,12 @@ public class JSONLegendGraphicBuilder extends LegendGraphicBuilder {
 
         IconProperties props = IconPropertyExtractor.extractProperties(newStyle, (SimpleFeature) feature);
 
-        String iconUrl = props.href(baseURL, wsName, styleName);
+        String iconUrl;
+        if (workspaceInfo != null) {
+            iconUrl = props.href(baseURL, workspaceInfo, styleByName.getName());
+        } else {
+            iconUrl = props.href(baseURL, null, styleName);
+        }
         int index = iconUrl.indexOf('?');
         if (index >= 0) {
             String base = iconUrl.substring(0, index + 1);

--- a/src/wms/src/test/java/org/geoserver/wms/icons/IconPropertiesTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/icons/IconPropertiesTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertEquals;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Collections;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.api.style.Fill;
@@ -22,9 +24,18 @@ import org.geotools.api.style.Rule;
 import org.geotools.api.style.Stroke;
 import org.geotools.api.style.Style;
 import org.geotools.filter.text.cql2.CQLException;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class IconPropertiesTest extends IconTestSupport {
+
+    private static final WorkspaceInfo workspace = new WorkspaceInfoImpl();
+
+    @BeforeClass
+    public static void setup() throws UnsupportedEncodingException {
+        workspace.setName("workspace");
+    }
+
     @Test
     public void testSimpleStyleEncodesNoProperties() {
         final Style simple = styleFromRules(catchAllRule(grayCircle()));
@@ -34,7 +45,7 @@ public class IconPropertiesTest extends IconTestSupport {
     @Test
     public void testWorkspacedStyleEncodesNoProperties() {
         final Style simple = styleFromRules(catchAllRule(grayCircle()));
-        assertEquals("0.0.0=", encode("workspace", simple, fieldIs1));
+        assertEquals("0.0.0=", encode(workspace, simple, fieldIs1));
     }
 
     @Test
@@ -222,9 +233,9 @@ public class IconPropertiesTest extends IconTestSupport {
                 .replace("http://127.0.0.1/kml/icon/test?", "");
     }
 
-    protected String encode(String workspace, Style style, SimpleFeature feature) {
+    protected String encode(WorkspaceInfo workspace, Style style, SimpleFeature feature) {
         return IconPropertyExtractor.extractProperties(style, feature)
                 .href("http://127.0.0.1/", workspace, "test")
-                .replace("http://127.0.0.1/kml/icon/" + workspace + "/test?", "");
+                .replace("http://127.0.0.1/kml/icon/" + workspace.getName() + "/test?", "");
     }
 }

--- a/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/arealandmarks.sld
+++ b/src/wms/src/test/resources/org/geoserver/wms/legendgraphic/arealandmarks.sld
@@ -71,7 +71,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0.0">
           </sld:PolygonSymbolizer>
           
         </sld:Rule>
-        
+
       </sld:FeatureTypeStyle>
     </sld:UserStyle>
   </sld:UserLayer>


### PR DESCRIPTION
[![GEOS-11274](https://badgen.net/badge/JIRA/GEOS-11274/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11274) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR proposes a couple of improvements in the JSON legend graphic builder for styles that are within a workspace.

[GEOS-11274](https://osgeo-org.atlassian.net/browse/GEOS-11274): In case of a single external graphic, use the workspace style directory to build the URL, since it is also published (similarly to the global style directory). This was causing a NPE ("iconUrl" is null).

[GEOS-11751](https://osgeo-org.atlassian.net/browse/GEOS-11751): When calling the icon service, use either the workspace-prefixed style name or add the workspace name to the path.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.