### PR TITLE
[documentation fix] capabilitiesUrl should be capabilitiesURL

### DIFF
--- a/doc/en/api/1.0.0/wmsstores.yaml
+++ b/doc/en/api/1.0.0/wmsstores.yaml
@@ -247,7 +247,7 @@ parameters:
         ```
         <wmsStore>
           <name>remote</name>
-          <capabilitiesUrl>http://demo.geoserver.org/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities</capabilitiesUrl>
+          <capabilitiesURL>http://demo.geoserver.org/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities</capabilitiesURL>
         </wmsStore>
         ```
 
@@ -257,7 +257,7 @@ parameters:
         {
           "wmsStore": {
             "name": "remote",
-            "capabilitiesUrl": "http://demo.geoserver.org/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities"
+            "capabilitiesURL": "http://demo.geoserver.org/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities"
           }
         }
         ```
@@ -281,7 +281,7 @@ parameters:
           <description>A wms store</description>
           <enabled>true</enabled>
           <__default>true</__default>
-          <capabilitiesUrl>http://demo.geoserver.org/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities</capabilitiesUrl>
+          <capabilitiesURL>http://demo.geoserver.org/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities</capabilitiesURL>
           <user>admin</user>
           <password>geoserver</password>
           <maxConnections>6</maxConnections>
@@ -298,7 +298,7 @@ parameters:
             "description": "A wms store",
             "enabled": "true",
             "_default": "true",
-            "capabilitiesUrl": "http://demo.geoserver.org/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities",
+            "capabilitiesURL": "http://demo.geoserver.org/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities",
             "user": "admin",
             "password": "geoserver",
             "maxConnections": "6",

--- a/doc/en/api/1.0.0/wmtsstores.yaml
+++ b/doc/en/api/1.0.0/wmtsstores.yaml
@@ -247,7 +247,7 @@ parameters:
         ```
         <wmtsStore>
           <name>remote</name>
-          <capabilitiesUrl>http://demo.geoserver.org/geoserver/gwc/service/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities</capabilitiesUrl>
+          <capabilitiesURL>http://demo.geoserver.org/geoserver/gwc/service/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities</capabilitiesURL>
         </wmtsStore>
         ```
 
@@ -257,7 +257,7 @@ parameters:
         {
           "wmtsStore": {
             "name": "remote",
-            "capabilitiesUrl": "http://demo.geoserver.org/geoserver/gwc/service/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities"
+            "capabilitiesURL": "http://demo.geoserver.org/geoserver/gwc/service/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities"
           }
         }
         ```
@@ -281,7 +281,7 @@ parameters:
           <description>A wmts store</description>
           <enabled>true</enabled>
           <__default>true</__default>
-          <capabilitiesUrl>http://demo.geoserver.org/geoserver/gwc/service/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities</capabilitiesUrl>
+          <capabilitiesURL>http://demo.geoserver.org/geoserver/gwc/service/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities</capabilitiesURL>
           <user>admin</user>
           <password>geoserver</password>
           <maxConnections>6</maxConnections>
@@ -298,7 +298,7 @@ parameters:
             "description": "A wmts store",
             "enabled": "true",
             "_default": "true",
-            "capabilitiesUrl": "http://demo.geoserver.org/geoserver/gwc/service/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities",
+            "capabilitiesURL": "http://demo.geoserver.org/geoserver/gwc/service/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities",
             "user": "admin",
             "password": "geoserver",
             "maxConnections": "6",


### PR DESCRIPTION
Hi all.

Here's a small PR to fix a typo on a field name: `capabilitiesUrl` should be `capabilitiesURL`.
Applies to WMS and WMST stores.

Thanks for reviewing.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).