### PR TITLE
[GEOS-11832] count=0 service exception for some formats

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/GetFeature.java
@@ -331,7 +331,7 @@ public class GetFeature {
         List<FeatureCollection<? extends FeatureType, ? extends Feature>> results = new ArrayList<>();
         final List<CountExecutor> totalCountExecutors = new ArrayList<>();
         try {
-            for (int i = 0; (i < queries.size()) && (count < maxFeatures); i++) {
+            for (int i = 0; (i < queries.size()) && ((i == 0) || (count < maxFeatures)); i++) {
 
                 Query query = queries.get(i);
                 try {
@@ -1227,11 +1227,13 @@ public class GetFeature {
 
         String wfsVersion = request.getVersion();
 
-        if (maxFeatures <= 0) {
+        if (maxFeatures < 0) {
             maxFeatures = org.geotools.api.data.Query.DEFAULT_MAX;
         }
 
-        if (filter == null) {
+        if (maxFeatures == 0) {
+            filter = Filter.EXCLUDE;
+        } else if (filter == null) {
             filter = Filter.INCLUDE;
         } else {
             // Gentlemen, we can rebuild it. We have the technology!

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/CSVOutputFormatTest.java
@@ -520,4 +520,16 @@ public class CSVOutputFormatTest extends WFSTestSupport {
 
         assertEquals(date, lines.get(1)[3]);
     }
+
+    @Test
+    public void testCountZero() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse(
+                "wfs?version=2.0.0&request=GetFeature&typeName=sf:PrimitiveGeoFeature&outputFormat=csv&count=0",
+                UTF_8.name());
+        assertEquals(CSV, getBaseMimeType(response.getContentType()));
+        assertEquals(UTF_8.name(), response.getCharacterEncoding());
+        assertEquals("attachment; filename=PrimitiveGeoFeature.csv", response.getHeader("Content-Disposition"));
+        List<String[]> lines = readLines(response.getContentAsString(), ',');
+        assertEquals(1, lines.size());
+    }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/GeoJsonOutputFormatTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/GeoJsonOutputFormatTest.java
@@ -4,11 +4,17 @@
  */
 package org.geoserver.wfs.response;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 
+import java.util.Collection;
 import java.util.Collections;
 import javax.xml.namespace.QName;
+import net.sf.json.JSONObject;
 import org.geoserver.data.test.MockData;
 import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wfs.WFSTestSupport;
@@ -56,5 +62,20 @@ public final class GeoJsonOutputFormatTest extends WFSTestSupport {
         // check that measures where encoded
         assertThat(response.getContentAsString(), notNullValue());
         assertThat(response.getContentAsString(), Matchers.containsString("[[120,50,20,15],[90,80,35,5]]"));
+    }
+
+    @Test
+    public void testCountZero() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse(
+                "wfs?version=2.0.0&request=GetFeature&typeName=sf:PrimitiveGeoFeature&outputFormat=json&count=0",
+                UTF_8.name());
+        assertEquals("application/json", getBaseMimeType(response.getContentType()));
+        assertEquals(UTF_8.name(), response.getCharacterEncoding());
+        assertEquals("inline; filename=PrimitiveGeoFeature.json", response.getHeader("Content-Disposition"));
+        JSONObject collection = (JSONObject) json(response);
+        assertThat(collection.getInt("totalFeatures"), is(5));
+        assertThat(collection.getInt("numberMatched"), is(5));
+        assertThat(collection.getInt("numberReturned"), is(0));
+        assertThat((Collection<?>) collection.getJSONArray("features"), empty());
     }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/ShapeZipTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/ShapeZipTest.java
@@ -993,4 +993,14 @@ public class ShapeZipTest extends WFSTestSupport {
             FileUtils.deleteQuietly(tempFolder);
         }
     }
+
+    @Test
+    public void testCountZero() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse("wfs?version=2.0.0&request=GetFeature&typeName="
+                + getLayerId(SystemTestData.BASIC_POLYGONS) + "&outputFormat=SHAPE-ZIP&count=0");
+        assertEquals("application/zip", response.getContentType());
+        assertEquals("attachment; filename=BasicPolygons.zip", response.getHeader("Content-Disposition"));
+        checkShapefileIntegrity(
+                new String[] {"BasicPolygons"}, new ByteArrayInputStream(response.getContentAsByteArray()));
+    }
 }

--- a/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/v2_0/GetFeaturePagingTest.java
@@ -601,9 +601,9 @@ public class GetFeaturePagingTest extends WFS20TestSupport {
 
     @Test
     public void testCountZero() throws Exception {
-        Document doc = getAsDOM("/wfs?request=GetFeature&version=2.0.0&service=wfs&" + "typename=gs:Fifteen&count=0");
+        Document doc = getAsDOM("/wfs?request=GetFeature&version=2.0.0&service=wfs&typename=gs:Fifteen&count=0");
         XMLAssert.assertXpathExists("/wfs:FeatureCollection", doc);
-        XMLAssert.assertXpathEvaluatesTo("0", "/wfs:FeatureCollection/@numberMatched", doc);
+        XMLAssert.assertXpathEvaluatesTo("15", "/wfs:FeatureCollection/@numberMatched", doc);
         XMLAssert.assertXpathEvaluatesTo("0", "/wfs:FeatureCollection/@numberReturned", doc);
     }
 }


### PR DESCRIPTION
[![GEOS-11832](https://badgen.net/badge/JIRA/GEOS-11832/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11832) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->
This PR updates the behavior when count=0 to always query the first feature type so that the list of feature collections passed to the output format always contains at least one feature collection. The GML, JSON and KML formats are able to return an empty response without a feature collection but the CSV and shapefile formats need a feature collection to build the response. This change also allows the totalFeatures and numberMatched values in the GML and JSON formats to return a proper value instead of 0.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.