### PR TITLE
[Backport-2.27.x][GEOS-11797]: minor fix on coverageViewEditor page (remove style)

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/data/layer/CoverageViewEditor.html
+++ b/src/web/core/src/main/java/org/geoserver/web/data/layer/CoverageViewEditor.html
@@ -40,7 +40,7 @@
               </tr>
             </table>
           </div>
-          <div wicket:id="jiffleEditorContainer" style="display: none;">
+          <div wicket:id="jiffleEditorContainer">
             <legend>
               <wicket:message key="jiffleMode">definition</wicket:message>
             </legend>


### PR DESCRIPTION
[![GEOS-11797](https://badgen.net/badge/JIRA/GEOS-11797/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11797) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backport to 2.27.x