### PR TITLE
[GEOS-11857] Random NPE In LocalWorkspaceCallback

### DIFF
--- a/src/main/src/main/java/org/geoserver/ows/LocalWorkspaceCallback.java
+++ b/src/main/src/main/java/org/geoserver/ows/LocalWorkspaceCallback.java
@@ -38,11 +38,9 @@ public class LocalWorkspaceCallback implements DispatcherCallback, ExtensionPrio
     static final Logger LOGGER = Logging.getLogger(LocalWorkspaceCallback.class);
 
     GeoServer gs;
-    Catalog catalog;
 
     public LocalWorkspaceCallback(GeoServer gs) {
         this.gs = gs;
-        catalog = gs.getCatalog();
     }
 
     @Override
@@ -61,6 +59,7 @@ public class LocalWorkspaceCallback implements DispatcherCallback, ExtensionPrio
             }
 
             // check if the context matches a workspace
+            Catalog catalog = gs.getCatalog();
             ws = catalog.getWorkspaceByName(first);
             if (ws != null) {
                 LocalWorkspace.set(ws);


### PR DESCRIPTION
Keep on seeing this issue in my local environment, seems to be related to a russian roulette in bean initialization order.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.
