### PR TITLE
[GEOS-11822] OGC API procesess basic implementation

### DIFF
--- a/data/release/global.xml
+++ b/data/release/global.xml
@@ -12,21 +12,6 @@
       <contactPosition>Chief Geographer</contactPosition>
       <onlineResource>https://www.osgeo.org/</onlineResource>
       <welcome>Designed for interoperability, GeoServer publishes data from any major spatial data source using open standards.</welcome>
-      <internationalAddress class="org.geotools.util.GrowableInternationalString"/>
-      <internationalAddressCity class="org.geotools.util.GrowableInternationalString"/>
-      <internationalAddressCountry class="org.geotools.util.GrowableInternationalString"/>
-      <internationalAddressDeliveryPoint class="org.geotools.util.GrowableInternationalString"/>
-      <internationalAddressPostalCode class="org.geotools.util.GrowableInternationalString"/>
-      <internationalAddressState class="org.geotools.util.GrowableInternationalString"/>
-      <internationalAddressType class="org.geotools.util.GrowableInternationalString"/>
-      <internationalContactEmail class="org.geotools.util.GrowableInternationalString"/>
-      <internationalContactFacsimile class="org.geotools.util.GrowableInternationalString"/>
-      <internationalContactOrganization class="org.geotools.util.GrowableInternationalString"/>
-      <internationalContactPerson class="org.geotools.util.GrowableInternationalString"/>
-      <internationalContactPosition class="org.geotools.util.GrowableInternationalString"/>
-      <internationalContactVoice class="org.geotools.util.GrowableInternationalString"/>
-      <internationalOnlineResource class="org.geotools.util.GrowableInternationalString"/>
-      <internationalWelcome class="org.geotools.util.GrowableInternationalString"/>
     </contact>
     <charset>UTF-8</charset>
     <numDecimals>8</numDecimals>
@@ -35,6 +20,13 @@
     <verboseExceptions>false</verboseExceptions>
     <metadata>
       <map>
+        <entry>
+          <string>CogSettings.Key</string>
+          <cogSettings>
+            <useCachingStream>false</useCachingStream>
+            <rangeReaderSettings>HTTP</rangeReaderSettings>
+          </cogSettings>
+        </entry>
         <entry>
           <string>quietOnNotFound</string>
           <boolean>false</boolean>

--- a/doc/en/user/source/community/ogc-api/index.rst
+++ b/doc/en/user/source/community/ogc-api/index.rst
@@ -23,6 +23,7 @@ Community modules:
    tiles/index
    maps/index
    coverages/index
+   processes/index
    styles/index
    tiled-features/index
    testbed

