### PR TITLE
[GEOS-11796] Deadlocks During GeoServer Startup When Loading Style Group Layer Groups

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerDataDirectory.java
@@ -97,7 +97,7 @@ public class GeoServerDataDirectory {
      *
      * <p>The deadlock occurs in the following call chain:
      *
-     * <pre>
+     * <pre>{@code
      * loadCatalog() ->
      * CatalogImpl.add(LayerGroup) ->
      *  validate(LayerGroup) ->
@@ -108,7 +108,7 @@ public class GeoServerDataDirectory {
      *       GeoServerDataDirectory.getEntityResolver() ->
      *        GeoServerExtensions.bean(EntityResolverProvider.class) ->
      *         DefaultListableBeanFactory.getSingletonFactoryBeanForTypeCheck()
-     * </pre>
+     * }</pre>
      *
      * <p>During catalog loading, a temporary provider is set using
      * {@link #setEntityResolverProvider(EntityResolverProvider)} and cleared afterwards.

--- a/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
@@ -156,7 +156,7 @@ class CatalogLoader {
      *
      * <p>The call chain that leads to the deadlock is:
      *
-     * <pre>
+     * <pre>{@code
      * loadCatalog() ->
      * CatalogImpl.add(LayerGroup) ->
      *  validate(LayerGroup) ->
@@ -166,7 +166,7 @@ class CatalogLoader {
      *      GeoServerDataDirectory.parseSld(StyleInfo) ->
      *       GeoServerDataDirectory.getEntityResolver() ->
      *        GeoServerExtensions.bean(EntityResolverProvider.class)
-     * </pre>
+     * }</pre>
      *
      * <p>The temporary provider respects XML external entity settings from global.xml configuration.
      */

--- a/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
@@ -31,12 +31,16 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.impl.ResolvingProxy;
+import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.config.GeoServerInfo;
 import org.geoserver.config.GeoServerLoader;
 import org.geoserver.config.datadir.DataDirectoryWalker.LayerDirectory;
 import org.geoserver.config.datadir.DataDirectoryWalker.StoreDirectory;
 import org.geoserver.config.datadir.DataDirectoryWalker.WorkspaceDirectory;
+import org.geoserver.config.impl.GeoServerImpl;
 import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.util.EntityResolverProvider;
 import org.geotools.util.logging.Logging;
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
@@ -116,6 +120,7 @@ class CatalogLoader {
 
         // admin auth set by GeoServerLoader and propagated to the ForkJoinPool threads
         Authentication admin = SecurityContextHolder.getContext().getAuthentication();
+        setTemporaryEntityResolverProvider();
         ForkJoinPool executor = ExecutorFactory.createExecutor(admin);
         try {
             addAll(executor, this::loadGlobalStyles);
@@ -137,8 +142,54 @@ class CatalogLoader {
             throw new IllegalStateException(e);
         } finally {
             this.catalog.setExtendedValidation(extendedValidation);
+            clearTemporaryEntityResolverProvider();
             executor.shutdownNow();
         }
+    }
+
+    /**
+     * Sets up a temporary EntityResolverProvider during catalog loading to avoid Spring bean dependency issues.
+     *
+     * <p>This method creates a temporary EntityResolverProvider that doesn't depend on Spring initialization, instead
+     * using the global.xml configuration if available. This prevents deadlocks when validating XML files that would
+     * otherwise use {@code GeoServerExtensions.bean(EntityResolverProvider.class)}
+     *
+     * <p>The call chain that leads to the deadlock is:
+     *
+     * <pre>
+     * loadCatalog() ->
+     * CatalogImpl.add(LayerGroup) ->
+     *  validate(LayerGroup) ->
+     *   StyledLayerDescriptor sld = styles.get(i).getSLD() ->
+     *    StyleInfoImpl.getSLD() ->
+     *     ResourcePool.getSld(StyleInfo) ->
+     *      GeoServerDataDirectory.parseSld(StyleInfo) ->
+     *       GeoServerDataDirectory.getEntityResolver() ->
+     *        GeoServerExtensions.bean(EntityResolverProvider.class)
+     * </pre>
+     *
+     * <p>The temporary provider respects XML external entity settings from global.xml configuration.
+     */
+    private void setTemporaryEntityResolverProvider() {
+        Optional<Path> gsGlobalFile = fileWalk.gsGlobal();
+        Optional<GeoServerInfo> info = gsGlobalFile.flatMap(fileWalk.getXStreamLoader()::depersist);
+        GeoServerInfo global = info.orElse(null);
+        GeoServer geoServer = new GeoServerImpl();
+        if (global != null) {
+            geoServer.setGlobal(global);
+        }
+        EntityResolverProvider provider = new EntityResolverProvider(geoServer);
+        fileWalk.getDataDirectory().setEntityResolverProvider(provider);
+    }
+
+    /**
+     * Clears the temporary EntityResolverProvider after catalog loading completes.
+     *
+     * <p>This removes the temporary provider set by {@link #setTemporaryEntityResolverProvider()}, allowing normal
+     * Spring bean resolution to take over after catalog loading is complete.
+     */
+    private void clearTemporaryEntityResolverProvider() {
+        fileWalk.getDataDirectory().setEntityResolverProvider(null);
     }
 
     /**

--- a/src/main/src/main/java/org/geoserver/config/datadir/DataDirectoryGeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/datadir/DataDirectoryGeoServerLoader.java
@@ -276,10 +276,6 @@ public class DataDirectoryGeoServerLoader extends DefaultGeoServerLoader {
         }
 
         // warm up GeoServerExtensions with extensions probably called during catalog loading
-        // EntityResolverProvider is intentionally not preloaded to avoid circular dependency with GeoServer bean
-        // The EntityResolverProvider isn't used during catalog loading, and ResourcePoolInitializer
-        // will properly set it in the ResourcePool after catalog loading is complete
-        // CatalogImpl
         preLoadExtensions(CatalogValidator.class);
         // Styles.handlers()
         preLoadExtensions(StyleHandler.class);

--- a/src/main/src/test/resources/data_dir/nested_layer_groups/styles/namedstyle.sld
+++ b/src/main/src/test/resources/data_dir/nested_layer_groups/styles/namedstyle.sld
@@ -1,0 +1,26 @@
+<StyledLayerDescriptor version="1.0.0" 
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+    xmlns="http://www.opengis.net/sld" 
+    xmlns:ogc="http://www.opengis.net/ogc" 
+    xmlns:xlink="http://www.w3.org/1999/xlink" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>topp:layer1</Name>
+    <UserStyle>
+      <Title>Toner Style</Title>
+      <Abstract>A black and white cartographic style inspired by Stamen's Toner</Abstract>
+      
+      <!-- Background -->
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>background</Name>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#FFFFFF</CssParameter>
+            </Fill>
+          </PolygonSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+   </UserStyle>
+ </NamedLayer>
+</StyledLayerDescriptor>

--- a/src/main/src/test/resources/data_dir/nested_layer_groups/styles/namedstyle.xml
+++ b/src/main/src/test/resources/data_dir/nested_layer_groups/styles/namedstyle.xml
@@ -1,0 +1,8 @@
+<style>
+  <id>StyleInfoImpl--6308ea04:13d350bb416:-7fff</id>
+  <name>namedstyle</name>
+  <sldVersion>
+    <version>1.0.0</version>
+  </sldVersion>
+  <filename>namedstyle.sld</filename>
+</style>


### PR DESCRIPTION
[![GEOS-11796](https://badgen.net/badge/JIRA/GEOS-11796/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11796) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fix deadlocks during GeoServer startup when loading data directories with style group layer groups.

The problem is a circular dependency between catalog loading and Spring bean initialization. When style group layer groups are loaded, the following call chain occurs:

- `CatalogImpl.add(LayerGroup)` triggers validation
- Validation attempts to parse SLD with `styles.get(i).getSLD()`
- XML parsing requires an `EntityResolver` from `GeoServerDataDirectory`
- `EntityResolver` lookup via `GeoServerExtensions.bean()` while Spring is still initializing
- Results in deadlock in `DefaultListableBeanFactory.getSingletonFactoryBeanForTypeCheck()`

This fix:

1. Makes `EntityResolverProvider` a static field in `GeoServerDataDirectory` to break the circular dependency
2. Adds a setter to inject a provider without Spring dependency
3. Creates a temporary provider during catalog loading that respects XML external entity settings
4. Clears the provider after loading completes

> Static field is necessary because some code directly instantiates `GeoServerDataDirectory` instead of using the Spring bean (e.g., `ResourcePool.dataDir()`).

Added tests for nested layer groups and style groups to ensure the fix works correctly.

Affected components:

- `GeoServerDataDirectory`
- `CatalogLoader`
- `EntityResolverProvider`

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.