### PR TITLE
Fix all app-schema modules including gs-main test jar with compile scope

### DIFF
--- a/src/extension/app-schema/app-schema-core/pom.xml
+++ b/src/extension/app-schema/app-schema-core/pom.xml
@@ -28,6 +28,7 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-geopkg-test/pom.xml
+++ b/src/extension/app-schema/app-schema-geopkg-test/pom.xml
@@ -32,6 +32,7 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-indexes-test/pom.xml
+++ b/src/extension/app-schema/app-schema-indexes-test/pom.xml
@@ -33,6 +33,7 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-mongo-test/pom.xml
+++ b/src/extension/app-schema/app-schema-mongo-test/pom.xml
@@ -31,6 +31,7 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-oracle-test/pom.xml
+++ b/src/extension/app-schema/app-schema-oracle-test/pom.xml
@@ -32,6 +32,7 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <!--

--- a/src/extension/app-schema/app-schema-postgis-test/pom.xml
+++ b/src/extension/app-schema/app-schema-postgis-test/pom.xml
@@ -32,6 +32,7 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-solr-test/pom.xml
+++ b/src/extension/app-schema/app-schema-solr-test/pom.xml
@@ -31,6 +31,7 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-test/pom.xml
+++ b/src/extension/app-schema/app-schema-test/pom.xml
@@ -32,6 +32,7 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <!--

--- a/src/extension/app-schema/sample-data-access-test/pom.xml
+++ b/src/extension/app-schema/sample-data-access-test/pom.xml
@@ -27,6 +27,7 @@
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <!--


### PR DESCRIPTION
All `app-schema` extension modules have `org.geoserver:gs-main:jar:tests:<version>:compile` where it should be `org.geoserver:gs-main:jar:tests:<version>:test`

Before:

```shell
mvn dependency:list -o -f src/extension/app-schema/ -Papp-schema,app-schema-online-test | grep gs-main:jar:tests
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:compile -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:compile -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:compile -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:compile -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:compile -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:compile -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:compile -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:compile -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:compile -- module gs.main (auto)```
```

After:
```shell
mvn dependency:list -o -f src/extension/app-schema/ -Papp-schema,app-schema-online-test | grep gs-main:jar:tests
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:test -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:test -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:test -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:test -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:test -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:test -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:test -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:test -- module gs.main (auto)
[INFO]    org.geoserver:gs-main:jar:tests:2.28-SNAPSHOT:test -- module gs.main (auto)
```

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.