--- a/doc/en/user/source/community/ogc-api/processes/index.rst
+++ b/doc/en/user/source/community/ogc-api/processes/index.rst
@@ -1,0 +1,51 @@
+.. _ogcapi-processes:
+
+OGC API - Processes
+===================
+
+A `OGC API - Maps <https://github.com/opengeospatial/ogcapi-processes>`_ based on the current specification draft, delivering partial functionality:
+
+- Process listing
+- Process description
+- Synchronous execution via KVP invocation
+
+Missing functionality at the time of writing, and known issues:
+
+- API definition is not fully aligned yet
+- Exection via POST
+- Remote URL inputs
+- Asynchronous exectuion
+
+OGC API - Processes Implementation status
+-----------------------------------------
+
+.. list-table::
+   :widths: 30, 20, 50
+   :header-rows: 1
+
+   * - `OGC API - Maps <https://github.com/opengeospatial/ogcapi-processes>`__
+     - Version
+     - Implementation status
+   * - Part 1: Core
+     - `Draft <https://docs.ogc.org/is/18-062r2/18-062r2.html>`__
+     - Implementation based on current specification draft (KVP is not part of Processes 1.0, but it's part of the current draft)
+
+Installing the GeoServer OGC API - Processes module
+---------------------------------------------------
+
+#. Download the OGC API nightly GeoServer community module from :download_community:`ogcapi-processes`.
+   
+   .. warning:: Verify that the version number in the filename corresponds to the version of GeoServer you are running (for example geoserver-|release|-ogcapi-processes-plugin.zip above).
+
+#. Extract the contents of the archive into the ``WEB-INF/lib`` directory of the GeoServer installation.
+
+#. On restart the services are listed at http://localhost:8080/geoserver
+
+Configuration of OGC API - Processes module
+-------------------------------------------
+
+The module is based on the GeoServer WPS one, follows the same configuration and exposes
+the same processes (so for example, it's possible to limit the processes one wants to expose
+via the same configuration mechanisms as WPS).
+
+

--- a/src/community/ogcapi/ogcapi-processes-assembly/pom.xml
+++ b/src/community/ogcapi/ogcapi-processes-assembly/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  (c) 2019 Open Source Geospatial Foundation - all rights reserved
+  ~  This code is licensed under the GPL 2.0 license, available at the root
+  ~  application directory.
+  ~  
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.community</groupId>
+    <artifactId>gs-ogcapi</artifactId>
+    <version>2.28-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.geoserver.community</groupId>
+  <artifactId>gs-ogcapi-processes-assembly</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-ogcapi-processes</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-web-ogcapi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-core</artifactId>
+      <version>${gs.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-web-processes</artifactId>
+      <version>${gs.version}</version>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/src/community/ogcapi/ogcapi-processes-assembly/src/assembly/assembly.xml
+++ b/src/community/ogcapi/ogcapi-processes-assembly/src/assembly/assembly.xml
@@ -1,0 +1,43 @@
+<assembly>
+  <id>ogcapi-processes-plugin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>target/dependency</directory>
+      <outputDirectory></outputDirectory>
+      <includes>	
+        <include>gs-ogcapi-processes-*.jar</include>
+        <include>gs-ogcapi-core-*.jar</include>
+        <include>gs-web-ogcapi-*.jar</include>
+        <include>gt-cql2-*.jar</include>
+        <include>swagger-core-*.jar</include>
+        <include>jackson-dataformat-*.jar</include>
+        <include>jackson-module-jaxb*.jar</include>
+        <include>swagger-models-*.jar</include>
+        <include>snakeyaml-*.jar</include>
+        <include>validation-api*.jar</include>
+        <include>gs-web-processes-*.jar</include>
+        <!-- must include WPS too -->
+        <include>gs-wps-core*</include>
+        <include>gs-web-wps*</include>
+        <include>gt-process-geometry*</include>
+        <include>gt-xsd-wps*</include>
+        <include>net.opengis.wps*</include>
+        <include>gt-csv*</include>
+        <include>opencsv*</include>
+        <include>gs-wps-kml-ppio*</include>
+        <include>gt-xsd-kml*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${geoserverBaseDir}/community/target/html/licenses</directory>
+      <outputDirectory></outputDirectory>
+      <includes>
+         <include>GPL.html</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/community/ogcapi/ogcapi-processes/pom.xml
+++ b/src/community/ogcapi/ogcapi-processes/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.community</groupId>
+    <artifactId>gs-ogcapi</artifactId>
+    <version>2.28-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.geoserver.community</groupId>
+  <artifactId>gs-ogcapi-processes</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-ogcapi-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-wps-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-ows</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-main</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-wps-core</artifactId>
+      <version>2.28-SNAPSHOT</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-ogcapi-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/AbstractProcessIO.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/AbstractProcessIO.java
@@ -1,0 +1,137 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.ogcapi.QueryablesBuilder;
+import org.geoserver.wps.ppio.BoundingBoxPPIO;
+import org.geoserver.wps.ppio.CDataPPIO;
+import org.geoserver.wps.ppio.ComplexPPIO;
+import org.geoserver.wps.ppio.LiteralPPIO;
+import org.geoserver.wps.ppio.ProcessParameterIO;
+import org.geoserver.wps.ppio.RawDataPPIO;
+import org.geoserver.wps.process.AbstractRawData;
+import org.geotools.api.data.Parameter;
+import org.geotools.util.logging.Logging;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.InvalidMediaTypeException;
+import org.springframework.http.MediaType;
+
+/** A class representing the common parts of process inputs and outputs in the OGC API Processes specification. */
+public class AbstractProcessIO {
+
+    private static final Logger LOGGER = Logging.getLogger(AbstractProcessIO.class);
+
+    String title;
+    String description;
+    Schema<?> schema;
+
+    public AbstractProcessIO(Parameter<?> p, ApplicationContext context) {
+        this.title = p.getTitle().toString();
+        this.description = p.getDescription().toString();
+
+        // look up the PPIOs, this should always work
+        List<ProcessParameterIO> ppios = ProcessParameterIO.findDecoder(p, context);
+        if (ppios.isEmpty()) {
+            throw new IllegalArgumentException("Could not find process parameter for type " + p.key + "," + p.type);
+        }
+
+        // handle the literal case
+        if (ppios.get(0) instanceof LiteralPPIO) {
+            this.schema = QueryablesBuilder.getSchema(p.getType());
+        } else if (ppios.get(0) instanceof BoundingBoxPPIO) {
+            // TODO: support bounding box inputs
+            throw new IllegalArgumentException("Bounding box inputs are not supported yet");
+        } else {
+            List<Schema> schemas = new ArrayList<>();
+            for (ProcessParameterIO ppio : ppios) {
+                ComplexPPIO cppio = (ComplexPPIO) ppio;
+                try {
+                    if (ppio instanceof RawDataPPIO) {
+                        String[] mimeTypes = AbstractRawData.getMimeTypes(p);
+
+                        for (String mimeType : mimeTypes) {
+                            if (isTextBased(mimeType)) {
+                                schemas.add(MimeTypeSchema.text(mimeType));
+                            } else {
+                                schemas.add(MimeTypeSchema.binary(mimeType));
+                            }
+                        }
+                    } else {
+                        String mimeType = cppio.getMimeType();
+                        if (cppio instanceof CDataPPIO || isTextBased(mimeType)) {
+                            schemas.add(MimeTypeSchema.text(mimeType));
+                        } else {
+                            schemas.add(MimeTypeSchema.binary(mimeType));
+                        }
+                    }
+                } catch (InvalidMediaTypeException e) {
+                    LOGGER.log(Level.FINER, "Skipping invalid mime type for input " + p.getName(), e);
+                }
+            }
+            this.schema = new ComposedSchema().oneOf(schemas);
+            this.schema.setTitle(p.getType().getSimpleName());
+        }
+    }
+
+    /**
+     * Heuristically checks if the given mime type is text based. This is used to determine if the schema should be a
+     * String or a BinarySchema.
+     *
+     * @param mime
+     * @return
+     */
+    private static boolean isTextBased(String mime) {
+        MediaType mediaType = MediaType.parseMediaType(mime);
+
+        // Check for "text/*"
+        if (mediaType.getType().equalsIgnoreCase("text")) {
+            return true;
+        }
+
+        // Check for known text-based "application/*"
+        if (mediaType.getType().equalsIgnoreCase("application")) {
+            String subtype = mediaType.getSubtype().toLowerCase();
+            return subtype.contains("json")
+                    || subtype.contains("gml")
+                    || subtype.contains("xml")
+                    || subtype.contains("javascript")
+                    || subtype.contains("x-www-form-urlencoded")
+                    || subtype.contains("yaml")
+                    || subtype.contains("csv");
+        }
+
+        return false;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Schema<?> getSchema() {
+        return schema;
+    }
+
+    public void setSchema(Schema<?> schema) {
+        this.schema = schema;
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/JobControl.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/JobControl.java
@@ -1,0 +1,14 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum JobControl {
+    @JsonProperty("async-execute")
+    ASYNC,
+    @JsonProperty("sync-execute")
+    SYNC;
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/MimeTypeSchema.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/MimeTypeSchema.java
@@ -1,0 +1,51 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import io.swagger.v3.oas.models.media.StringSchema;
+import java.util.Objects;
+
+/** Workaround for Swagger API not supporting the contentMediaType property of the OpenAPI 3.0.0 spec. */
+public class MimeTypeSchema extends StringSchema {
+    /** The content media type of the schema. */
+    String contentMediaType;
+
+    /** Creates a new schema for a binary type. */
+    public static MimeTypeSchema binary(String contentMediaType) {
+        MimeTypeSchema schema = new MimeTypeSchema(contentMediaType);
+        schema.setFormat("binary");
+        return schema;
+    }
+
+    /** Creates a new schema for a complex text type (e.g., JSON, XML) */
+    public static MimeTypeSchema text(String contentMediaType) {
+        return new MimeTypeSchema(contentMediaType);
+    }
+
+    private MimeTypeSchema(String contentMediaType) {
+        this.contentMediaType = contentMediaType;
+    }
+
+    public String getContentMediaType() {
+        return contentMediaType;
+    }
+
+    public void setContentMediaType(String contentMediaType) {
+        this.contentMediaType = contentMediaType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        MimeTypeSchema that = (MimeTypeSchema) o;
+        return Objects.equals(contentMediaType, that.contentMediaType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), contentMediaType);
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessDocument.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessDocument.java
@@ -1,0 +1,61 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+import org.geoserver.wps.process.AbstractRawData;
+import org.geotools.api.data.Parameter;
+import org.geotools.api.feature.type.Name;
+import org.geotools.process.ProcessFactory;
+import org.geotools.util.logging.Logging;
+import org.springframework.context.ApplicationContext;
+
+/** Document describing a process, including its inputs and outputs */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProcessDocument extends ProcessSummaryDocument {
+
+    private static final Logger LOGGER = Logging.getLogger(ProcessDocument.class);
+
+    Map<String, ProcessInput> inputs;
+    Map<String, ProcessOutput> outputs;
+
+    public ProcessDocument(ProcessFactory pf, Name name, ApplicationContext context) {
+        super(pf, name);
+
+        // collect the inputs
+        inputs = new LinkedHashMap<>();
+        Collection<String> outputMimeParameters =
+                AbstractRawData.getOutputMimeParameters(name, pf).values();
+        for (Parameter<?> p : pf.getParameterInfo(name).values()) {
+            // skip the output mime choice params, they will be filled automatically by OGC API processes (TODO!)
+            if (outputMimeParameters.contains(p.key)) {
+                continue;
+            }
+
+            ProcessInput input = new ProcessInput(p, context);
+            inputs.put(p.getName(), input);
+        }
+
+        // collect the outputs
+        Map<String, Parameter<?>> outs = pf.getResultInfo(name, null);
+        outputs = new LinkedHashMap<>();
+        for (Parameter p : outs.values()) {
+            ProcessOutput output = new ProcessOutput(p, context);
+            outputs.put(p.getName(), output);
+        }
+    }
+
+    public Map<String, ProcessInput> getInputs() {
+        return inputs;
+    }
+
+    public Map<String, ProcessOutput> getOutputs() {
+        return outputs;
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessInput.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessInput.java
@@ -1,0 +1,38 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import org.geotools.api.data.Parameter;
+import org.springframework.context.ApplicationContext;
+
+/** A class representing the input of a process in the OGC API Processes specification. */
+public class ProcessInput extends AbstractProcessIO {
+
+    public static final String UNBOUNDED = "unbounded";
+    int minOccurs = 1;
+    Object maxOccurs = UNBOUNDED; // can be either an integer or "unbounded"
+
+    public ProcessInput(Parameter<?> p, ApplicationContext context) {
+        super(p, context);
+        this.minOccurs = p.getMinOccurs();
+        this.maxOccurs = p.getMaxOccurs() == Integer.MAX_VALUE ? UNBOUNDED : p.getMaxOccurs();
+    }
+
+    public int getMinOccurs() {
+        return minOccurs;
+    }
+
+    public void setMinOccurs(int minOccurs) {
+        this.minOccurs = minOccurs;
+    }
+
+    public Object getMaxOccurs() {
+        return maxOccurs;
+    }
+
+    public void setMaxOccurs(Object maxOccurs) {
+        this.maxOccurs = maxOccurs;
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessListDocument.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessListDocument.java
@@ -1,0 +1,44 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.geoserver.ogcapi.AbstractDocument;
+import org.geoserver.wps.process.GeoServerProcessors;
+import org.geotools.api.feature.type.Name;
+import org.geotools.process.ProcessFactory;
+
+/** List of processes provided by this server (eventually paged) */
+public class ProcessListDocument extends AbstractDocument {
+
+    List<ProcessSummaryDocument> processes;
+
+    public ProcessListDocument() {
+        // gather the process list
+        processes = new ArrayList<>();
+        Set<ProcessFactory> pfs = GeoServerProcessors.getProcessFactories();
+        for (ProcessFactory pf : pfs) {
+            for (Name name : pf.getNames()) {
+                ProcessSummaryDocument summary = new ProcessSummaryDocument(pf, name);
+                processes.add(summary);
+            }
+        }
+        processes.sort((a, b) -> {
+            String id1 = a.getId();
+            String id2 = b.getId();
+            return id1.compareTo(id2);
+        });
+
+        addSelfLinks("ogc/processes/v1/processes");
+
+        // TODO: handle paging
+    }
+
+    public List<ProcessSummaryDocument> getProcesses() {
+        return processes;
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessOutput.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessOutput.java
@@ -1,0 +1,16 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import org.geotools.api.data.Parameter;
+import org.springframework.context.ApplicationContext;
+
+/** Represents the output of a process in the OGC API Processes service. */
+public class ProcessOutput extends AbstractProcessIO {
+
+    public ProcessOutput(Parameter p, ApplicationContext context) {
+        super(p, context);
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessSummaryDocument.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessSummaryDocument.java
@@ -1,0 +1,88 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.ogcapi.v1.processes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.List;
+import java.util.Objects;
+import org.geoserver.ogcapi.AbstractDocument;
+import org.geotools.api.feature.type.Name;
+import org.geotools.process.ProcessFactory;
+
+@JsonInclude(Include.NON_NULL)
+public class ProcessSummaryDocument extends AbstractDocument {
+
+    String version;
+    String title;
+    String description;
+    List<JobControl> jobControlOptions = List.of(JobControl.SYNC, JobControl.ASYNC);
+    List<String> keywords;
+
+    public ProcessSummaryDocument(ProcessFactory factory, Name processName) {
+        this.id = processName.getURI();
+        this.version = factory.getVersion(processName);
+        this.title = factory.getTitle(processName).toString();
+        this.description = factory.getDescription(processName).toString();
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<JobControl> getJobControlOptions() {
+        return jobControlOptions;
+    }
+
+    public void setJobControlOptions(List<JobControl> jobControlOptions) {
+        this.jobControlOptions = jobControlOptions;
+    }
+
+    public List<String> getKeywords() {
+        return keywords;
+    }
+
+    public void setKeywords(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ProcessSummaryDocument that = (ProcessSummaryDocument) o;
+        return Objects.equals(version, that.version)
+                && Objects.equals(title, that.title)
+                && Objects.equals(description, that.description)
+                && Objects.equals(jobControlOptions, that.jobControlOptions)
+                && Objects.equals(keywords, that.keywords);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), version, title, description, jobControlOptions, keywords);
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessesAPIBuilder.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessesAPIBuilder.java
@@ -1,0 +1,30 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import java.io.IOException;
+import org.geoserver.wps.WPSInfo;
+
+/** Builds the OGC Processes OpenAPI document */
+public class ProcessesAPIBuilder extends org.geoserver.ogcapi.OpenAPIBuilder<WPSInfo> {
+
+    public ProcessesAPIBuilder() {
+        super(ProcessesAPIBuilder.class, "openapi.yaml", "Processes 1.0 server", ProcessesService.class);
+    }
+
+    @Override
+    public OpenAPI build(WPSInfo service) throws IOException {
+        OpenAPI api = super.build(service);
+
+        // the external documentation
+        api.externalDocs(new ExternalDocumentation()
+                .description("Processes specification")
+                .url("https://docs.ogc.org/is/18-062r2/18-062r2.html"));
+
+        return api;
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessesLandingPage.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessesLandingPage.java
@@ -1,0 +1,29 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import java.util.Optional;
+import org.geoserver.ogcapi.AbstractLandingPageDocument;
+import org.geoserver.ogcapi.LinksBuilder;
+import org.geoserver.wps.WPSInfo;
+
+/** Landing page of the OGC API Processes service */
+public class ProcessesLandingPage extends AbstractLandingPageDocument {
+    public static final String REL_PROCESSES = "http://www.opengis.net/def/rel/ogc/1.0/processes";
+
+    public ProcessesLandingPage(WPSInfo wps, String basePath) {
+        super(
+                Optional.ofNullable(wps.getTitle()).orElse("Processes 1.0 server"),
+                Optional.ofNullable(wps.getAbstract()).orElse(""),
+                basePath);
+
+        // processes
+        new LinksBuilder(ProcessListDocument.class, basePath)
+                .segment("/processes")
+                .title("Processes Metadata as ")
+                .rel(REL_PROCESSES)
+                .add(this);
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessesService.java
+++ b/src/community/ogcapi/ogcapi-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessesService.java
@@ -1,0 +1,369 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import static org.geoserver.ogcapi.MappingJackson2YAMLMessageConverter.APPLICATION_YAML_VALUE;
+import static org.geoserver.ogcapi.OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamResult;
+import net.opengis.ows11.BoundingBoxType;
+import net.opengis.ows11.ExceptionType;
+import net.opengis.wps10.ComplexDataType;
+import net.opengis.wps10.DataInputsType1;
+import net.opengis.wps10.DataType;
+import net.opengis.wps10.ExecuteResponseType;
+import net.opengis.wps10.ExecuteType;
+import net.opengis.wps10.InputType;
+import net.opengis.wps10.LiteralDataType;
+import net.opengis.wps10.OutputDataType;
+import net.opengis.wps10.OutputDefinitionType;
+import net.opengis.wps10.ResponseFormType;
+import net.opengis.wps10.Wps10Factory;
+import org.eclipse.emf.common.util.EList;
+import org.geoserver.config.GeoServer;
+import org.geoserver.ogcapi.APIDispatcher;
+import org.geoserver.ogcapi.APIException;
+import org.geoserver.ogcapi.APIService;
+import org.geoserver.ogcapi.ConformanceClass;
+import org.geoserver.ogcapi.ConformanceDocument;
+import org.geoserver.ogcapi.HTMLResponseBody;
+import org.geoserver.ows.Ows11Util;
+import org.geoserver.platform.ServiceException;
+import org.geoserver.wps.BinaryEncoderDelegate;
+import org.geoserver.wps.CDataEncoderDelegate;
+import org.geoserver.wps.DefaultWebProcessingService;
+import org.geoserver.wps.RawDataEncoderDelegate;
+import org.geoserver.wps.WPSInfo;
+import org.geoserver.wps.XMLEncoderDelegate;
+import org.geoserver.wps.ppio.ComplexPPIO;
+import org.geoserver.wps.ppio.LiteralPPIO;
+import org.geoserver.wps.ppio.ProcessParameterIO;
+import org.geoserver.wps.process.GeoServerProcessors;
+import org.geotools.api.data.Parameter;
+import org.geotools.api.feature.type.Name;
+import org.geotools.feature.NameImpl;
+import org.geotools.process.ProcessFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@APIService(service = "Processes", version = "1.0.0", landingPage = "ogc/processes/v1", serviceClass = WPSInfo.class)
+@RequestMapping(path = APIDispatcher.ROOT_PATH + "/processes/v1")
+public class ProcessesService {
+
+    public static final String CONF_CLASS_PROCESSES_CORE =
+            "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core";
+    public static final String CONF_CLASS_PROCESS_DESCRIPTION =
+            "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/ogc-process-description";
+    public static final String CONF_CLASS_CALLBACK = "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/callback";
+    public static final String CONF_CLASS_JSON = "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/json";
+    public static final String CONF_CLASS_HTML = "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/html";
+    public static final String CONF_CLASS_OAS3 = "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/oas30";
+    public static final String CONF_JOB_LIST = "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/job-list";
+    public static final String CONF_CALLBACK = "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/callback";
+    public static final String CONF_DISMISS = "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/dismiss";
+    // this one comes from the current DRAFT
+    // https://docs.ogc.org/DRAFTS/18-062r3.html#_requirements_class_kvp_encoded_execute
+    public static final String CONF_KVP_EXECUTE = "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/kvp-execute";
+    // The response format parameter for KVP encoded execute
+    public static final String RESPONSE_FORMAT_KVP = "response[f]";
+
+    private final GeoServer geoServer;
+    private final DefaultWebProcessingService wps;
+    private final ApplicationContext context;
+
+    public ProcessesService(GeoServer geoServer, DefaultWebProcessingService wps, ApplicationContext context) {
+        this.geoServer = geoServer;
+        this.wps = wps;
+        this.context = context;
+    }
+
+    public WPSInfo getServiceInfo() {
+        // required for DisabledServiceCheck class
+        return geoServer.getService(WPSInfo.class);
+    }
+
+    @GetMapping(name = "getLandingPage")
+    @ResponseBody
+    @HTMLResponseBody(templateName = "landingPage.ftl", fileName = "landingPage.html")
+    public ProcessesLandingPage landingPage() {
+        return new ProcessesLandingPage(getServiceInfo(), "ogc/processes/v1");
+    }
+
+    @GetMapping(
+            path = {"openapi", "openapi.json", "openapi.yaml"},
+            name = "getApi",
+            produces = {OPEN_API_MEDIA_TYPE_VALUE, APPLICATION_YAML_VALUE, MediaType.TEXT_XML_VALUE})
+    @ResponseBody
+    @HTMLResponseBody(templateName = "api.ftl", fileName = "api.html")
+    public OpenAPI api() throws IOException {
+        return new ProcessesAPIBuilder().build(getServiceInfo());
+    }
+
+    @GetMapping(path = "conformance", name = "getConformanceDeclaration")
+    @ResponseBody
+    @HTMLResponseBody(templateName = "conformance.ftl", fileName = "conformance.html")
+    public ConformanceDocument conformance() {
+        List<String> classes = Arrays.asList(
+                ConformanceClass.CORE,
+                ConformanceClass.OAS3,
+                CONF_CLASS_PROCESSES_CORE,
+                CONF_CLASS_PROCESS_DESCRIPTION,
+                CONF_CLASS_HTML,
+                CONF_CLASS_JSON,
+                CONF_KVP_EXECUTE
+                // TODO: add job listing, callback, dismiss
+                );
+        return new ConformanceDocument("OGC API Processes", classes);
+    }
+
+    @GetMapping(path = "processes", name = "getProcessList")
+    @ResponseBody
+    @HTMLResponseBody(templateName = "processes.ftl", fileName = "processes.html")
+    public ProcessListDocument processes() {
+        return new ProcessListDocument();
+    }
+
+    @GetMapping(path = "processes/{processId}", name = "getProcessDescription")
+    @ResponseBody
+    @HTMLResponseBody(templateName = "process.ftl", fileName = "process.html")
+    public ProcessDocument describeProcess(@PathVariable("processId") String processId) {
+        Name name = toName(processId);
+        ProcessFactory pf = GeoServerProcessors.createProcessFactory(name, true);
+        if (pf == null) {
+            throw new APIException(
+                    ServiceException.INVALID_PARAMETER_VALUE, "Process not found: " + processId, HttpStatus.NOT_FOUND);
+        }
+        return new ProcessDocument(pf, name, context);
+    }
+
+    private static NameImpl toName(String processId) {
+        int idx = processId.indexOf(':');
+        if (idx < 0) return new NameImpl(processId);
+        String namespace = processId.substring(0, idx);
+        String localPart = processId.substring(idx + 1);
+        return new NameImpl(namespace, localPart);
+    }
+
+    /** GeoServer specific extension to support execution of simple processes via the OGC API */
+    @GetMapping(path = "processes/{processId}/execution", name = "executeProcessKVP")
+    public void executeGet(
+            @PathVariable("processId") String processId,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse)
+            throws Exception {
+        Name name = toName(processId);
+        ProcessFactory pf = GeoServerProcessors.createProcessFactory(name, true);
+        if (pf == null) {
+            throw new APIException(
+                    ServiceException.INVALID_PARAMETER_VALUE, "Process not found: " + processId, HttpStatus.NOT_FOUND);
+        }
+
+        // bridge to the WPS service
+        ExecuteType execute = mapQueryStringToExecute(httpRequest, pf, name);
+        ExecuteResponseType response = wps.execute(execute);
+        writeRawResponse(httpResponse, response);
+    }
+
+    /** Writes the raw response directly to the output */
+    private void writeRawResponse(HttpServletResponse httpResponse, ExecuteResponseType response) throws IOException {
+        if (response.getStatus().getProcessFailed() != null) {
+            StringBuffer errors = new StringBuffer();
+            EList exceptions =
+                    response.getStatus().getProcessFailed().getExceptionReport().getException();
+            for (Object ex : exceptions) {
+                if (ex instanceof ExceptionType) {
+                    ExceptionType exceptionType = (ExceptionType) ex;
+                    throw new APIException(
+                            exceptionType.getExceptionCode(),
+                            exceptionType.getExceptionText().get(0).toString(),
+                            HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        }
+
+        OutputDataType result =
+                (OutputDataType) response.getProcessOutputs().getOutput().get(0);
+        LiteralDataType literal = result.getData().getLiteralData();
+        BoundingBoxType bbox = result.getData().getBoundingBoxData();
+        if (literal != null) {
+            httpResponse.setContentType("text/plain");
+            httpResponse.getWriter().write(literal.getValue());
+        } else if (bbox != null) {
+            // TODO: handle bbox responses
+            throw new IllegalArgumentException("Cannot handle bounding box responses yet");
+        } else {
+            writeComplex(
+                    httpResponse, result.getData().getComplexData().getData().get(0));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private ExecuteType mapQueryStringToExecute(HttpServletRequest httpRequest, ProcessFactory pf, Name name) {
+        Wps10Factory wpsFactory = Wps10Factory.eINSTANCE;
+        ExecuteType execute = wpsFactory.createExecuteType();
+        execute.setIdentifier(Ows11Util.code(name));
+        DataInputsType1 dataInputsType = wpsFactory.createDataInputsType1();
+        execute.setDataInputs(dataInputsType);
+        for (Map.Entry<String, Parameter<?>> stringParameterEntry :
+                pf.getParameterInfo(name).entrySet()) {
+            String key = stringParameterEntry.getKey();
+            Parameter<?> parameter = stringParameterEntry.getValue();
+            String value = httpRequest.getParameter(key);
+            if (value == null) {
+                if (parameter.getMinOccurs() > 0)
+                    throw new APIException(
+                            ServiceException.INVALID_PARAMETER_VALUE,
+                            "Missing required parameter: " + key,
+                            HttpStatus.BAD_REQUEST);
+                // otherwise skip it
+                continue;
+            }
+            String type = httpRequest.getParameter(key + "[type]");
+
+            // map to an input
+            InputType inputType = wpsFactory.createInputType();
+            inputType.setIdentifier(Ows11Util.code(key));
+            DataType dataType = wpsFactory.createDataType();
+            inputType.setData(dataType);
+            List<ProcessParameterIO> ppios = ProcessParameterIO.findDecoder(parameter, context);
+            if (ppios.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Could not find process parameter for type " + parameter.key + "," + parameter.type);
+            }
+
+            if (type == null) {
+                // handle the literal case
+                if (ppios.get(0) instanceof LiteralPPIO) {
+                    LiteralDataType literal = wpsFactory.createLiteralDataType();
+                    literal.setValue(value);
+                    dataType.setLiteralData(literal);
+                } else {
+                    // handle the complex case (only one, default)
+                    ComplexPPIO complexPPIO = (ComplexPPIO) ppios.get(0);
+                    ComplexDataType complex = getComplexDataType(wpsFactory, complexPPIO, value);
+                    dataType.setComplexData(complex);
+                }
+            } else {
+                // look up the type among the PPIOs
+                for (ProcessParameterIO ppio : ppios) {
+                    if (ppio instanceof ComplexPPIO) {
+                        ComplexPPIO complexPPIO = (ComplexPPIO) ppio;
+                        if (complexPPIO.getMimeType().equalsIgnoreCase(type)) {
+                            ComplexDataType complex = getComplexDataType(wpsFactory, complexPPIO, value);
+                            dataType.setComplexData(complex);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            dataInputsType.getInput().add(inputType);
+        }
+
+        // handle the outputs, force a response
+        Map<String, Parameter<?>> resultInfo = pf.getResultInfo(name, null);
+        if (resultInfo.size() > 1) {
+            throw new UnsupportedOperationException("Support for multiple outputs not available in GET request mode");
+        }
+        OutputDefinitionType outputType = wpsFactory.createOutputDefinitionType();
+        outputType.setIdentifier(Ows11Util.code(resultInfo.keySet().iterator().next()));
+        String responseFormat = httpRequest.getParameter(RESPONSE_FORMAT_KVP);
+        if (responseFormat != null && !responseFormat.isEmpty()) {
+            setResponseMediaType(outputType, resultInfo, responseFormat);
+        }
+        ResponseFormType responseFormType = wpsFactory.createResponseFormType();
+        responseFormType.setRawDataOutput(outputType);
+        execute.setResponseForm(responseFormType);
+        return execute;
+    }
+
+    private static ComplexDataType getComplexDataType(Wps10Factory wpsFactory, ComplexPPIO complexPPIO, String value) {
+        ComplexDataType complex = wpsFactory.createComplexDataType();
+        complex.setMimeType(complexPPIO.getMimeType());
+        complex.getData().add(value);
+        return complex;
+    }
+
+    private void setResponseMediaType(
+            OutputDefinitionType outputType, Map<String, Parameter<?>> resultInfo, String responseFormat) {
+        String[] formats = responseFormat.split("\\s*,\\s*");
+        Set<String> formatsSet = Set.of(formats);
+        Parameter<?> result = resultInfo.values().iterator().next();
+        List<ProcessParameterIO> encoders = ProcessParameterIO.findEncoder(result, context);
+        // look for complex ones
+        for (ProcessParameterIO encoder : encoders) {
+            if (encoder instanceof ComplexPPIO) {
+                ComplexPPIO complexEncoder = (ComplexPPIO) encoder;
+                if (formatsSet.contains(complexEncoder.getMimeType())) {
+                    outputType.setMimeType(complexEncoder.getMimeType());
+                    return;
+                }
+            }
+        }
+        // look for literal ones
+        for (ProcessParameterIO encoder : encoders) {
+            if (encoder instanceof LiteralPPIO) {
+                if (formatsSet.contains("text/plain") || formatsSet.contains("application/json")) {
+                    // we can do without format
+                    return;
+                }
+            }
+        }
+        // ouch, we don't know how to handle this
+        throw new APIException(
+                ServiceException.INVALID_PARAMETER_VALUE,
+                "Cannot handle response format: " + responseFormat,
+                HttpStatus.BAD_REQUEST);
+    }
+
+    private void writeComplex(HttpServletResponse httpResponse, Object rawResult) {
+        try {
+            if (rawResult instanceof RawDataEncoderDelegate) {
+                RawDataEncoderDelegate delegate = (RawDataEncoderDelegate) rawResult;
+                delegate.encode(httpResponse.getOutputStream());
+                httpResponse.setContentType(delegate.getRawData().getMimeType());
+            } else if (rawResult instanceof XMLEncoderDelegate) {
+                XMLEncoderDelegate delegate = (XMLEncoderDelegate) rawResult;
+                TransformerHandler xmls =
+                        ((SAXTransformerFactory) SAXTransformerFactory.newInstance()).newTransformerHandler();
+                xmls.setResult(new StreamResult(httpResponse.getOutputStream()));
+                delegate.encode(xmls);
+                httpResponse.setContentType(delegate.getPPIO().getMimeType());
+            } else if (rawResult instanceof CDataEncoderDelegate) {
+                CDataEncoderDelegate cdataDelegate = (CDataEncoderDelegate) rawResult;
+                cdataDelegate.encode(httpResponse.getOutputStream());
+                httpResponse.setContentType(cdataDelegate.getPPIO().getMimeType());
+            } else if (rawResult instanceof BinaryEncoderDelegate) {
+                BinaryEncoderDelegate binaryDelegate = (BinaryEncoderDelegate) rawResult;
+                binaryDelegate.encode(httpResponse.getOutputStream());
+                httpResponse.setContentType(binaryDelegate.getPPIO().getMimeType());
+            } else {
+                throw new IllegalArgumentException(
+                        "Cannot encode an object of class " + rawResult.getClass() + " in raw form");
+            }
+        } catch (Exception e) {
+            throw new APIException(
+                    "InternalError",
+                    "An error occurred while encoding the results of the process",
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    e);
+        }
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/main/resources/applicationContext.xml
+++ b/src/community/ogcapi/ogcapi-processes/src/main/resources/applicationContext.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  (c) 2019 Open Source Geospatial Foundation - all rights reserved
+  ~  This code is licensed under the GPL 2.0 license, available at the root
+  ~  application directory.
+  ~  
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans             
+	     http://www.springframework.org/schema/beans/spring-beans-3.0.xsd         
+	     http://www.springframework.org/schema/context
+	     http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+>
+
+    <!-- <mvc:annotation-driven/> -->
+    <context:component-scan base-package="org.geoserver.ogcapi.v1.processes"/>
+
+    <!-- Bridges to have OGC services show up as OWS services too -->
+    <bean id="mapsServiceFactory" class="org.geoserver.ogcapi.APIServiceFactoryBean">
+        <constructor-arg index="0" value="Processes"/>
+        <constructor-arg index="1" value="1.0.0"/>
+    </bean>
+
+
+</beans>

--- a/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/landingPage.ftl
+++ b/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/landingPage.ftl
@@ -1,0 +1,50 @@
+<#global pagecrumbs>
+  <li class='breadcrumb-item active'>Home</li>
+</#global>
+<#include "common-header.ftl">
+
+  <h1>${service.title!"GeoServer Processes 1.0 Service"}</h1>
+  <p class="my-4">
+    ${service.abstract!""}<br/>
+    This is the landing page of the Processes 1.0 service, providing links to the service API and its contents.<br/>
+  </p>
+
+  <div class="row my-3">
+    <div class="col-6 col-xl-3 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h2>API definition</h2>
+          <p>The <a id="htmlApiLink" href="${model.getLinkUrl('api', 'text/html')!}"> API document</a> provides a machine processable description of this service API conformant to OpenAPI 3.
+        </div>
+      </div>
+    </div>
+
+    <div class="col-6 col-xl-3 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h2>Processes</h2>
+          <p>The <a id="htmlProcessesLink" href="${model.getLinkUrl('processes', 'text/html')!}"> processes page</a> provides a list of all the processes available in this service.
+          <br/>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-6 col-xl-3 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <#include "landingpage-conformance.ftl">
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <h2>Contact information</h2>
+  <address>
+    <ul>
+      <li>Server managed by ${contact.contactPerson!"-unspecified-"}</li>
+      <li>Organization: ${contact.contactOrganization!"-unspecified-"}</li>
+      <li>Mail: <a href="mailto:${contact.contactEmail!''}">${contact.contactEmail!"-unspecified-"}</a></li>
+    </ul>
+  </address>
+<#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/openapi.yaml
+++ b/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/openapi.yaml
@@ -1,0 +1,1081 @@
+openapi: 3.0.3
+info:
+  title: 'A sample API conforming to the standard OGC API - Processes - Part 1 : Core'
+  version: 1.0.0
+  description: 'This document is an API definition document provided alongside the
+    OGC API - Processes standard. The
+
+    OGC API - Processes Standard specifies a processing interface to communicate over
+    a RESTful protocol using JavaScript Object Notation (JSON) encodings. The
+
+    specification allows for the wrapping of computational tasks into executable processes
+    that can be offered by a server and be invoked by a client application.'
+  contact:
+    name: Open Geospatial Consortium (OGC)
+    email: standards-team@ogc.org
+    url: https://www.ogc.org/contacts
+  license:
+    name: OGC
+    url: http://www.ogc.org/legal/
+servers:
+  - description: Example server
+    url: http://example.org/ogcapi
+paths:
+  /:
+    get:
+      summary: landing page of this API
+      description: |
+        'The landing page provides links to the: 
+        * The APIDefinition (no fixed path), 
+        * The Conformance statements (path /conformance), 
+        * The processes metadata (path /processes), 
+        * The endpoint for job monitoring (path /jobs).
+        For more information, see [Section 7.2](https://docs.ogc.org/is/18-062/18-062.html#sc_landing_page).'
+      operationId: getLandingPage
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+      tags:
+        - Capabilities
+      responses:
+        200:
+          $ref: '#/components/responses/LandingPageResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /conformance:
+    get:
+      summary: information about standards that this API conforms to
+      description: A list of all conformance classes, specified in a standard, that the server conforms to.
+      operationId: getConformanceClasses
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+      tags:
+        - ConformanceDeclaration
+      responses:
+        200:
+          $ref: '#/components/responses/ConformanceResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /processes:
+    get:
+      summary: retrieve the list of available processes
+      description: >
+        The list of processes contains a summary of each process the OGC API - Processes offers,
+        including the link to a more detailed description of the process.
+      operationId: getProcesses
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+      tags:
+        - ProcessList
+      responses:
+        200:
+          $ref: '#/components/responses/ProcessesResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /processes/{processID}:
+    get:
+      summary: retrieve a process description
+      description: >
+        The process description contains information about inputs and
+        outputs and a link to the execution-endpoint for the process. The Core does
+        not mandate the use of a specific process description to specify the interface
+        of a process. That said, the Core requirements class makes the following recommendation:
+        Implementations SHOULD consider supporting the OGC process description.
+      operationId: getProcessDescription
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+        - $ref: '#/components/parameters/processID'
+      tags:
+        - ProcessDescription
+      responses:
+        200:
+          $ref: '#/components/responses/ProcessDescriptionResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /processes/{processID}/execution:
+    post:
+      summary: execute a process.
+      description: >
+        Create a new job.
+      operationId: execute
+      tags:
+        - Execute
+      parameters:
+        - $ref: '#/components/parameters/processID'
+      requestBody:
+        description: Mandatory execute request JSON
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecutionRequestBody'
+      responses:
+        200:
+          $ref: '#/components/responses/SynchronousExecutionResponse'
+        201:
+          $ref: '#/components/responses/AsynchronousExecutionResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+      callbacks:
+        jobCompleted:
+          '{$request.body#/subscriber/successUri}':
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      additionalProperties:
+                        oneOf:
+                          - oneOf:
+                              - type: string
+                              - type: number
+                              - type: integer
+                              - type: boolean
+                              - type: array
+                              - type: string
+                                format: byte
+                              - type: object
+                                required:
+                                  - bbox
+                                properties:
+                                  bbox:
+                                    type: array
+                                    oneOf:
+                                      - minItems: 4
+                                        maxItems: 4
+                                      - minItems: 6
+                                        maxItems: 6
+                                    items:
+                                      type: number
+                                  crs:
+                                    type: string
+                                    format: uri
+                                    default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                                    enum:
+                                      - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                                      - http://www.opengis.net/def/crs/OGC/0/CRS84h
+                          - type: object
+                            required:
+                              - href
+                            properties:
+                              href:
+                                type: string
+                              rel:
+                                type: string
+                                example: service
+                              type:
+                                type: string
+                                example: application/json
+                              hreflang:
+                                type: string
+                                example: en
+                              title:
+                                type: string
+              responses:
+                200:
+                  description: Results received successfully
+  /jobs:
+    get:
+      summary: retrieve the list of jobs.
+      description: Lists available jobs.
+      operationId: getJobs
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+      tags:
+        - JobList
+      responses:
+        200:
+          $ref: '#/components/responses/JobListResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+  /jobs/{jobId}:
+    get:
+      summary: retrieve the status of a job
+      description: Shows the status of a job.
+      operationId: getStatus
+      tags:
+        - Status
+      parameters:
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/f-json-html'
+      responses:
+        200:
+          $ref: '#/components/responses/JobStatusResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+    delete:
+      summary: cancel a job execution, remove a finished job
+      description: Cancel a job execution and remove it from the jobs list.
+      operationId: dismiss
+      tags:
+        - Dismiss
+      parameters:
+        - $ref: '#/components/parameters/jobId'
+      responses:
+        200:
+          $ref: '#/components/responses/JobStatusResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /jobs/{jobId}/results:
+    get:
+      summary: retrieve the result(s) of a job
+      description: Lists available results of a job. In case of a failure, lists exceptions instead.
+      operationId: getResult
+      tags:
+        - Result
+      parameters:
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/f-json-html'
+      responses:
+        200:
+          $ref: '#/components/responses/JobResultResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+components:
+  schemas:
+    LandingPage:
+      type: object
+      required:
+        - links
+      properties:
+        title:
+          type: string
+          example: Example processing server
+        description:
+          type: string
+          example: Example server implementing the OGC API - Processes 1.0 Standard
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+    Exception:
+      title: Exception Schema
+      description: JSON schema for exceptions based on RFC 7807
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+      additionalProperties: true
+    Conformance:
+      type: object
+      required:
+        - conformsTo
+      properties:
+        conformsTo:
+          type: array
+          items:
+            type: string
+          example: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core
+    Processes:
+      type: object
+      required:
+        - processes
+        - links
+      properties:
+        processes:
+          type: array
+          items:
+            type: object
+            required:
+              - id
+              - version
+            properties:
+              title:
+                type: string
+              description:
+                type: string
+              keywords:
+                type: array
+                items:
+                  type: string
+              metadata:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    title:
+                      type: string
+                    role:
+                      type: string
+                    href:
+                      type: string
+              additionalParameters:
+                type: object
+                properties:
+                  title:
+                    type: string
+                  role:
+                    type: string
+                  href:
+                    type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - value
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: array
+                          items:
+                            oneOf:
+                              - type: string
+                              - type: number
+                              - type: integer
+                              - type: array
+                                items: {}
+                              - type: object
+              id:
+                type: string
+              version:
+                type: string
+              jobControlOptions:
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - sync-execute
+                    - async-execute
+                    - dismiss
+              outputTransmission:
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - value
+                    - reference
+                  default: value
+              links:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - href
+                  properties:
+                    href:
+                      type: string
+                    rel:
+                      type: string
+                      example: service
+                    type:
+                      type: string
+                      example: application/json
+                    hreflang:
+                      type: string
+                      example: en
+                    title:
+                      type: string
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+    ProcessDescription:
+      type: object
+      required:
+        - id
+        - version
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        keywords:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              role:
+                type: string
+              href:
+                type: string
+        additionalParameters:
+          type: object
+          properties:
+            title:
+              type: string
+            role:
+              type: string
+            href:
+              type: string
+            parameters:
+              type: array
+              items:
+                type: object
+                required:
+                  - name
+                  - value
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: string
+                        - type: number
+                        - type: integer
+                        - type: array
+                          items: {}
+                        - type: object
+        id:
+          type: string
+        version:
+          type: string
+        jobControlOptions:
+          type: array
+          items:
+            type: string
+            enum:
+              - sync-execute
+              - async-execute
+              - dismiss
+        outputTransmission:
+          type: array
+          items:
+            type: string
+            enum:
+              - value
+              - reference
+            default: value
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+        inputs:
+          additionalProperties:
+            type: object
+            required:
+              - schema
+            properties:
+              minOccurs:
+                type: integer
+                default: 1
+              maxOccurs:
+                oneOf:
+                  - type: integer
+                    default: 1
+                  - type: string
+                    enum:
+                      - unbounded
+              schema:
+                oneOf:
+                  - type: object
+                  - type: object
+        outputs:
+          additionalProperties:
+            type: object
+            required:
+              - schema
+            properties:
+              schema:
+                oneOf:
+                  - type: object
+                  - type: object
+    ExecutionRequestBody:
+      type: object
+      properties:
+        inputs:
+          additionalProperties:
+            oneOf:
+              - oneOf:
+                  - type: string
+                  - type: number
+                  - type: integer
+                  - type: boolean
+                  - type: array
+                  - type: string
+                    format: byte
+                  - type: object
+                    required:
+                      - bbox
+                    properties:
+                      bbox:
+                        type: array
+                        oneOf:
+                          - minItems: 4
+                            maxItems: 4
+                          - minItems: 6
+                            maxItems: 6
+                        items:
+                          type: number
+                      crs:
+                        type: string
+                        format: uri
+                        default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                        enum:
+                          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                          - http://www.opengis.net/def/crs/OGC/0/CRS84h
+              - type: object
+                required:
+                  - value
+                properties:
+                  mediaType:
+                    type: string
+                  encoding:
+                    type: string
+                  schema:
+                    oneOf:
+                      - type: string
+                        format: url
+                      - type: object
+                  value:
+                    oneOf:
+                      - oneOf:
+                          - type: string
+                          - type: number
+                          - type: integer
+                          - type: boolean
+                          - type: array
+                          - type: string
+                            format: byte
+                          - type: object
+                            required:
+                              - bbox
+                            properties:
+                              bbox:
+                                type: array
+                                oneOf:
+                                  - minItems: 4
+                                    maxItems: 4
+                                  - minItems: 6
+                                    maxItems: 6
+                                items:
+                                  type: number
+                              crs:
+                                type: string
+                                format: uri
+                                default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                                enum:
+                                  - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                                  - http://www.opengis.net/def/crs/OGC/0/CRS84h
+                      - type: object
+              - type: object
+                required:
+                  - href
+                properties:
+                  href:
+                    type: string
+                  rel:
+                    type: string
+                    example: service
+                  type:
+                    type: string
+                    example: application/json
+                  hreflang:
+                    type: string
+                    example: en
+                  title:
+                    type: string
+        outputs:
+          additionalProperties:
+            type: object
+            properties:
+              format:
+                type: object
+                properties:
+                  mediaType:
+                    type: string
+                  encoding:
+                    type: string
+                  schema:
+                    oneOf:
+                      - type: string
+                        format: url
+                      - type: object
+              transmissionMode:
+                type: string
+                enum:
+                  - value
+                  - reference
+                default: value
+        response:
+          type: string
+          enum:
+            - raw
+            - document
+          default: raw
+        subscriber:
+          description: "Optional URIs for callbacks for this job. Support for this\
+            \ \nparameter is not required and the parameter may be removed from the\
+            \ API \ndefinition, if conformance class **'callback'** is not listed\
+            \ in the conformance\ndeclaration under `/conformance`."
+          type: object
+          required:
+            - successUri
+          properties:
+            successUri:
+              type: string
+              format: uri
+            inProgressUri:
+              type: string
+              format: uri
+            failedUri:
+              type: string
+              format: uri
+    SynchronousResponse:
+      oneOf:
+        - type: string
+        - type: number
+        - type: integer
+        - type: object
+          nullable: true
+        - type: array
+        - type: boolean
+        - type: string
+          format: binary
+        - type: object
+          additionalProperties:
+            oneOf:
+              - oneOf:
+                  - type: string
+                  - type: number
+                  - type: integer
+                  - type: boolean
+                  - type: array
+                  - type: string
+                    format: byte
+                  - type: object
+                    required:
+                      - bbox
+                    properties:
+                      bbox:
+                        type: array
+                        oneOf:
+                          - minItems: 4
+                            maxItems: 4
+                          - minItems: 6
+                            maxItems: 6
+                        items:
+                          type: number
+                      crs:
+                        type: string
+                        format: uri
+                        default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                        enum:
+                          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                          - http://www.opengis.net/def/crs/OGC/0/CRS84h
+              - type: object
+                required:
+                  - href
+                properties:
+                  href:
+                    type: string
+                  rel:
+                    type: string
+                    example: service
+                  type:
+                    type: string
+                    example: application/json
+                  hreflang:
+                    type: string
+                    example: en
+                  title:
+                    type: string
+    AsynchrounousResponse:
+      type: object
+      required:
+        - jobID
+        - status
+        - type
+      properties:
+        processID:
+          type: string
+        type:
+          type: string
+          enum:
+            - process
+        jobID:
+          type: string
+        status:
+          type: string
+          nullable: false
+          enum:
+            - accepted
+            - running
+            - successful
+            - failed
+            - dismissed
+        message:
+          type: string
+        created:
+          type: string
+          format: date-time
+        started:
+          type: string
+          format: date-time
+        finished:
+          type: string
+          format: date-time
+        updated:
+          type: string
+          format: date-time
+        progress:
+          type: integer
+          minimum: 0
+          maximum: 100
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+    JobList:
+      type: object
+      required:
+        - jobs
+        - links
+      properties:
+        jobs:
+          type: array
+          items:
+            type: object
+            required:
+              - jobID
+              - status
+              - type
+            properties:
+              processID:
+                type: string
+              type:
+                type: string
+                enum:
+                  - process
+              jobID:
+                type: string
+              status:
+                type: string
+                nullable: false
+                enum:
+                  - accepted
+                  - running
+                  - successful
+                  - failed
+                  - dismissed
+              message:
+                type: string
+              created:
+                type: string
+                format: date-time
+              started:
+                type: string
+                format: date-time
+              finished:
+                type: string
+                format: date-time
+              updated:
+                type: string
+                format: date-time
+              progress:
+                type: integer
+                minimum: 0
+                maximum: 100
+              links:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - href
+                  properties:
+                    href:
+                      type: string
+                    rel:
+                      type: string
+                      example: service
+                    type:
+                      type: string
+                      example: application/json
+                    hreflang:
+                      type: string
+                      example: en
+                    title:
+                      type: string
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+    JobResultResponse:
+      type: object
+      additionalProperties:
+        oneOf:
+          - oneOf:
+              - type: string
+              - type: number
+              - type: integer
+              - type: boolean
+              - type: array
+              - type: string
+                format: byte
+              - type: object
+                required:
+                  - bbox
+                properties:
+                  bbox:
+                    type: array
+                    oneOf:
+                      - minItems: 4
+                        maxItems: 4
+                      - minItems: 6
+                        maxItems: 6
+                    items:
+                      type: number
+                  crs:
+                    type: string
+                    format: uri
+                    default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                    enum:
+                      - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                      - http://www.opengis.net/def/crs/OGC/0/CRS84h
+          - type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+  parameters:
+    f-json-html:
+      name: f
+      in: query
+      required: false
+      description: 'The format of the response. The default is application/json. The
+        value json is equivalent to application/json. The value html is equivalent
+        to text/html.'
+      schema:
+        type: string
+        enum:
+          - json
+          - html
+    processID:
+      name: processID
+      in: path
+      required: true
+      schema:
+        type: string
+    jobId:
+      name: jobId
+      in: path
+      required: true
+      schema:
+        type: string
+  responses:
+    LandingPageResponse:
+      description: The landing page provides links to the API definition (link relations
+        `service-desc` and `service-doc`), the Conformance declaration (path `/conformance`,
+        link relation `http://www.opengis.net/def/rel/ogc/1.0/conformance`), and to
+        other resources.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/LandingPage'
+        text/html:
+          schema:
+            type: string
+    ExceptionResponse:
+      description: A server error occurred.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Exception'
+        text/html:
+          schema:
+            type: string
+    ConformanceResponse:
+      description: >
+        The URIs of all conformance classes supported by the server. To
+        support "generic" clients that want to access multiple OGC API - Processes
+        implementations - and not "just" a specific API server, the server
+         declares the conformance classes it implements and conforms to.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Conformance'
+          example:
+            conformsTo:
+              - http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core
+        text/html:
+          schema:
+            type: string
+    ProcessesResponse:
+      description: Information about the available processes
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Processes'
+    ProcessDescriptionResponse:
+      description: A process description.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProcessDescription'
+        text/html:
+          schema:
+            type: string
+    NotFoundResponse:
+      description: The requested URI was not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Exception'
+        text/html:
+          schema:
+            type: string
+    SynchronousExecutionResponse:
+      description: Result of synchronous execution
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/SynchronousResponse'
+    AsynchronousExecutionResponse:
+      description: Started asynchronous execution. Created job.
+      headers:
+        Location:
+          schema:
+            type: string
+          description: URL to check the status of the execution/job.
+        Preference-Applied:
+          schema:
+            type: string
+          description: The preference applied to execute the process asynchronously
+            (see RFC 7240).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AsynchrounousResponse'
+    JobListResponse:
+      description: A list of jobs for this process.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/JobList'
+    JobStatusResponse:
+      description: The status of a job.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AsynchrounousResponse'
+    JobResultResponse:
+      description: The results of a job.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/JobResultResponse'
+        text/html:
+          schema:
+            type: string

--- a/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/openapi_inlined.yaml
+++ b/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/openapi_inlined.yaml
@@ -1,0 +1,1081 @@
+openapi: 3.0.3
+info:
+  title: 'A sample API conforming to the standard OGC API - Processes - Part 1 : Core'
+  version: 1.0.0
+  description: 'This document is an API definition document provided alongside the
+    OGC API - Processes standard. The
+
+    OGC API - Processes Standard specifies a processing interface to communicate over
+    a RESTful protocol using JavaScript Object Notation (JSON) encodings. The
+
+    specification allows for the wrapping of computational tasks into executable processes
+    that can be offered by a server and be invoked by a client application.'
+  contact:
+    name: Open Geospatial Consortium (OGC)
+    email: standards-team@ogc.org
+    url: https://www.ogc.org/contacts
+  license:
+    name: OGC
+    url: http://www.ogc.org/legal/
+servers:
+  - description: Example server
+    url: http://example.org/ogcapi
+paths:
+  /:
+    get:
+      summary: landing page of this API
+      description: | 
+        'The landing page provides links to the: 
+        * The APIDefinition (no fixed path), 
+        * The Conformance statements (path /conformance), 
+        * The processes metadata (path /processes), 
+        * The endpoint for job monitoring (path /jobs).
+        For more information, see [Section 7.2](https://docs.ogc.org/is/18-062/18-062.html#sc_landing_page).'
+      operationId: getLandingPage
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+      tags:
+        - Capabilities
+      responses:
+        200:
+          $ref: '#/components/responses/LandingPageResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /conformance:
+    get:
+      summary: information about standards that this API conforms to
+      description: A list of all conformance classes, specified in a standard, that the server conforms to.
+      operationId: getConformanceClasses
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+      tags:
+        - ConformanceDeclaration
+      responses:
+        200:
+          $ref: '#/components/responses/ConformanceResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /processes:
+    get:
+      summary: retrieve the list of available processes
+      description: > 
+        The list of processes contains a summary of each process the OGC API - Processes offers,
+        including the link to a more detailed description of the process.
+      operationId: getProcesses
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+      tags:
+        - ProcessList
+      responses:
+        200:
+          $ref: '#/components/responses/ProcessesResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /processes/{processID}:
+    get:
+      summary: retrieve a process description
+      description: >
+        The process description contains information about inputs and
+        outputs and a link to the execution-endpoint for the process. The Core does
+        not mandate the use of a specific process description to specify the interface
+        of a process. That said, the Core requirements class makes the following recommendation:
+        Implementations SHOULD consider supporting the OGC process description.
+      operationId: getProcessDescription
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+        - $ref: '#/components/parameters/processID'
+      tags:
+        - ProcessDescription
+      responses:
+        200:
+          $ref: '#/components/responses/ProcessDescriptionResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /processes/{processID}/execution:
+    post:
+      summary: execute a process.
+      description: >
+        Create a new job.
+      operationId: execute
+      tags:
+        - Execute
+      parameters:
+        - $ref: '#/components/parameters/processID'
+      requestBody:
+        description: Mandatory execute request JSON
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecutionRequestBody'
+      responses:
+        200:
+          $ref: '#/components/responses/SynchronousExecutionResponse'
+        201:
+          $ref: '#/components/responses/AsynchronousExecutionResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+      callbacks:
+        jobCompleted:
+          '{$request.body#/subscriber/successUri}':
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      additionalProperties:
+                        oneOf:
+                          - oneOf:
+                              - type: string
+                              - type: number
+                              - type: integer
+                              - type: boolean
+                              - type: array
+                              - type: string
+                                format: byte
+                              - type: object
+                                required:
+                                  - bbox
+                                properties:
+                                  bbox:
+                                    type: array
+                                    oneOf:
+                                      - minItems: 4
+                                        maxItems: 4
+                                      - minItems: 6
+                                        maxItems: 6
+                                    items:
+                                      type: number
+                                  crs:
+                                    type: string
+                                    format: uri
+                                    default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                                    enum:
+                                      - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                                      - http://www.opengis.net/def/crs/OGC/0/CRS84h
+                          - type: object
+                            required:
+                              - href
+                            properties:
+                              href:
+                                type: string
+                              rel:
+                                type: string
+                                example: service
+                              type:
+                                type: string
+                                example: application/json
+                              hreflang:
+                                type: string
+                                example: en
+                              title:
+                                type: string
+              responses:
+                200:
+                  description: Results received successfully
+  /jobs:
+    get:
+      summary: retrieve the list of jobs.
+      description: Lists available jobs.
+      operationId: getJobs
+      parameters:
+        - $ref: '#/components/parameters/f-json-html'
+      tags:
+        - JobList
+      responses:
+        200:
+          $ref: '#/components/responses/JobListResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+  /jobs/{jobId}:
+    get:
+      summary: retrieve the status of a job
+      description: Shows the status of a job.
+      operationId: getStatus
+      tags:
+        - Status
+      parameters:
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/f-json-html'          
+      responses:
+        200:
+          $ref: '#/components/responses/JobStatusResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+    delete:
+      summary: cancel a job execution, remove a finished job
+      description: Cancel a job execution and remove it from the jobs list.
+      operationId: dismiss
+      tags:
+        - Dismiss
+      parameters:
+        - $ref: '#/components/parameters/jobId'
+      responses:
+        200:
+          $ref: '#/components/responses/JobStatusResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+  /jobs/{jobId}/results:
+    get:
+      summary: retrieve the result(s) of a job
+      description: Lists available results of a job. In case of a failure, lists exceptions instead.
+      operationId: getResult
+      tags:
+        - Result
+      parameters:
+        - $ref: '#/components/parameters/jobId'
+        - $ref: '#/components/parameters/f-json-html'          
+      responses:
+        200:
+          $ref: '#/components/responses/JobResultResponse'
+        404:
+          $ref: '#/components/responses/NotFoundResponse'
+        500:
+          $ref: '#/components/responses/ExceptionResponse'
+components:
+  schemas:
+    LandingPage:
+      type: object
+      required:
+        - links
+      properties:
+        title:
+          type: string
+          example: Example processing server
+        description:
+          type: string
+          example: Example server implementing the OGC API - Processes 1.0 Standard
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+    Exception:
+      title: Exception Schema
+      description: JSON schema for exceptions based on RFC 7807
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+      additionalProperties: true
+    Conformance:
+      type: object
+      required:
+        - conformsTo
+      properties:
+        conformsTo:
+          type: array
+          items:
+            type: string
+          example: http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core
+    Processes:
+      type: object
+      required:
+        - processes
+        - links
+      properties:
+        processes:
+          type: array
+          items:
+            type: object
+            required:
+              - id
+              - version
+            properties:
+              title:
+                type: string
+              description:
+                type: string
+              keywords:
+                type: array
+                items:
+                  type: string
+              metadata:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    title:
+                      type: string
+                    role:
+                      type: string
+                    href:
+                      type: string
+              additionalParameters:
+                type: object
+                properties:
+                  title:
+                    type: string
+                  role:
+                    type: string
+                  href:
+                    type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - value
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: array
+                          items:
+                            oneOf:
+                              - type: string
+                              - type: number
+                              - type: integer
+                              - type: array
+                                items: {}
+                              - type: object
+              id:
+                type: string
+              version:
+                type: string
+              jobControlOptions:
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - sync-execute
+                    - async-execute
+                    - dismiss
+              outputTransmission:
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - value
+                    - reference
+                  default: value
+              links:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - href
+                  properties:
+                    href:
+                      type: string
+                    rel:
+                      type: string
+                      example: service
+                    type:
+                      type: string
+                      example: application/json
+                    hreflang:
+                      type: string
+                      example: en
+                    title:
+                      type: string
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+    ProcessDescription:
+      type: object
+      required:
+        - id
+        - version
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        keywords:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              role:
+                type: string
+              href:
+                type: string
+        additionalParameters:
+          type: object
+          properties:
+            title:
+              type: string
+            role:
+              type: string
+            href:
+              type: string
+            parameters:
+              type: array
+              items:
+                type: object
+                required:
+                  - name
+                  - value
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: string
+                        - type: number
+                        - type: integer
+                        - type: array
+                          items: {}
+                        - type: object
+        id:
+          type: string
+        version:
+          type: string
+        jobControlOptions:
+          type: array
+          items:
+            type: string
+            enum:
+              - sync-execute
+              - async-execute
+              - dismiss
+        outputTransmission:
+          type: array
+          items:
+            type: string
+            enum:
+              - value
+              - reference
+            default: value
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+        inputs:
+          additionalProperties:
+            type: object
+            required:
+              - schema
+            properties:
+              minOccurs:
+                type: integer
+                default: 1
+              maxOccurs:
+                oneOf:
+                  - type: integer
+                    default: 1
+                  - type: string
+                    enum:
+                      - unbounded
+              schema:
+                oneOf:
+                  - type: object
+                  - type: object
+        outputs:
+          additionalProperties:
+            type: object
+            required:
+              - schema
+            properties:
+              schema:
+                oneOf:
+                  - type: object
+                  - type: object
+    ExecutionRequestBody:
+      type: object
+      properties:
+        inputs:
+          additionalProperties:
+            oneOf:
+              - oneOf:
+                  - type: string
+                  - type: number
+                  - type: integer
+                  - type: boolean
+                  - type: array
+                  - type: string
+                    format: byte
+                  - type: object
+                    required:
+                      - bbox
+                    properties:
+                      bbox:
+                        type: array
+                        oneOf:
+                          - minItems: 4
+                            maxItems: 4
+                          - minItems: 6
+                            maxItems: 6
+                        items:
+                          type: number
+                      crs:
+                        type: string
+                        format: uri
+                        default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                        enum:
+                          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                          - http://www.opengis.net/def/crs/OGC/0/CRS84h
+              - type: object
+                required:
+                  - value
+                properties:
+                  mediaType:
+                    type: string
+                  encoding:
+                    type: string
+                  schema:
+                    oneOf:
+                      - type: string
+                        format: url
+                      - type: object
+                  value:
+                    oneOf:
+                      - oneOf:
+                          - type: string
+                          - type: number
+                          - type: integer
+                          - type: boolean
+                          - type: array
+                          - type: string
+                            format: byte
+                          - type: object
+                            required:
+                              - bbox
+                            properties:
+                              bbox:
+                                type: array
+                                oneOf:
+                                  - minItems: 4
+                                    maxItems: 4
+                                  - minItems: 6
+                                    maxItems: 6
+                                items:
+                                  type: number
+                              crs:
+                                type: string
+                                format: uri
+                                default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                                enum:
+                                  - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                                  - http://www.opengis.net/def/crs/OGC/0/CRS84h
+                      - type: object
+              - type: object
+                required:
+                  - href
+                properties:
+                  href:
+                    type: string
+                  rel:
+                    type: string
+                    example: service
+                  type:
+                    type: string
+                    example: application/json
+                  hreflang:
+                    type: string
+                    example: en
+                  title:
+                    type: string
+        outputs:
+          additionalProperties:
+            type: object
+            properties:
+              format:
+                type: object
+                properties:
+                  mediaType:
+                    type: string
+                  encoding:
+                    type: string
+                  schema:
+                    oneOf:
+                      - type: string
+                        format: url
+                      - type: object
+              transmissionMode:
+                type: string
+                enum:
+                  - value
+                  - reference
+                default: value
+        response:
+          type: string
+          enum:
+            - raw
+            - document
+          default: raw
+        subscriber:
+          description: "Optional URIs for callbacks for this job. Support for this\
+            \ \nparameter is not required and the parameter may be removed from the\
+            \ API \ndefinition, if conformance class **'callback'** is not listed\
+            \ in the conformance\ndeclaration under `/conformance`."
+          type: object
+          required:
+            - successUri
+          properties:
+            successUri:
+              type: string
+              format: uri
+            inProgressUri:
+              type: string
+              format: uri
+            failedUri:
+              type: string
+              format: uri
+    SynchronousResponse:
+      oneOf:
+        - type: string
+        - type: number
+        - type: integer
+        - type: object
+          nullable: true
+        - type: array
+        - type: boolean
+        - type: string
+          format: binary
+        - type: object
+          additionalProperties:
+            oneOf:
+              - oneOf:
+                  - type: string
+                  - type: number
+                  - type: integer
+                  - type: boolean
+                  - type: array
+                  - type: string
+                    format: byte
+                  - type: object
+                    required:
+                      - bbox
+                    properties:
+                      bbox:
+                        type: array
+                        oneOf:
+                          - minItems: 4
+                            maxItems: 4
+                          - minItems: 6
+                            maxItems: 6
+                        items:
+                          type: number
+                      crs:
+                        type: string
+                        format: uri
+                        default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                        enum:
+                          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                          - http://www.opengis.net/def/crs/OGC/0/CRS84h
+              - type: object
+                required:
+                  - href
+                properties:
+                  href:
+                    type: string
+                  rel:
+                    type: string
+                    example: service
+                  type:
+                    type: string
+                    example: application/json
+                  hreflang:
+                    type: string
+                    example: en
+                  title:
+                    type: string
+    AsynchrounousResponse:
+      type: object
+      required:
+        - jobID
+        - status
+        - type
+      properties:
+        processID:
+          type: string
+        type:
+          type: string
+          enum:
+            - process
+        jobID:
+          type: string
+        status:
+          type: string
+          nullable: false
+          enum:
+            - accepted
+            - running
+            - successful
+            - failed
+            - dismissed
+        message:
+          type: string
+        created:
+          type: string
+          format: date-time
+        started:
+          type: string
+          format: date-time
+        finished:
+          type: string
+          format: date-time
+        updated:
+          type: string
+          format: date-time
+        progress:
+          type: integer
+          minimum: 0
+          maximum: 100
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+    Resp200_1aa8edb6:
+      type: object
+      required:
+        - jobs
+        - links
+      properties:
+        jobs:
+          type: array
+          items:
+            type: object
+            required:
+              - jobID
+              - status
+              - type
+            properties:
+              processID:
+                type: string
+              type:
+                type: string
+                enum:
+                  - process
+              jobID:
+                type: string
+              status:
+                type: string
+                nullable: false
+                enum:
+                  - accepted
+                  - running
+                  - successful
+                  - failed
+                  - dismissed
+              message:
+                type: string
+              created:
+                type: string
+                format: date-time
+              started:
+                type: string
+                format: date-time
+              finished:
+                type: string
+                format: date-time
+              updated:
+                type: string
+                format: date-time
+              progress:
+                type: integer
+                minimum: 0
+                maximum: 100
+              links:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - href
+                  properties:
+                    href:
+                      type: string
+                    rel:
+                      type: string
+                      example: service
+                    type:
+                      type: string
+                      example: application/json
+                    hreflang:
+                      type: string
+                      example: en
+                    title:
+                      type: string
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+    JobResultResponse:
+      type: object
+      additionalProperties:
+        oneOf:
+          - oneOf:
+              - type: string
+              - type: number
+              - type: integer
+              - type: boolean
+              - type: array
+              - type: string
+                format: byte
+              - type: object
+                required:
+                  - bbox
+                properties:
+                  bbox:
+                    type: array
+                    oneOf:
+                      - minItems: 4
+                        maxItems: 4
+                      - minItems: 6
+                        maxItems: 6
+                    items:
+                      type: number
+                  crs:
+                    type: string
+                    format: uri
+                    default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                    enum:
+                      - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                      - http://www.opengis.net/def/crs/OGC/0/CRS84h
+          - type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+              rel:
+                type: string
+                example: service
+              type:
+                type: string
+                example: application/json
+              hreflang:
+                type: string
+                example: en
+              title:
+                type: string
+  parameters:
+    f-json-html:
+      name: f
+      in: query
+      required: false
+      description: 'The format of the response. The default is application/json. The
+        value json is equivalent to application/json. The value html is equivalent
+        to text/html.'
+      schema:
+        type: string
+        enum:
+          - json
+          - html
+    processID:
+      name: processID
+      in: path
+      required: true
+      schema:
+        type: string
+    jobId:
+      name: jobId
+      in: path
+      required: true
+      schema:
+        type: string
+  responses:
+    LandingPageResponse:
+      description: The landing page provides links to the API definition (link relations
+        `service-desc` and `service-doc`), the Conformance declaration (path `/conformance`,
+        link relation `http://www.opengis.net/def/rel/ogc/1.0/conformance`), and to
+        other resources.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/LandingPage'
+        text/html:
+          schema:
+            type: string
+    ExceptionResponse:
+      description: A server error occurred.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Exception'
+        text/html:
+          schema:
+            type: string
+    ConformanceResponse:
+      description: > 
+        The URIs of all conformance classes supported by the server. To
+        support "generic" clients that want to access multiple OGC API - Processes
+        implementations - and not "just" a specific API server, the server
+         declares the conformance classes it implements and conforms to.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Conformance'
+          example:
+            conformsTo:
+              - http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core
+        text/html:
+          schema:
+            type: string
+    ProcessesResponse:
+      description: Information about the available processes
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Processes'
+    ProcessDescriptionResponse:
+      description: A process description.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProcessDescription'
+        text/html:
+          schema:
+            type: string
+    NotFoundResponse:
+      description: The requested URI was not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Exception'
+        text/html:
+          schema:
+            type: string
+    SynchronousExecutionResponse:
+      description: Result of synchronous execution
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/SynchronousResponse'
+    AsynchronousExecutionResponse:
+      description: Started asynchronous execution. Created job.
+      headers:
+        Location:
+          schema:
+            type: string
+          description: URL to check the status of the execution/job.
+        Preference-Applied:
+          schema:
+            type: string
+          description: The preference applied to execute the process asynchronously
+            (see RFC 7240).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AsynchrounousResponse'
+    JobListResponse:
+      description: A list of jobs for this process.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Resp200_1aa8edb6'
+    JobStatusResponse:
+      description: The status of a job.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AsynchrounousResponse'
+    JobResultResponse:
+      description: The results of a job.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/JobResultResponse'
+        text/html:
+          schema:
+            type: string

--- a/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/process.ftl
+++ b/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/process.ftl
@@ -1,0 +1,79 @@
+<#global pagetitle=model.id>
+<#global pagepath="/processes/"+model.id>
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item'><a href='${serviceLink("processes")}'>Processes</a></li>
+  <li class='breadcrumb-item active'>${model.id}</li>
+</#global>
+<#include "common-header.ftl">
+
+  <div class="row">
+    <div class="col-xs col-md-6 col-lg-8">
+      <div class="card my-4">
+        <div class="card-header">
+          <h2>${model.id}</h2>
+        </div>
+        <#assign process=model>
+        <#include "process_summary.ftl">
+      </div>
+
+     <div class="card my-4">
+        <div class="card-header">
+          <h2>Process inputs</h2>
+        </div>
+        <div class="card-body">
+          <#if model.inputs??>
+          <table class="function-table">
+          <tr>
+            <th>Identifier</th>
+            <th>Title</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <#list model.inputs as id, parameter>
+            <tr id="input_${id}">
+                <td>${id}</td>
+                <td>${parameter.title!""}</td>
+                <td>${parameter.schema.getTitle()!""}</td>
+                <td>${parameter.description!""}</td>
+            </tr>
+          </#list>
+          </table>
+          <#else>
+          The process has no inputs.
+          </#if>
+        </div>
+      </div>
+
+      <div class="card my-4">
+        <div class="card-header">
+          <h2>Process outputs</h2>
+        </div>
+        <div class="card-body">
+          <#if model.outputs??>
+          <table class="function-table">
+          <tr>
+            <th>Identifier</th>
+            <th>Title</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+          <#list model.outputs as id, parameter>
+            <tr id="output_${id}">
+                <td>${id}</td>
+                <td>${parameter.title!""}</td>
+                <td>${parameter.schema.getTitle()!""}</td>
+                <td>${parameter.description!""}</td>
+            </tr>
+          </#list>
+          </table>
+          <#else>
+          The process has no outputs.
+          </#if>
+        </div>
+      </div>
+    </div>
+
+    
+  </div>
+<#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/process_summary.ftl
+++ b/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/process_summary.ftl
@@ -1,0 +1,11 @@
+<div class="card-body">
+  <ul>
+    <#if process.title??>
+      <li><b>Title</b>: <span id="${process.htmlId}_title">${process.title}</span><br/></li>
+      </#if>
+      <#if process.description??>
+      <li><b>Description</b>: <span id="${process.htmlId}_description">${process.description!}</span><br/></li>
+      </#if>
+  </ul>
+</div>
+

--- a/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/processes.ftl
+++ b/src/community/ogcapi/ogcapi-processes/src/main/resources/org/geoserver/ogcapi/v1/processes/processes.ftl
@@ -1,0 +1,25 @@
+<#global pagecrumbs>
+  <li class='breadcrumb-item'><a href='${serviceLink("")}'>Home</a></li>
+  <li class='breadcrumb-item active'>Processes</li>
+</#global>
+<#include "common-header.ftl">
+
+  <h1>GeoServer Processes</h1>
+  <p class="my-4">
+    This document lists all the processes available in the OGC API Processes service.<br/>
+  </p>
+  
+  <div class="row">
+    <#list model.processes as process>
+    <div class="col-xs-12 col-md-6 col-lg-4 pb-4">
+      <div class="card h-100">
+        <div class="card-header">
+          <h2><a href="${serviceLink("processes/${process.id}")}">${process.id}</a></h2>
+        </div>
+        <#include "process_summary.ftl">
+      </div>
+    </div>
+    </#list>
+  </div>
+
+<#include "common-footer.ftl">

--- a/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ApiTest.java
+++ b/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ApiTest.java
@@ -1,0 +1,184 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.servers.Server;
+import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.logging.Level;
+import org.geoserver.ogcapi.OGCApiTestSupport;
+import org.geoserver.ogcapi.OpenAPIMessageConverter;
+import org.geoserver.test.GeoServerBaseTestSupport;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class ApiTest extends OGCApiTestSupport {
+
+    @Test
+    public void testApiJson() throws Exception {
+        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/processes/v1/openapi", 200);
+        validateJSONAPI(response);
+    }
+
+    private void validateJSONAPI(MockHttpServletResponse response)
+            throws UnsupportedEncodingException, JsonProcessingException {
+        assertThat(
+                response.getContentType(), CoreMatchers.startsWith(OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE));
+        String json = response.getContentAsString();
+        LOGGER.log(Level.INFO, json);
+
+        ObjectMapper mapper = Json.mapper();
+        OpenAPI api = mapper.readValue(json, OpenAPI.class);
+        validateApi(api);
+    }
+
+    @Test
+    public void testHTMLEncoding() throws Exception {
+        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/processes/v1?f=text/html", 200);
+        assertEquals("text/html", response.getContentType());
+        String html = response.getContentAsString();
+        GeoServerBaseTestSupport.LOGGER.info(html);
+        assertThat(html, containsString("<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\">"));
+    }
+
+    @Test
+    public void testApiHTML() throws Exception {
+        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/processes/v1/openapi?f=text/html", 200);
+        assertEquals("text/html", response.getContentType());
+        String html = response.getContentAsString();
+        LOGGER.info(html);
+
+        // check template expansion worked properly
+        assertThat(
+                html,
+                containsString(
+                        "<link rel=\"icon\" type=\"image/png\" href=\"http://localhost:8080/geoserver/swagger-ui/favicon-32x32.png\" sizes=\"32x32\" />"));
+        assertThat(
+                html,
+                containsString(
+                        "<link rel=\"icon\" type=\"image/png\" href=\"http://localhost:8080/geoserver/swagger-ui/favicon-16x16.png\" sizes=\"16x16\" />"));
+        assertThat(
+                html,
+                containsString("<script src=\"http://localhost:8080/geoserver/swagger-ui/swagger-ui-bundle.js\">"));
+        assertThat(
+                html,
+                containsString(
+                        "<script src=\"http://localhost:8080/geoserver/swagger-ui/swagger-ui-standalone-preset.js\">"));
+        assertThat(html, containsString("<script src=\"http://localhost:8080/geoserver/webresources/ogcapi/api.js\">"));
+        assertThat(
+                html,
+                containsString(
+                        "<input type=\"hidden\" id=\"apiLocation\" value="
+                                + "\"http://localhost:8080/geoserver/ogc/processes/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0\"/>"));
+        assertThat(html, not(containsString("<script>")));
+    }
+
+    @Test
+    public void testApiYaml() throws Exception {
+        String yaml = getAsString("ogc/processes/v1/openapi?f=application/yaml");
+        validateYAMLApi(yaml);
+    }
+
+    private void validateYAMLApi(String yaml) throws JsonProcessingException {
+        GeoServerBaseTestSupport.LOGGER.log(Level.INFO, yaml);
+
+        ObjectMapper mapper = Yaml.mapper();
+        OpenAPI api = mapper.readValue(yaml, OpenAPI.class);
+        validateApi(api);
+    }
+
+    @Test
+    public void testYamlAsAcceptsHeader() throws Exception {
+        MockHttpServletRequest request = createRequest("ogc/processes/v1/openapi");
+        request.setMethod("GET");
+        request.setContent(new byte[] {});
+        request.addHeader(HttpHeaders.ACCEPT, "foo/bar, application/yaml, text/html");
+        MockHttpServletResponse response = dispatch(request);
+        assertEquals(200, response.getStatus());
+        assertThat(response.getContentType(), CoreMatchers.startsWith("application/yaml"));
+        String yaml =
+                string(new ByteArrayInputStream(response.getContentAsString().getBytes()));
+
+        ObjectMapper mapper = Yaml.mapper();
+        OpenAPI api = mapper.readValue(yaml, OpenAPI.class);
+        validateApi(api);
+    }
+
+    private void validateApi(OpenAPI api) {
+        // only one server
+        List<Server> servers = api.getServers();
+        assertThat(servers, hasSize(1));
+        assertThat(servers.get(0).getUrl(), equalTo("http://localhost:8080/geoserver/ogc/processes/v1"));
+
+        // info version is spec version
+        assertEquals("1.0.0", api.getInfo().getVersion());
+
+        // paths
+        Paths paths = api.getPaths();
+
+        // ... landing page
+        PathItem landing = paths.get("/");
+        assertNotNull(landing);
+        assertThat(landing.getGet().getOperationId(), equalTo("getLandingPage"));
+
+        // ... conformance
+        PathItem conformance = paths.get("/conformance");
+        assertNotNull(conformance);
+        assertThat(conformance.getGet().getOperationId(), equalTo("getConformanceClasses"));
+
+        // ... processes
+        PathItem processes = paths.get("/processes");
+        assertNotNull(processes);
+        assertThat(processes.getGet().getOperationId(), equalTo("getProcesses"));
+
+        // ... process
+        PathItem process = paths.get("/processes/{processID}");
+        assertNotNull(process);
+        assertThat(process.getGet().getOperationId(), equalTo("getProcessDescription"));
+
+        // ... process execution
+        PathItem execution = paths.get("/processes/{processID}/execution");
+        assertNotNull(execution);
+        Operation executePost = execution.getPost();
+        assertThat(executePost.getOperationId(), equalTo("execute"));
+        // TODO: execute GET too
+
+        // ... job listing
+        PathItem jobs = paths.get("/jobs");
+        assertNotNull(jobs);
+        assertThat(jobs.getGet().getOperationId(), equalTo("getJobs"));
+
+        // ... single job handling (get and dismiss)
+        PathItem job = paths.get("/jobs/{jobId}");
+        assertNotNull(job);
+        assertThat(job.getGet().getOperationId(), equalTo("getStatus"));
+        assertThat(job.getDelete().getOperationId(), equalTo("dismiss"));
+
+        // ... asynch execution results
+        PathItem results = paths.get("/jobs/{jobId}/results");
+        assertNotNull(results);
+        assertThat(results.getGet().getOperationId(), equalTo("getResult"));
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ConformanceTest.java
+++ b/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ConformanceTest.java
@@ -1,0 +1,65 @@
+/* (c) 2018 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import static org.geoserver.ogcapi.v1.processes.ProcessesService.CONF_CLASS_HTML;
+import static org.geoserver.ogcapi.v1.processes.ProcessesService.CONF_CLASS_JSON;
+import static org.geoserver.ogcapi.v1.processes.ProcessesService.CONF_CLASS_PROCESSES_CORE;
+import static org.geoserver.ogcapi.v1.processes.ProcessesService.CONF_CLASS_PROCESS_DESCRIPTION;
+import static org.geoserver.ogcapi.v1.processes.ProcessesService.CONF_KVP_EXECUTE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+
+import com.jayway.jsonpath.DocumentContext;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.geoserver.ogcapi.ConformanceClass;
+import org.geoserver.ogcapi.OGCApiTestSupport;
+import org.junit.Test;
+
+public class ConformanceTest extends OGCApiTestSupport {
+
+    @Test
+    public void testConformanceJson() throws Exception {
+        DocumentContext json = getAsJSONPath("ogc/processes/v1/conformance", 200);
+        checkConformance(json);
+    }
+
+    private void checkConformance(DocumentContext json) {
+        assertEquals(2, (int) json.read("$.length()", Integer.class));
+        assertThat(json.read("$.conformsTo"), containsInAnyOrder(getExpectedConformanceClasses()));
+    }
+
+    private String[] getExpectedConformanceClasses() {
+        // TODO: add conformance classes and check the contents accordingly
+        return new String[] {
+            ConformanceClass.CORE,
+            ConformanceClass.OAS3,
+            CONF_CLASS_PROCESSES_CORE,
+            CONF_CLASS_PROCESS_DESCRIPTION,
+            CONF_CLASS_HTML,
+            CONF_CLASS_JSON,
+            CONF_KVP_EXECUTE
+        };
+    }
+
+    @Test
+    public void testCollectionsYaml() throws Exception {
+        String yaml = getAsString("ogc/processes/v1/conformance/?f=application/yaml");
+        checkConformance(convertYamlToJsonPath(yaml));
+    }
+
+    @Test
+    public void testConformanceHTML() throws Exception {
+        org.jsoup.nodes.Document document = getAsJSoup("ogc/processes/v1/conformance?f=text/html");
+        assertEquals(
+                "GeoServer OGC API Processes Conformance",
+                document.select("#title").text());
+        List<String> classes =
+                document.select("#content li").stream().map(e -> e.text()).collect(Collectors.toList());
+        assertThat(classes, containsInAnyOrder(getExpectedConformanceClasses()));
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ExecutionGetTest.java
+++ b/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ExecutionGetTest.java
@@ -1,0 +1,55 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.ogcapi.OGCApiTestSupport;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class ExecutionGetTest extends OGCApiTestSupport {
+
+    @Override
+    protected void setUpTestData(SystemTestData testData) throws Exception {
+        super.setUpTestData(testData);
+        testData.setUpDefaultRasterLayers();
+    }
+
+    @Test
+    public void testGetExecutionCoverageValues() throws Exception {
+        // call with defaults: sync execution, inline response, json format
+        JSONObject json = (JSONObject) getAsJSON("ogc/processes/v1/processes/gs:GetCoveragesValue/execution?name="
+                + getLayerId(SystemTestData.TASMANIA_DEM) + "&x=145.220&y=-41.504");
+        JSONArray values = json.getJSONArray("values");
+        assertEquals(1, values.size());
+        assertEquals(298, values.get(0));
+    }
+
+    @Test
+    public void testGetExecutionInvalidInput() throws Exception {
+        // call with defaults: sync execution, inline response, json format
+        JSONObject json = (JSONObject) getAsJSON(
+                "ogc/processes/v1/processes/gs:GetCoveragesValue/execution?name=notAGrid&x=145.220&y=-41.504");
+        print(json);
+        assertEquals("NoApplicableCode", json.getString("type"));
+        assertThat(json.getString("title"), containsString("Could not find coverage notAGrid"));
+    }
+
+    @Test
+    public void testInputOutputMimeTypes() throws Exception {
+        // call with custom format for input and output
+        MockHttpServletResponse response = getAsServletResponse(
+                "ogc/processes/v1/processes/JTS:buffer/execution?geom[type]=application/wkt&geom=POINT(0 0)&distance=10&capStyle=Square&response[f]=application/wkt");
+        assertEquals(200, response.getStatus());
+        assertEquals("application/wkt", response.getContentType());
+        assertEquals("POLYGON ((10 10, 10 -10, -10 -10, -10 10, 10 10))", response.getContentAsString());
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/LandingPageTest.java
+++ b/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/LandingPageTest.java
@@ -1,0 +1,169 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.jayway.jsonpath.DocumentContext;
+import java.util.List;
+import org.geoserver.config.GeoServer;
+import org.geoserver.ogcapi.Link;
+import org.geoserver.ogcapi.OGCApiTestSupport;
+import org.geoserver.ogcapi.OpenAPIMessageConverter;
+import org.geoserver.platform.Service;
+import org.geoserver.wps.WPSInfo;
+import org.geotools.util.Version;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class LandingPageTest extends OGCApiTestSupport {
+
+    @Test
+    public void testServiceDescriptor() {
+        Service service = getService("Processes", new Version("1.0.0"));
+        assertNotNull(service);
+        assertEquals("Processes", service.getId());
+        assertEquals(new Version("1.0.0"), service.getVersion());
+        assertThat(service.getService(), CoreMatchers.instanceOf(ProcessesService.class));
+        assertThat(
+                service.getOperations(),
+                Matchers.containsInAnyOrder(
+                        "getLandingPage",
+                        "getApi",
+                        "getConformanceDeclaration",
+                        "getProcessList",
+                        "getProcessDescription",
+                        "executeProcessKVP"));
+    }
+
+    @Test
+    public void testLandingPageNoSlash() throws Exception {
+        DocumentContext json = getAsJSONPath("ogc/processes/v1", 200);
+        checkJSONLandingPage(json);
+    }
+
+    @Test
+    public void testLandingPageSlash() throws Exception {
+        DocumentContext json = getAsJSONPath("ogc/processes/v1/", 200);
+        checkJSONLandingPage(json);
+    }
+
+    @Test
+    public void testLandingPageJSON() throws Exception {
+        DocumentContext json = getAsJSONPath("ogc/processes/v1?f=json", 200);
+        checkJSONLandingPage(json);
+    }
+
+    @Test
+    public void testLandingPageYaml() throws Exception {
+        String yaml = getAsString("ogc/processes/v1?f=application/yaml");
+        // System.out.println(yaml);
+        DocumentContext json = convertYamlToJsonPath(yaml);
+        assertJSONList(
+                json,
+                "links[?(@.type == 'application/yaml' && @.href =~ /.*ogc\\/processes\\/v1\\/\\?.*/)].rel",
+                "self");
+        assertJSONList(
+                json,
+                "links[?(@.type != 'application/yaml' && @.href =~ /.*ogc\\/processes\\/v1\\/\\?.*/)].rel",
+                "alternate",
+                "alternate");
+        checkJSONLandingPageShared(json);
+    }
+
+    @Test
+    public void testLandingPageHTML() throws Exception {
+        org.jsoup.nodes.Document document = getAsJSoup("ogc/processes/v1?f=html");
+        // check a couple of links
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/processes/v1/openapi?f=text%2Fhtml",
+                document.select("#htmlApiLink").attr("href"));
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/processes/v1/conformance?f=text%2Fhtml",
+                document.select("#htmlConformanceLink").attr("href"));
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/processes/v1/processes?f=text%2Fhtml",
+                document.select("#htmlProcessesLink").attr("href"));
+    }
+
+    void checkJSONLandingPage(DocumentContext json) {
+        assertEquals(12, (int) json.read("links.length()", Integer.class));
+        // check landing page links
+        assertJSONList(
+                json,
+                "links[?(@.type == 'application/json' && @.href =~ /.*ogc\\/processes\\/v1\\/\\?.*/)].rel",
+                "self");
+        assertJSONList(
+                json,
+                "links[?(@.type != 'application/json' && @.href =~ /.*ogc\\/processes\\/v1\\/\\?.*/)].rel",
+                "alternate",
+                "alternate");
+        checkJSONLandingPageShared(json);
+    }
+
+    void checkJSONLandingPageShared(DocumentContext json) {
+        // check API links
+        assertJSONList(
+                json,
+                "links[?(@.href =~ /.*ogc\\/processes\\/v1\\/openapi.*/)].rel",
+                Link.REL_SERVICE_DESC,
+                Link.REL_SERVICE_DESC,
+                Link.REL_SERVICE_DOC);
+        // check API with right API mime type
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/processes/v1/openapi?f=application%2Fvnd.oai.openapi%2Bjson%3Bversion%3D3.0",
+                readSingle(json, "links[?(@.type=='" + OpenAPIMessageConverter.OPEN_API_MEDIA_TYPE_VALUE + "')].href"));
+        // check conformance links
+        assertJSONList(
+                json,
+                "links[?(@.href =~ /.*ogc\\/processes\\/v1\\/conformance.*/)].rel",
+                Link.REL_CONFORMANCE_URI,
+                Link.REL_CONFORMANCE_URI,
+                Link.REL_CONFORMANCE_URI);
+        // check collection links
+        assertJSONList(
+                json,
+                "links[?(@.href =~ /.*ogc\\/processes\\/v1\\/processes.*/)].rel",
+                ProcessesLandingPage.REL_PROCESSES,
+                ProcessesLandingPage.REL_PROCESSES,
+                ProcessesLandingPage.REL_PROCESSES);
+
+        // check title
+        assertEquals("Processes 1.0 server", json.read("title"));
+        // check description
+        assertEquals("", json.read("description"));
+    }
+
+    @Test
+    public void testLandingPageHeaders() throws Exception {
+        MockHttpServletResponse response = getAsMockHttpServletResponse("ogc/processes/v1", 200);
+        List<String> link = response.getHeaders("Link");
+        assertThat(
+                link,
+                hasItems(
+                        "<http://localhost:8080/geoserver/ogc/processes/v1/?f=application%2Fyaml>; rel=\"alternate\"; type=\"application/yaml\"; title=\"This document as application/yaml\"",
+                        "<http://localhost:8080/geoserver/ogc/processes/v1/?f=application%2Fjson>; rel=\"self\"; type=\"application/json\"; title=\"This document\""));
+    }
+
+    @Test
+    public void testDisabledService() throws Exception {
+        GeoServer gs = getGeoServer();
+        WPSInfo service = gs.getService(WPSInfo.class);
+        service.setEnabled(false);
+        gs.save(service);
+        try {
+            MockHttpServletResponse httpServletResponse = getAsMockHttpServletResponse("ogc/processes/v1", 404);
+            assertEquals("Service Processes is disabled", httpServletResponse.getErrorMessage());
+        } finally {
+            service.setEnabled(true);
+            gs.save(service);
+        }
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ProcessDescriptionTest.java
+++ b/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ProcessDescriptionTest.java
@@ -1,0 +1,157 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.jayway.jsonpath.DocumentContext;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import net.minidev.json.JSONArray;
+import org.geoserver.ogcapi.OGCApiTestSupport;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.Test;
+
+public class ProcessDescriptionTest extends OGCApiTestSupport {
+
+    @Test
+    public void testBufferProcess() throws Exception {
+        DocumentContext doc = getAsJSONPath("ogc/processes/v1/processes/JTS:buffer", 200);
+
+        // basics
+        assertEquals("JTS:buffer", doc.read("id"));
+        assertEquals("Buffer", doc.read("title"));
+        assertEquals(
+                "Returns a polygonal geometry representing the input geometry enlarged by a given distance around its exterior.",
+                doc.read("description"));
+        assertEquals(List.of("sync-execute", "async-execute"), doc.read("jobControlOptions"));
+
+        // geometry (complex input)
+        DocumentContext geom = readContext(doc, "inputs.geom");
+        assertEquals("Input geometry", geom.read("description"));
+        assertEquals(1, geom.read("minOccurs", Integer.class).intValue());
+        assertEquals(1, geom.read("maxOccurs", Integer.class).intValue());
+        JSONArray geomSchema = readContext(geom, "schema.oneOf").json();
+        checkGeometrySchema(geomSchema);
+
+        // distance (floating point, no restrictions)
+        DocumentContext distance = readContext(doc, "inputs.distance");
+        assertEquals(
+                "Distance to buffer the input geometry, in the units of the geometry", distance.read("description"));
+        assertEquals(1, distance.read("minOccurs", Integer.class).intValue());
+        assertEquals(1, distance.read("maxOccurs", Integer.class).intValue());
+        assertEquals("number", distance.read("schema.type"));
+
+        // quadrantSegments, optional
+        DocumentContext quadrants = readContext(doc, "inputs.quadrantSegments");
+        assertEquals(
+                "Number determining the style and smoothness of buffer corners. Positive numbers create round corners with that number of segments per quarter-circle, 0 creates flat corners.",
+                quadrants.read("description"));
+        assertEquals(0, quadrants.read("minOccurs", Integer.class).intValue());
+        assertEquals(1, quadrants.read("maxOccurs", Integer.class).intValue());
+        assertEquals("integer", quadrants.read("schema.type"));
+
+        // capStyle, optional, enumerated
+        DocumentContext capStyle = readContext(doc, "inputs.capStyle");
+        assertEquals(
+                "Style for the buffer end caps. Values are: Round - rounded ends (default), Flat - flat ends; Square - square ends.",
+                capStyle.read("description"));
+        assertEquals(0, capStyle.read("minOccurs", Integer.class).intValue());
+        assertEquals(1, capStyle.read("maxOccurs", Integer.class).intValue());
+        assertEquals("string", capStyle.read("schema.type"));
+        assertEquals(List.of("Round", "Flat", "Square"), capStyle.read("schema.enum"));
+
+        // output
+        DocumentContext result = readContext(doc, "outputs.result");
+        assertEquals("Buffered geometry", result.read("description"));
+        JSONArray resultSchema = readContext(geom, "schema.oneOf").json();
+        checkGeometrySchema(resultSchema);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void checkGeometrySchema(JSONArray geomSchema) {
+        Set<String> expectedTypes =
+                new HashSet<>(Set.of("application/json", "application/gml-2.1.2", "application/gml-3.1.1"));
+        for (int i = 0; i < geomSchema.size(); i++) {
+            Map<String, String> schema = (Map) geomSchema.get(i);
+            String type = schema.get("type");
+            String format = schema.get("format");
+            String mediaType = schema.get("contentMediaType");
+            assertEquals("string", type);
+            if (expectedTypes.remove(mediaType)) assertNull(format); // no one of them is actually binary
+        }
+        assertEquals("Could not find some expected type: " + expectedTypes, 0, expectedTypes.size());
+    }
+
+    @Test
+    public void testBufferProcessHTML() throws Exception {
+        Document doc = getAsJSoup("ogc/processes/v1/processes/JTS:buffer?f=html");
+
+        // 1. Title check
+        String pageTitle = doc.title();
+        assertEquals("JTS:buffer", pageTitle);
+
+        // 2. Process title and description
+        assertEquals("Buffer", doc.getElementById("JTS__buffer_title").text());
+        assertEquals(
+                "Returns a polygonal geometry representing the input geometry enlarged by a given distance around its exterior.",
+                doc.getElementById("JTS__buffer_description").text());
+
+        // 3. Inputs table
+        Element inputsTable = doc.select("div.card:has(h2:contains(Process inputs)) table.function-table")
+                .first();
+        assertNotNull("Inputs table not found", inputsTable);
+
+        Elements inputRows = inputsTable.select("tr[id]");
+        assertEquals(4, inputRows.size());
+
+        // Check individual input rows (order should be preserved by the factory, uses LinkedHashMap internally)
+        checkInputRow(inputRows.get(0), "geom", "geom", "Geometry", "Input geometry");
+        checkInputRow(
+                inputRows.get(1),
+                "distance",
+                "distance",
+                "number",
+                "Distance to buffer the input geometry, in the units of the geometry");
+        checkInputRow(
+                inputRows.get(2),
+                "quadrantSegments",
+                "quadrantSegments",
+                "integer",
+                "Number determining the style and smoothness of buffer corners. Positive numbers create round corners with that number of segments per quarter-circle, 0 creates flat corners.");
+        checkInputRow(
+                inputRows.get(3),
+                "capStyle",
+                "capStyle",
+                "string",
+                "Style for the buffer end caps. Values are: Round - rounded ends (default), Flat - flat ends; Square - square ends.");
+
+        // 4. Outputs table
+        Element outputsTable = doc.select("div.card:has(h2:contains(Process outputs)) table.function-table")
+                .first();
+        assertNotNull("Outputs table not found", outputsTable);
+
+        Elements outputRows = outputsTable.select("tr[id]");
+        assertEquals(1, outputRows.size());
+
+        checkInputRow(outputRows.get(0), "result", "result", "Geometry", "Buffered geometry");
+    }
+
+    private void checkInputRow(
+            Element row, String expectedId, String expectedTitle, String expectedType, String expectedDesc) {
+        Elements cols = row.select("td");
+        assertEquals(4, cols.size());
+        assertEquals(expectedId, cols.get(0).text());
+        assertEquals(expectedTitle, cols.get(1).text());
+        assertEquals(expectedType, cols.get(2).text());
+        assertEquals(expectedDesc, cols.get(3).text());
+    }
+}

--- a/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ProcessesTest.java
+++ b/src/community/ogcapi/ogcapi-processes/src/test/java/org/geoserver/ogcapi/v1/processes/ProcessesTest.java
@@ -1,0 +1,115 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import com.jayway.jsonpath.DocumentContext;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.geoserver.config.GeoServer;
+import org.geoserver.ogcapi.OGCApiTestSupport;
+import org.geoserver.wps.DeprecatedProcessFactory;
+import org.geoserver.wps.ProcessGroupInfo;
+import org.geoserver.wps.ProcessGroupInfoImpl;
+import org.geoserver.wps.WPSInfo;
+import org.geotools.api.feature.type.Name;
+import org.geotools.feature.NameImpl;
+import org.geotools.process.ProcessFactory;
+import org.geotools.process.Processors;
+import org.hamcrest.Matchers;
+import org.jsoup.nodes.Document;
+import org.junit.Test;
+
+public class ProcessesTest extends OGCApiTestSupport {
+
+    @Test
+    public void testProcessesJson() throws Exception {
+        DocumentContext json = getAsJSONPath("ogc/processes/v1/processes", 200);
+        testProcessesJson(json, "application/json");
+    }
+
+    @Test
+    public void testProcessesYaml() throws Exception {
+        String yaml = getAsString("ogc/processes/v1/processes?f=yaml");
+        DocumentContext json = convertYamlToJsonPath(yaml);
+        testProcessesJson(json, "application/yaml");
+    }
+
+    private void testProcessesJson(DocumentContext json, String selfFormat) {
+        // check the self link
+        assertEquals(selfFormat, readSingle(json, "links[?(@.rel == 'self')].type"));
+        String selfFormatEncoded = selfFormat.replace("/", "%2F");
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/processes/v1/processes?f=" + selfFormatEncoded,
+                readSingle(json, "links[?(@.rel == 'self')].href"));
+
+        // grab a process and do a quick test
+        DocumentContext disjoint = readSingleContext(json, "processes[?(@.id == 'JTS:disjoint')]");
+        assertEquals("1.0.0", disjoint.read("version"));
+        assertEquals("Disjoint Test", disjoint.read("title"));
+        assertEquals("Tests if two geometries do not have any points in common.", disjoint.read("description"));
+
+        // check there are "many" processes
+        assertThat(json.read("processes.length()", Integer.class), Matchers.greaterThan(10));
+    }
+
+    @Test
+    public void testProcessSelection() throws Exception {
+        // disable all factories but the geoserver one
+        List<ProcessGroupInfo> groups = Processors.getProcessFactories().stream()
+                .map(pf -> {
+                    ProcessGroupInfo group = new ProcessGroupInfoImpl();
+                    group.setFactoryClass(pf.getClass());
+                    group.setEnabled(!(pf instanceof DeprecatedProcessFactory)
+                            && pf.getNames().stream().anyMatch(n -> "gs".equals(n.getNamespaceURI())));
+                    return group;
+                })
+                .collect(Collectors.toList());
+
+        GeoServer gs = getGeoServer();
+        WPSInfo wps = gs.getService(WPSInfo.class);
+        wps.getProcessGroups().clear();
+        wps.getProcessGroups().addAll(groups);
+        gs.save(wps);
+
+        try {
+            DocumentContext json = getAsJSONPath("ogc/processes/v1/processes", 200);
+            // JTS processes are gone
+            assertEquals(
+                    0,
+                    json.read("processes[?(@.id == 'JTS:disjoint')].length()", List.class)
+                            .size());
+            // but a GS one is found
+            assertEquals(
+                    1,
+                    json.read("processes[?(@.id == 'gs:GeorectifyCoverage')].length()", List.class)
+                            .size());
+        } finally {
+            wps.getProcessGroups().clear();
+            gs.save(wps);
+        }
+    }
+
+    @Test
+    public void testProcessesHTML() throws Exception {
+        Document document = getAsJSoup("ogc/processes/v1/processes?f=html");
+
+        Name disjointName = new NameImpl("JTS", "disjoint");
+        ProcessFactory jtsFactory = Processors.createProcessFactory(disjointName);
+
+        // just test the disjoint process
+        assertEquals(
+                jtsFactory.getTitle(disjointName).toString(),
+                document.select("#JTS__disjoint_title").text());
+        assertEquals(
+                jtsFactory.getDescription(disjointName).toString(),
+                document.select("#JTS__disjoint_description").text());
+        assertEquals(
+                "http://localhost:8080/geoserver/ogc/processes/v1/processes/JTS:disjoint",
+                document.selectFirst("a:contains(JTS:disjoint)").attr("href"));
+    }
+}

--- a/src/community/ogcapi/pom.xml
+++ b/src/community/ogcapi/pom.xml
@@ -32,12 +32,15 @@
     <module>dggs</module>
     <module>ogcapi-coverages</module>
     <module>ogcapi-coverages-assembly</module>
+    <module>ogcapi-processes</module>
+    <module>ogcapi-processes-assembly</module>
 
     <module>web-coverages</module>
     <module>web-images</module>
     <module>web-maps</module>
     <module>web-styles</module>
     <module>web-tiles</module>
+    <module>web-processes</module>
 
   </modules>
 

--- a/src/community/ogcapi/web-processes/pom.xml
+++ b/src/community/ogcapi/web-processes/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.community</groupId>
+    <artifactId>gs-ogcapi</artifactId>
+    <version>2.28-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.geoserver.community</groupId>
+  <artifactId>gs-web-processes</artifactId>
+  <packaging>jar</packaging>
+  <name>OGC API Processes web module</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-core</artifactId>
+      <version>${gs.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-web-wps</artifactId>
+      <version>${gs.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-web-ogcapi</artifactId>
+      <version>${gs.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.geoserver.community</groupId>
+      <artifactId>gs-ogcapi-processes</artifactId>
+      <version>${gs.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/src/community/ogcapi/web-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessesServiceDescriptionProvider.java
+++ b/src/community/ogcapi/web-processes/src/main/java/org/geoserver/ogcapi/v1/processes/ProcessesServiceDescriptionProvider.java
@@ -1,0 +1,16 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.processes;
+
+import org.geoserver.config.GeoServer;
+import org.geoserver.web.ogcapi.OgcApiServiceDescriptionProvider;
+import org.geoserver.wps.WPSInfo;
+
+public class ProcessesServiceDescriptionProvider extends OgcApiServiceDescriptionProvider<WPSInfo, ProcessesService> {
+
+    public ProcessesServiceDescriptionProvider(GeoServer gs) {
+        super(gs, "WPS", "Processes", "Processes");
+    }
+}

--- a/src/community/ogcapi/web-processes/src/main/resources/applicationContext.xml
+++ b/src/community/ogcapi/web-processes/src/main/resources/applicationContext.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  (c) 2019 Open Source Geospatial Foundation - all rights reserved
+  ~  This code is licensed under the GPL 2.0 license, available at the root
+  ~  application directory.
+  ~  
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans             
+	     http://www.springframework.org/schema/beans/spring-beans-3.0.xsd         
+	     http://www.springframework.org/schema/context
+	     http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+>
+
+    <bean id="processesServiceDescriptor" class="org.geoserver.ogcapi.v1.processes.ProcessesServiceDescriptionProvider">
+    </bean>
+</beans>

--- a/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/MappingJackson2HttpMessageConverter.java
+++ b/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/MappingJackson2HttpMessageConverter.java
@@ -6,6 +6,9 @@ package org.geoserver.ogcapi;
 
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 import java.lang.reflect.Type;
@@ -19,7 +22,10 @@ public class MappingJackson2HttpMessageConverter
         extends org.springframework.http.converter.json.MappingJackson2HttpMessageConverter {
 
     public MappingJackson2HttpMessageConverter() {
-        getObjectMapper().registerModule(new JtsModule());
+        ObjectMapper mapper = getObjectMapper();
+        mapper.registerModule(new JtsModule());
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.writer(new DefaultPrettyPrinter());
     }
 
     @Override

--- a/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesBuilder.java
+++ b/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/QueryablesBuilder.java
@@ -9,6 +9,7 @@ import static org.geotools.data.complex.util.ComplexFeatureConstants.FEATURE_CHA
 import io.swagger.v3.oas.models.media.Schema;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -120,6 +121,15 @@ public class QueryablesBuilder {
      * @return the schema
      */
     public static Schema<?> getAlphanumericSchema(Class<?> binding) {
+        if (binding.isEnum()) {
+            Schema<String> schema = new Schema<>();
+            schema.setType("string");
+            schema.setTitle("string");
+            Arrays.stream(binding.getEnumConstants()).map(Object::toString).forEach(n -> schema.addEnumItemObject(n));
+            return schema;
+        }
+
+        // other types
         Schema<?> schema = new Schema<>();
 
         schema.setType(org.geoserver.ogcapi.AttributeType.fromClass(binding).getType());
@@ -137,6 +147,12 @@ public class QueryablesBuilder {
             schema.setFormat("uuid");
         } else if (URL.class.isAssignableFrom(binding)) {
             schema.setTitle("uri");
+        } else if (binding.isAssignableFrom(String.class)) {
+            schema.setFormat("string");
+        } else if (binding.isAssignableFrom(Boolean.class)) {
+            schema.setFormat("boolean");
+        } else if (binding.isAssignableFrom(Number.class)) {
+            schema.setFormat("number");
         }
         return schema;
     }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/BinaryEncoderDelegate.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/BinaryEncoderDelegate.java
@@ -40,4 +40,8 @@ public class BinaryEncoderDelegate implements EncoderDelegate {
     public void encode(OutputStream os) throws Exception {
         ppio.encode(object, os);
     }
+
+    public BinaryPPIO getPPIO() {
+        return ppio;
+    }
 }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/CDataEncoderDelegate.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/CDataEncoderDelegate.java
@@ -50,6 +50,10 @@ public class CDataEncoderDelegate implements EncoderDelegate {
         ppio.encode(object, os);
     }
 
+    public CDataPPIO getPPIO() {
+        return ppio;
+    }
+
     static class ContentHandlerWriter extends Writer {
 
         ContentHandler ch;

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/XMLEncoderDelegate.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/XMLEncoderDelegate.java
@@ -32,4 +32,8 @@ public class XMLEncoderDelegate implements EncoderDelegate {
     public void encode(ContentHandler handler) throws Exception {
         ppio.encode(object, handler);
     }
+
+    public XMLPPIO getPPIO() {
+        return ppio;
+    }
 }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/GetCoveragesValue.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/GetCoveragesValue.java
@@ -39,7 +39,9 @@ import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Coordinate;
 
 /** A process that returns values from a coverage at a given location */
-@DescribeProcess(title = "GetCoveragesValue", description = "Returns values from a coverage at a given location")
+@DescribeProcess(
+        title = "GetCoveragesValue",
+        description = "Returns values from one or more coverages at a given location")
 public class GetCoveragesValue implements GeoServerProcess {
     private final Catalog catalog;
 

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -1593,6 +1593,11 @@
           <version>${project.version}</version>
         </dependency>
         <dependency>
+          <groupId>org.geoserver.community</groupId>
+          <artifactId>gs-ogcapi-processes</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-web-ogcapi</artifactId>
           <version>${project.version}</version>
@@ -1626,6 +1631,11 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-web-tiles</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.geoserver.community</groupId>
+          <artifactId>gs-web-processes</artifactId>
           <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
Initial commit for the OGC API processes module, provides only bare bone KVP execution, no async support, but good enough for users that want to have an easy restful way to invoke a small process (e.g., JTS ones) or a quick process that does not need async execution. The rest will come in time.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.
