### PR TITLE
[GEOS-11900] Amend failing tests hidden by surefire junit 5 issues

### DIFF
--- a/src/extension/importer/web/src/test/java/org/geoserver/importer/web/ImportTaskTableTest.java
+++ b/src/extension/importer/web/src/test/java/org/geoserver/importer/web/ImportTaskTableTest.java
@@ -78,9 +78,11 @@ public class ImportTaskTableTest extends GeoServerWicketTestSupport {
 
         // Check that the WKT links set
         tester.assertModelValue(
-                "taskTable:listContainer:items:1:itemProperties:2:component:form:crs:wkt:wktLabel", "CRS:NAD27");
+                "taskTable:listContainer:items:1:itemProperties:2:component:form:crs:wkt:wktLabel",
+                "NAD27 longitude-latitude");
         tester.assertModelValue(
-                "taskTable:listContainer:items:2:itemProperties:2:component:form:crs:wkt:wktLabel", "CRS:NAD83");
+                "taskTable:listContainer:items:2:itemProperties:2:component:form:crs:wkt:wktLabel",
+                "NAD83 longitude-latitude");
 
         // Apply the first
         tester.clickLink("taskTable:listContainer:items:1:itemProperties:2:component:form:apply", true);

--- a/src/wms/src/main/java/org/geoserver/wms/WMS.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMS.java
@@ -980,9 +980,9 @@ public class WMS implements ApplicationContextAware {
      */
     public static String toInternalSRS(String srs, Version version) {
         if (srs != null && VERSION_1_3_0.equals(version)) {
-            // do not transform the srs if it's from the web factory, GeoServer has an override to replace it
+            // do not transform the srs if it's from the web or mapml factory, GeoServer has an override to replace it
             // with the EPSG code to leverage all the transformation capabilities of the EPSG database
-            if (srs.startsWith("CRS:")) return srs;
+            if (srs.startsWith("CRS:") || srs.startsWith("MapML:")) return srs;
             try {
                 CoordinateReferenceSystem crs = CRS.decode(srs);
                 if (crs != null) {


### PR DESCRIPTION
[![GEOS-11900](https://badgen.net/badge/JIRA/GEOS-11900/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11900) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.