### PR TITLE
Improve getMap robustness for request BBOX outside Layer

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/GetMap.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetMap.java
@@ -356,8 +356,6 @@ public class GetMap {
             throws IOException {
         WMSLayerInfo wmsLayer = (WMSLayerInfo) mapLayerInfo.getResource();
         if (!checkWMSLayerMinMaxScale(wmsLayer, mapContent.getScaleDenominator())) return;
-        WebMapServer wms = wmsLayer.getStore().getWebMapServer(null);
-        Layer gt2Layer = wmsLayer.getWMSLayer(null);
         if (wmsLayer.isMetadataBBoxRespected()) {
             boolean isInsideBounnds = checkEnvelopOverLapWithNativeBounds(
                     mapContent.getViewport().getBounds(), wmsLayer.getNativeBoundingBox());
@@ -370,6 +368,9 @@ public class GetMap {
                 return;
             }
         }
+        
+        WebMapServer wms = wmsLayer.getStore().getWebMapServer(null);
+        Layer gt2Layer = wmsLayer.getWMSLayer(null);
 
         // see if we can merge this layer with the previous one
         boolean merged = false;


### PR DESCRIPTION
Geoserver has a mechanism to avoid calling getMap on layer that requestBbox doest not intersect. 
This mechanism works fine but it does not allow the geoserve to be robust to a WMS cascade fail.

My usage case is the following, I have a layer group that may contains a lot of cascaded WMS layers, each one covers aspecific zone. I do not want the failure of one of them to impact request in zone they do not cover. 

I particulary tested locally with a layer group that contains 2 layers, (layer1, layer2), and a request that is only on layer1 data BBOX, I discovered that when I start the geoserver, and make my request, geoserver try to reach layer2 geoserver even though the request is only on layer1 zone. 

It seems that is caused by the following lines placed before the checkEnvelopOverLapWithNativeBounds in getMap.java:

```
WebMapServer wms = wmsLayer.getStore().getWebMapServer(null);
Layer gt2Layer = wmsLayer.getWMSLayer(null); 
```

Moving those 2 lines after the checkEnvelopOverLapWithNativeBounds, solved my problem, and my request to my layer group was OK event though layer2 geoserver was down.

The unit tests seem to have not broken by my changes.
What do you think about it ? Do we add a new UT ? I'm not sure how to do that. 