### PR TITLE
[GEOS-11688] After restart unable to load External Style SLD when req…

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/wms/map/GetMapKvpRequestReader.java
@@ -192,8 +192,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
     }
 
     private CloseableHttpClient getHttpClient() {
-        CloseableHttpClient client = this._httpClient;
-        if (null == client) {
+        if (null == this._httpClient) {
             synchronized (this) {
                 if (null == this._httpClient) {
                     CacheConfiguration wmsCacheConfig = getCacheConfig();
@@ -204,7 +203,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
                 }
             }
         }
-        return client;
+        return this._httpClient;
     }
 
     private RequestConfig createHttpRequestConfig() {
@@ -231,7 +230,7 @@ public class GetMapKvpRequestReader extends KvpRequestReader implements Disposab
         return wms.getServiceInfo().getRemoteStyleTimeout();
     }
 
-    private synchronized CloseableHttpClient createHttpClient(
+    protected synchronized CloseableHttpClient createHttpClient(
             RequestConfig requestConfig, CacheConfiguration wmsCacheConfig) {
         Objects.requireNonNull(requestConfig);
         Objects.requireNonNull(wmsCacheConfig);

--- a/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/map/GetMapKvpRequestReaderTest.java
@@ -14,9 +14,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -39,9 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.media.jai.InterpolationBicubic;
@@ -50,9 +48,12 @@ import javax.media.jai.InterpolationNearest;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.cache.HttpCacheContext;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
 import org.geoserver.catalog.CatalogBuilder;
 import org.geoserver.catalog.CatalogFactory;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -769,6 +770,64 @@ public class GetMapKvpRequestReaderTest extends KvpRequestReaderTestSupport {
             };
             reqReader.read(spyRequest, parseKvp(kvp), caseInsensitiveKvp(kvp));
         }
+    }
+
+    @Test
+    public void testSldRemoteHttpConcurrency() throws Exception {
+        final String fakeBasicAuth = "FakeBasicAuth";
+        final String authHeader = "Authorization";
+        BasicHeader expectedBasicHeader = new BasicHeader(authHeader, fakeBasicAuth);
+
+        GetMapRequest request = reader.createRequest();
+        GetMapRequest spyRequest = spy(request);
+        Header[] headers = new Header[1];
+        when(spyRequest.getHttpRequestHeader(authHeader)).thenReturn(fakeBasicAuth);
+
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        HttpEntity entity = mock(HttpEntity.class);
+
+        GetMapKvpRequestReader reqReader;
+        try (InputStream sld = GetMapKvpRequestReader.class.getResourceAsStream("BasicPolygonsLibraryNoDefault.sld")) {
+            when(entity.getContent()).thenReturn(sld);
+            when(response.getEntity()).thenReturn(entity);
+            when(client.execute(any(HttpGet.class), any(HttpCacheContext.class))).thenReturn(response);
+
+            reqReader = new GetMapKvpRequestReader(wms, null) {
+                @Override
+                protected CloseableHttpClient createHttpClient(RequestConfig config, CacheConfiguration cacheConfig) {
+                    return client;
+                }
+            };
+        }
+
+
+        int numberOfThreads = 10;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        for (int i = 0; i < numberOfThreads; i++) {
+            service.submit(() -> {
+                try {
+                    URL url = new URL("http://localhost/geoserver/rest/sldurl/sample.sld");
+                    String urlDecoded = URLDecoder.decode(url.toExternalForm(), "UTF-8");
+                    HashMap kvp = new HashMap<>();
+                    kvp.put("layers", getLayerId(BASIC_POLYGONS));
+                    kvp.put("sld", urlDecoded);
+
+                    reqReader.read(spyRequest, parseKvp(kvp), caseInsensitiveKvp(kvp));
+                    assertSameHeader(headers, expectedBasicHeader);
+                } catch (Exception ignored) {
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        service.shutdown();
+
+        // Assert the same mock HTTP client instance was used by every thread
+        verify(client, times(numberOfThreads)).execute(any(HttpGet.class), any(HttpContext.class));
     }
 
     private void assertSameHeader(Header[] headers, BasicHeader expectedBasicHeader) {


### PR DESCRIPTION
[![GEOS-11688](https://badgen.net/badge/JIRA/GEOS-11688/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11688) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When requesting multiple WMS tiles with an remote SLD at the same time after a Geoserver restart lead to an error. The tiles could not be generated. As explained in:
https://osgeo-org.atlassian.net/browse/GEOS-11688
This PR fixed the logic which caused this bug, and added a test.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).