### PR TITLE
[GEOS-11801] MapML preview link zoom and extent are incorrect

### DIFF
--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLDocumentBuilder.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLDocumentBuilder.java
@@ -101,9 +101,11 @@ import org.geoserver.wms.featureinfo.FeatureTemplate;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.MathTransform;
 import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.api.style.Style;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
+import org.geotools.geometry.Position2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
@@ -1789,7 +1791,6 @@ public class MapMLDocumentBuilder {
         boolean useTiles = false;
         boolean useFeatures = false;
         ReferencedEnvelope projectedBbox = this.projectedBox;
-        ReferencedEnvelope geographicBox = new ReferencedEnvelope(DefaultGeographicCRS.WGS84);
         List<String> headerContent = getPreviewTemplates(MAPML_PREVIEW_HEAD_FTL, getFeatureTypes());
         for (MapMLLayerMetadata mapMLLayerMetadata : mapMLLayerMetadataList) {
             layer += mapMLLayerMetadata.getLayerName() + ",";
@@ -1811,9 +1812,22 @@ public class MapMLDocumentBuilder {
                 }
             }
             try {
-                geographicBox = projectedBbox.transform(DefaultGeographicCRS.WGS84, true);
-                longitude = geographicBox.centre().getX();
-                latitude = geographicBox.centre().getY();
+                // getting the center after transforming the envelope results in
+                // odd preview lat/lon for non-orthogonal projections e.g. LCC
+                // IN SOME CASES, particularly remote/cascaded layers where the
+                // bounds don't tightly "fit" the data, per GEOS-11801
+                Position2D destPos = new Position2D();
+                MathTransform transform = CRS.findMathTransform(
+                        projectedBbox.getCoordinateReferenceSystem(), DefaultGeographicCRS.WGS84, true);
+                CRS.AxisOrder axisOrder = CRS.getAxisOrder(projectedBbox.getCoordinateReferenceSystem());
+                boolean xy = (axisOrder == CRS.AxisOrder.EAST_NORTH);
+                Position2D projectedCenter = new Position2D(
+                        projectedBbox.getCoordinateReferenceSystem(),
+                        xy ? projectedBbox.getCenterX() : projectedBbox.getCenterY(),
+                        xy ? projectedBbox.getCenterY() : projectedBbox.getCenterX());
+                transform.transform(projectedCenter, destPos);
+                longitude = destPos.getX();
+                latitude = destPos.getY();
             } catch (TransformException | FactoryException e) {
                 throw new ServiceException("Unable to transform bbox to WGS84", e);
             }

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSTest.java
@@ -53,6 +53,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.MetadataMap;
+import org.geoserver.catalog.ProjectionPolicy;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StyleInfo;
@@ -81,7 +82,9 @@ import org.geoserver.wfs.kvp.BBoxKvpParser;
 import org.geoserver.wms.WMSInfo;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.MathTransform;
 import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.geometry.Position2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
@@ -1484,6 +1487,110 @@ public class MapMLWMSTest extends MapMLTestSupport {
         testAlternateBounds(alternateLinks, ProjType.OSMTILE, new Envelope(-2E7, 2E7, -2E7, 2E7), 5e6);
         testAlternateBounds(alternateLinks, ProjType.APSTILE, new Envelope(-1E7, 1.4E7, -1E7, 1.4E7), 1e6);
         testAlternateBounds(alternateLinks, ProjType.CBMTILE, new Envelope(-8.1E6, 8.3E6, -3.6E6, 1.23E7), 1e5);
+    }
+
+    @Test
+    public void testMapMLViewerPreviewLocationHTMLWGS84() throws Exception {
+        // Set up a layer with specific bounds
+        Catalog catalog = getCatalog();
+        LayerInfo layerInfo = catalog.getLayerByName(MockData.POLYGONS.getLocalPart());
+        ResourceInfo resourceInfo = layerInfo.getResource();
+
+        double minx = -175.64837790528588;
+        double maxx = -10.721894124467468;
+        double miny = 34.35220514390023;
+        double maxy = 84.22690498087752;
+        // Define specific bounds for testing
+        ReferencedEnvelope customBounds = new ReferencedEnvelope(minx, maxx, miny, maxy, DefaultGeographicCRS.WGS84);
+        resourceInfo.setLatLonBoundingBox(customBounds);
+        catalog.save(resourceInfo);
+
+        // Request path with HTML format
+        String path = "wms?LAYERS=" + MockData.POLYGONS.getLocalPart() + "&STYLES=&FORMAT="
+                + MapMLConstants.MAPML_HTML_MIME_TYPE + "&SERVICE=WMS&VERSION=1.3.0"
+                + "&REQUEST=GetMap"
+                + "&SRS=MapML:WGS84"
+                + "&BBOX=-175.64837790528588,34.35220514390023,-10.721894124467468,84.22690498087752"
+                + "&WIDTH=600"
+                + "&HEIGHT=400"
+                + "&format_options="
+                + MapMLConstants.MAPML_WMS_MIME_TYPE_OPTION + ":image/png";
+
+        // Get the HTML response and parse it
+        Document doc = getAsJSoup(path);
+
+        Element viewer = doc.select("mapml-viewer").first();
+        assertNotNull("mapml-viewer element should be present", viewer);
+        String lat = Double.toString(customBounds.getCenterY());
+        String lon = Double.toString(customBounds.getCenterX());
+
+        String viewerLat = viewer.attr("lat");
+        String viewerLon = viewer.attr("lon");
+        assertTrue("Viewer lat should equal centre of bounds of input layer", lat.equalsIgnoreCase(viewerLat));
+        assertTrue("Viewer lon should equal centre bounds of input layer", lon.equalsIgnoreCase(viewerLon));
+    }
+
+    @Test
+    public void testMapMLViewerPreviewLocationHTMLCBMTILE() throws Exception {
+        // Set up a layer with the problematic bounds
+        Catalog catalog = getCatalog();
+        LayerInfo layerInfo = catalog.getLayerByName(MockData.POLYGONS.getLocalPart());
+        ResourceInfo resourceInfo = layerInfo.getResource();
+
+        // Define the specific problematic bounds
+        double minx = -175.64837790528588;
+        double maxx = -10.721894124467468;
+        double miny = 34.35220514390023;
+        double maxy = 84.22690498087752;
+        ReferencedEnvelope geographicBounds =
+                new ReferencedEnvelope(minx, maxx, miny, maxy, DefaultGeographicCRS.WGS84);
+        resourceInfo.setLatLonBoundingBox(geographicBounds);
+
+        // Configure the layer to use CBMTILE and force reprojection
+        resourceInfo.setSRS("MapML:CBMTILE");
+        resourceInfo.setProjectionPolicy(ProjectionPolicy.REPROJECT_TO_DECLARED);
+
+        CoordinateReferenceSystem cbmTileCRS = CRS.decode("MapML:CBMTILE");
+        ReferencedEnvelope cbmBounds = geographicBounds.transform(cbmTileCRS, true);
+        resourceInfo.setNativeBoundingBox(cbmBounds);
+        catalog.save(resourceInfo);
+
+        MathTransform transform = CRS.findMathTransform(cbmTileCRS, DefaultGeographicCRS.WGS84, true);
+        Position2D expectedViewerLocationWGS84 = new Position2D();
+        Position2D projectedBboxCentre = new Position2D(cbmTileCRS, cbmBounds.getCenterX(), cbmBounds.getCenterY());
+        transform.transform(projectedBboxCentre, expectedViewerLocationWGS84);
+
+        // Request path with HTML format specifying CBMTILE projection
+        String path = "wms?LAYERS=" + MockData.POLYGONS.getLocalPart() + "&STYLES=&FORMAT="
+                + MapMLConstants.MAPML_HTML_MIME_TYPE + "&SERVICE=WMS&VERSION=1.3.0"
+                + "&REQUEST=GetMap"
+                + "&SRS=MapML:CBMTILE"
+                + "&BBOX="
+                + cbmBounds.getMinX()
+                + "," + cbmBounds.getMinY()
+                + "," + cbmBounds.getMaxX()
+                + "," + cbmBounds.getMaxY()
+                + "&WIDTH=768"
+                + "&HEIGHT=387"
+                + "&format_options="
+                + MapMLConstants.MAPML_WMS_MIME_TYPE_OPTION + ":image/png";
+
+        // Get the HTML response and parse it
+        Document doc = getAsJSoup(path);
+
+        // Validate the mapml-viewer element
+        Element viewer = doc.select("mapml-viewer").first();
+        assertNotNull("mapml-viewer element should be present", viewer);
+        // Check that the projection attribute is set correctly
+        assertEquals("Projection should be set to CBMTILE", "CBMTILE", viewer.attr("projection"));
+
+        String expectedLon = Double.toString(expectedViewerLocationWGS84.getX());
+        String expectedLat = Double.toString(expectedViewerLocationWGS84.getY());
+
+        String viewerLat = viewer.attr("lat");
+        String viewerLon = viewer.attr("lon");
+        assertTrue("Viewer lat should equal centre of bounds of input layer", expectedLat.equalsIgnoreCase(viewerLat));
+        assertTrue("Viewer lon should equal centre bounds of input layer", expectedLon.equalsIgnoreCase(viewerLon));
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-11801](https://badgen.net/badge/JIRA/GEOS-11801/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11801) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
When cascading remote layers which have over-generous bounds in geographic coordinates, the location of the MapML preview (especially in MapML:CBMTILE) may seem incorrect due to projection / deprojection of the geographic bbox.  This change uses the calculated centre point of the request (preview) bbox and de-projects that point to use as the preview location, yielding slightly better results.  A narrowly-defined test is provided to prevent regression.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] ~[Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).~ n/a
- [ ] ~The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).~ n/a
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.