### PR TITLE
Quickfix - Docs - Described process for updating documentation doesn't match current working method

### DIFF
--- a/doc/en/docguide/source/contributing.rst
+++ b/doc/en/docguide/source/contributing.rst
@@ -18,18 +18,18 @@ least make a note of the issue so that someone might fix it for you.
 File an issue
 -------------
 
-If you don't want to write the documentation, and/or would like to suggest a page that isn't included, you can request it.  Use Jira to file an issue.  Please include the name of the page, content, and the place where this new information should be included.  As with all issues, it is not guaranteed that someone will fulfill your request.
+If you don't want to write the documentation, and/or would like to suggest a page that isn't included, you can request it.  Use `Jira <https://osgeo-org.atlassian.net/projects/GEOS>`_ to file an issue.  Please include the name of the page, content, and the place where this new information should be included.  As with all issues, it is not guaranteed that someone will fulfill your request.
 
 .. _file_an_issue_with_patch:
 
-File an issue and include a documentation patch
------------------------------------------------
+Fix the documentation yourself
+------------------------------
 
-GeoServer uses `Jira <https://osgeo-org.atlassian.net/projects/GEOS>`_ for issue tracking.  New documentation is treated like part of the code, so those who want to submit content (patches etc.) can use a pull request or file an issue with Jira and attach the content to the issue.  If the content is deemed satisfactory, a contributor with commit rights will add the content to the documentation.
+For :ref:`small edits or Quickfixes <quickfix>` GitHub supports direct reviewing and editing of documentation pages, any edit you make will be automatically forked and submitted to the project team as a pull request.
+
+For substantial changes, GeoServer uses `Jira <https://osgeo-org.atlassian.net/projects/GEOS>`_ for issue tracking.  New documentation is treated like part of the code, so those who want to submit content (patches etc.) can use a pull request.  If the content is deemed satisfactory, a contributor with commit rights will add the content to the documentation.
 
 For more information see `CONTRIBUTING.md <https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md>`_ in GitHub.
-
-GitHub supports direct reviewing and editing of documentation pages, any edit you make will be automatically forked and submitted to the project team as a pull request.
 
 .. _commit_rights:
 


### PR DESCRIPTION
I followed the described process for proposing a change to the documentation, which indicated patch files could be submitted, only [to be told that they are no longer accepted](https://osgeo-org.atlassian.net/browse/GEOS-11808?focusedCommentId=86607).

![image](https://github.com/user-attachments/assets/ed885a3b-febf-4fc1-8445-371500d1f477)

This change removes the reference to submitting a patch via Jira so that other people don't fall into the same wrong process.
This is according to the information I received from @aaime in the ticket GEOS-11808 (see link above for comment)

I tried not to remove any of the existing text whilst touching it up to make more sense. It now follows the flow: small change > big change > more info (matches the logic at line 6: _The following are listed roughly in order of "least involved" to "most involved"._)

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [X] New unit tests have been added covering the changes. - n/a
- [X] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [X] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers). - n/a
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way). - n/a
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.