### PR TITLE
Gihub actions: use all cores available in the builder

### DIFF
--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -40,13 +40,13 @@ jobs:
     - name: Build GeoServer modules and extensions without tests
       run: |
         mvn --version
-        mvn -B -ntp -U -T3 -DskipTests -Prelease -f src/pom.xml install
+        mvn -B -ntp -U -T1C -DskipTests -Prelease -f src/pom.xml install
     - name: Package GeoServer modules and extensions
       run: |
         mvn -B -ntp -nsu -N -f src/pom.xml assembly:single
     - name: Build and package community modules (without tests)
       run: |
-        mvn -B -ntp -nsu -U -T3 -DskipTests -PcommunityRelease,assembly -f src/community/pom.xml install
+        mvn -B -ntp -nsu -U -T1C -DskipTests -PcommunityRelease,assembly -f src/community/pom.xml install
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Build GeoServer modules and extensions without tests
       run: |
         mvn --version
-        mvn -B -ntp -U -T3 -DskipTests -Prelease -f src/pom.xml install
+        mvn -B -ntp -U -T1C -DskipTests -Prelease -f src/pom.xml install
     - name: Build aggregate javadocs
       run: |
         mvn -B -ntp -fae -f src/pom.xml javadoc:aggregate

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,10 +47,10 @@ jobs:
     - name: Build with Maven
       run: |
         mvn --version
-        mvn -B -ntp -U -T3 -fae -Prelease -f src/pom.xml clean install
+        mvn -B -ntp -U -T1C -fae -Prelease -f src/pom.xml clean install
     - name: Build community modules without tests
       run: |
-        mvn -B -ntp -nsu -U -T4 -fae -DskipTests -PcommunityRelease -f src/community/pom.xml clean install
+        mvn -B -ntp -nsu -U -T1C -fae -DskipTests -PcommunityRelease -f src/community/pom.xml clean install
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,7 @@ jobs:
           gs-${{ runner.os }}-maven-
     - name: Build with Maven
       run: |
-        mvn -B -ntp -U -T2 -Prelease,macos-github-build -f src/pom.xml clean install 
+        mvn -B -ntp -U -T2 -Prelease,macos-github-build -f src/pom.xml clean install
     - name: Remove SNAPSHOT jars from repository
       run: |
         find .m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/postgis_appschema_online.yml
+++ b/.github/workflows/postgis_appschema_online.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: |
             gs-${{ runner.os }}-maven-
       - name: Build GeoServer dependent modules (no tests, prepare fresh artifacts)
-        run: mvn -B clean install -T2 -U --file src/pom.xml -Prelease,app-schema-online-test -DskipTests -pl :gs-app-schema-postgis-test -am -Dspotless.apply.skip=true
+        run: mvn -B clean install -T1C -U --file src/pom.xml -Prelease,app-schema-online-test -DskipTests -pl :gs-app-schema-postgis-test -am -Dspotless.apply.skip=true
       - name: Build PostGIS app-schema online tests
         run: |
           mkdir ~/.geoserver

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -32,10 +32,10 @@ jobs:
           gs-${{ runner.os }}-maven-
     - name: Build with Maven with full QA checks
       run: |
-        mvn -B -ntp -U -T3 -fae -Dspotless.action=check -Dpom.fmt.action=verify -Dqa -DskipTests -Prelease -f src/pom.xml clean install
+        mvn -B -ntp -U -T1C -fae -Dspotless.action=check -Dpom.fmt.action=verify -Dqa -DskipTests -Prelease -f src/pom.xml clean install
     - name: Build community modules without unit tests, but applying formatting checks
       run: |
-        mvn -B -ntp -nsu -U -T4 -fae -Dspotless.action=check -Dpom.fmt.action=verify -DskipTests -Prelease,communityRelease -f src/community/pom.xml clean install
+        mvn -B -ntp -nsu -U -T1C -fae -Dspotless.action=check -Dpom.fmt.action=verify -DskipTests -Prelease,communityRelease -f src/community/pom.xml clean install
     - name: Remove SNAPSHOT jars from repository
       if: always()
       run: |


### PR DESCRIPTION
The number of cores available in the github action runner changes over time (used to be 2 cores, now it's 4 in all runners.). Use T1C to adapt to the current builder hw.

Update: left it to T2 on windows and osx, builds are failing a lot more with -T4 there...

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.