### PR TITLE
[GEOS-11860] MapML does not match raster rendering geometry simplification behavior

### DIFF
--- a/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLSimplifier.java
+++ b/src/extension/mapml/src/main/java/org/geoserver/mapml/MapMLSimplifier.java
@@ -29,10 +29,10 @@ import org.locationtech.jts.simplify.TopologyPreservingSimplifier;
 class MapMLSimplifier {
 
     /**
-     * The tolerance in pixels, two vertices at less than this distance will be considered the same. It's smaller
-     * compared to the server side renderer, the client side seems to render thinner lines.
+     * The tolerance in pixels, two vertices at less than this distance will be considered the same. The MapML client
+     * side seems to render thinner lines, we might want to use a smaller value.
      */
-    public static final double PIXEL_TOLERANCE = 0.1;
+    public static final double PIXEL_TOLERANCE = 0.8;
 
     private final double querySimplificationDistance;
     private final double simplificationDistance;

--- a/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSFeatureTest.java
+++ b/src/extension/mapml/src/test/java/org/geoserver/mapml/MapMLWMSFeatureTest.java
@@ -343,7 +343,7 @@ public class MapMLWMSFeatureTest extends MapMLTestSupport {
                 .feature(true)
                 .getAsMapML();
         features = mapml.getBody().getFeatures();
-        testScale(features, 4);
+        testScale(features, 3);
     }
 
     private static void testScale(List<Feature> features, int expectedScale) {


### PR DESCRIPTION
[![GEOS-11860](https://badgen.net/badge/JIRA/GEOS-11860/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11860) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See linked ticket for details.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.