### PR TITLE
[GEOS-11885] Add UUID support on SmartDataLoader

### DIFF
--- a/src/community/smart-data-loader/src/main/java/org/geoserver/smartdataloader/domain/DomainModelBuilder.java
+++ b/src/community/smart-data-loader/src/main/java/org/geoserver/smartdataloader/domain/DomainModelBuilder.java
@@ -206,6 +206,7 @@ public final class DomainModelBuilder {
                 return DomainAttributeType.INTEGER;
             case "text":
             case "varchar":
+            case "uuid":
                 return DomainAttributeType.TEXT;
             case "time":
             case "date":

--- a/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/domain/DomainModelBuilderTest.java
+++ b/src/community/smart-data-loader/src/test/java/org/geoserver/smartdataloader/domain/DomainModelBuilderTest.java
@@ -1,6 +1,7 @@
 package org.geoserver.smartdataloader.domain;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.DatabaseMetaData;
 import java.util.HashMap;
@@ -10,6 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.smartdataloader.AbstractJDBCSmartDataLoaderTestSupport;
 import org.geoserver.smartdataloader.JDBCFixtureHelper;
+import org.geoserver.smartdataloader.domain.entities.DomainEntitySimpleAttribute;
 import org.geoserver.smartdataloader.domain.entities.DomainModel;
 import org.geoserver.smartdataloader.domain.entities.DomainRelation;
 import org.geoserver.smartdataloader.metadata.DataStoreMetadata;
@@ -164,6 +166,8 @@ public abstract class DomainModelBuilderTest extends AbstractJDBCSmartDataLoader
         String paramContainingEntity = relationParam.getContainingEntity().getName();
         assertEquals(stContainingEntity, paramContainingEntity);
         assertEquals("meteo_observations", stContainingEntity);
-        assertEquals(4, dm.getRootEntity().getAttributes().size());
+        assertEquals(5, dm.getRootEntity().getAttributes().size());
+        List<DomainEntitySimpleAttribute> attributes = dm.getRootEntity().getAttributes();
+        assertTrue(attributes.stream().anyMatch(dsa -> dsa.getName().equals("universal_id")));
     }
 }

--- a/src/community/smart-data-loader/src/test/resources/org/geoserver/smartdataloader/postgis/mockdata/meteo_int8_db.sql
+++ b/src/community/smart-data-loader/src/test/resources/org/geoserver/smartdataloader/postgis/mockdata/meteo_int8_db.sql
@@ -22,7 +22,7 @@ SET search_path = smartappschematest, pg_catalog;
 SET default_tablespace = '';
 SET default_with_oids = false;
 
-CREATE TABLE smartappschematest.meteo_observations (id integer NOT NULL,parameter_id integer NOT NULL,station_id integer NOT NULL,"time" timestamp without time zone,value double PRECISION, decimal_value float4, unsupported_column xml);
+CREATE TABLE smartappschematest.meteo_observations (id integer NOT NULL,parameter_id integer NOT NULL,station_id integer NOT NULL,"time" timestamp without time zone,value double PRECISION, decimal_value float4, unsupported_column xml, universal_id uuid);
 ALTER TABLE smartappschematest.meteo_observations OWNER TO postgres;
 CREATE SEQUENCE meteo_observations_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
 ALTER TABLE smartappschematest.meteo_observations_id_seq OWNER TO postgres;
@@ -37,7 +37,7 @@ ALTER TABLE smartappschematest.meteo_maintainers OWNER TO postgres;
 CREATE TABLE smartappschematest.meteo_stations_maintainers (id integer NOT NULL, station_id integer, manteiner_id integer);
 ALTER TABLE smartappschematest.meteo_stations_maintainers OWNER TO postgres;
 
-INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (1,1,13,'2016-12-19 06:26:40',20, 20.3);
+INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value, universal_id) VALUES (1,1,13,'2016-12-19 06:26:40',20, 20.3, 'a1b2c3d4-e5f6-7890-1234-567890abcdef');
 INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (2,2,13,'2016-12-19 06:27:13',155, 155.4);
 INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (3,1,7,'2016-12-19 06:28:31',35, 31.1);
 INSERT INTO smartappschematest.meteo_observations (id, parameter_id, station_id, "time", value, decimal_value) VALUES (4,1,7,'2016-12-19 06:28:55',25, 25.3);


### PR DESCRIPTION
[![GEOS-11885](https://badgen.net/badge/JIRA/GEOS-11885/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11885) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Jira ticket:
https://osgeo-org.atlassian.net/browse/GEOS-11885

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.