### PR TITLE
[GEOS-11795] Incorrect clipping of point geometries in vector tiles

### DIFF
--- a/src/extension/vectortiles/src/main/java/no/ecc/vectortile/VectorTileEncoderNoClip.java
+++ b/src/extension/vectortiles/src/main/java/no/ecc/vectortile/VectorTileEncoderNoClip.java
@@ -12,8 +12,8 @@ import org.locationtech.jts.geom.Geometry;
  */
 public class VectorTileEncoderNoClip extends VectorTileEncoder {
 
-    public VectorTileEncoderNoClip(int extent, int polygonClipBuffer, boolean autoScale) {
-        super(extent, polygonClipBuffer, autoScale);
+    public VectorTileEncoderNoClip(int extent, int clipBuffer, boolean autoScale) {
+        super(extent, clipBuffer, autoScale);
     }
 
     /*
@@ -22,5 +22,13 @@ public class VectorTileEncoderNoClip extends VectorTileEncoder {
     @Override
     protected Geometry clipGeometry(Geometry geometry) {
         return geometry;
+    }
+
+    /*
+     * no clipping. Assume upstream has already clipped!
+     */
+    @Override
+    protected boolean clipCovers(Geometry geom) {
+        return true;
     }
 }

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileEncoderNoClipTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileEncoderNoClipTest.java
@@ -1,0 +1,40 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms.vector;
+
+import static org.junit.Assert.assertTrue;
+
+import no.ecc.vectortile.VectorTileEncoderNoClip;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+
+// Verify vector tile clipping works as expected - geometries that lie beyond the tile bounds & clip buffer should not
+// be clipped as we assume upstream has already clipped the geometries
+public class VectorTileEncoderNoClipTest {
+
+    @Test
+    public void testNoClippingApplied() {
+        GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+        // Position line outside of the clipBuffer (100)
+        VectorTileEncoderNoClip encoder = new VectorTileEncoderNoClip(4096, 100, false);
+        org.locationtech.jts.geom.LineString lineOutsideBounds =
+                geometryFactory.createLineString(new Coordinate[] {new Coordinate(-150, 0), new Coordinate(-150, 150)});
+        encoder.addFeature("ClipTestLayer", new java.util.HashMap<>(), lineOutsideBounds);
+        byte[] tile = encoder.encode();
+        // Ensure tile is generated and line has not been clipped (=tile is not empty)
+        assertTrue("Line should not be clipped", tile.length > 0);
+
+        // Position point outside of the clipBuffer (100)
+        encoder = new VectorTileEncoderNoClip(4096, 100, false);
+        org.locationtech.jts.geom.Point pointOutsideBounds = geometryFactory.createPoint(new Coordinate(-150, 0));
+        encoder.addFeature("ClipTestLayer", new java.util.HashMap<>(), pointOutsideBounds);
+        tile = encoder.encode();
+        // Ensure tile is generated and point has not been clipped (=tile is not empty)
+        assertTrue("Point should not be clipped", tile.length > 0);
+    }
+}


### PR DESCRIPTION
[![GEOS-11795](https://badgen.net/badge/JIRA/GEOS-11795/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11795) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Currently GeoServer Vector Tiles extension incorrectly clips point geometries in the buffer area set by fixed buffer ("Default Rendering Buffer" setting) or style-based buffer estimation.

VectorTileEncoderNoClip is intended to provide a VectorTileEncoder that does not perform any clipping. However, it was still clipping point geometries because the clipCovers method was not overridden (point geometries are clipped by clipCovers, not clipGeometry). This commit adds an override for clipCovers to ensure that point geometries outside the vector tile bounds are not clipped.

After this fix, vector tiles will correctly respect style-based or fixed buffering also for point geometries.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.