### PR TITLE
[Backport to 2.26.x][GEOS-11813] Create REST API For Security Provide…

### DIFF
--- a/doc/en/api/1.0.0/authenticationproviders.yaml
+++ b/doc/en/api/1.0.0/authenticationproviders.yaml
@@ -8,15 +8,15 @@ info:
     ### Representation notes
     - **XML:** each provider is serialized with its concrete class name as the element name
       (e.g. `<org.geoserver.security.config.UsernamePasswordAuthenticationProviderConfig>`).
-      For POST/PUT send the provider element **directly** (no `<authProvider>` wrapper).
+      For POST/PUT send the provider element **directly** (no `<authprovider>` wrapper).
     - **JSON:** requests may be **either** a bare object `{ ... }` **or** an envelope:
-        - Single: `{ "authProvider": { ... } }`
-        - List:   `{ "authProviders": [ { ... }, ... ] }`
-      (The controller also accepts a single-item `"authProviders"` array.)
+        - Single: `{ "authprovider": { ... } }`
+        - List:   `{ "authproviders": [ { ... }, ... ] }`
+      (The controller also accepts a single-item `"authproviders"` array.)
     - **Create rules:** `className` is required on POST.
     - **Update rules:** path `{providerName}` **must** equal payload `name`. `className` cannot change
       (you may omit it in the payload to keep the existing value).
-    - **Enable/disable semantics:** the active order in `<authProviderNames>` determines which providers
+    - **Enable/disable semantics:** the active order in `<authproviderNames>` determines which providers
       are enabled. Presence = enabled; absence = disabled.
 
 host: localhost:8080
@@ -26,20 +26,20 @@ security:
   - basicAuth: []
 
 paths:
-  /security/authProviders:
+  /security/authproviders:
     get:
       summary: List providers (active order)
       operationId: listAuthProviders
-      tags: [authProviders]
+      tags: [authproviders]
       produces: [application/json, application/xml]
       responses:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/authProviders'
+            $ref: '#/definitions/authproviders'
           examples:
             application/json:
-              authProviders:
+              authproviders:
                 - id: 52857278:13c7ffd66a8:-7ff0
                   name: default
                   className: org.geoserver.security.auth.UsernamePasswordAuthenticationProvider
@@ -54,7 +54,7 @@ paths:
     post:
       summary: Create a provider
       operationId: createAuthProvider
-      tags: [authProviders]
+      tags: [authproviders]
       consumes: [application/json, application/xml]
       produces: [application/json, application/xml]
       parameters:
@@ -68,13 +68,13 @@ paths:
           required: true
           description: |
             Provider payload.
-            - **XML:** send the provider element itself (no `<authProvider>` wrapper).
-            - **JSON:** send a bare object or an `{ "authProvider": { ... } }` envelope.
+            - **XML:** send the provider element itself (no `<authprovider>` wrapper).
+            - **JSON:** send a bare object or an `{ "authprovider": { ... } }` envelope.
           schema:
-            $ref: '#/definitions/authProviderCore'
+            $ref: '#/definitions/authproviderCore'
           x-examples:
             application/json:
-              authProvider:
+              authprovider:
                 name: my-up
                 className: org.geoserver.security.auth.UsernamePasswordAuthenticationProvider
                 userGroupServiceName: default
@@ -92,7 +92,7 @@ paths:
               type: string
               format: uri
           schema:
-            $ref: '#/definitions/authProviderCore'
+            $ref: '#/definitions/authproviderCore'
         '400':
           description: Validation error (e.g., missing `className`, reserved name `order`, duplicate name, invalid position)
           schema: { $ref: '#/definitions/errorResponse' }
@@ -103,11 +103,11 @@ paths:
           description: Server error
           schema: { $ref: '#/definitions/errorResponse' }
 
-  /security/authProviders/{providerName}:
+  /security/authproviders/{providerName}:
     get:
       summary: Get provider
       operationId: getAuthProvider
-      tags: [authProviders]
+      tags: [authproviders]
       produces: [application/json, application/xml]
       parameters:
         - name: providerName
@@ -118,7 +118,7 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/authProviderCore'
+            $ref: '#/definitions/authproviderCore'
           examples:
             application/json:
               id: 52857278:13c7ffd66a8:-7ff0
@@ -138,7 +138,7 @@ paths:
     put:
       summary: Update provider and/or move its position
       operationId: updateAuthProvider
-      tags: [authProviders]
+      tags: [authproviders]
       consumes: [application/json, application/xml]
       produces: [application/json, application/xml]
       parameters:
@@ -156,13 +156,13 @@ paths:
           required: true
           description: |
             Provider payload.
-            - **XML:** send the provider element itself (no `<authProvider>` wrapper).
-            - **JSON:** send a bare object or an `{ "authProvider": { ... } }` envelope.
+            - **XML:** send the provider element itself (no `<authprovider>` wrapper).
+            - **JSON:** send a bare object or an `{ "authprovider": { ... } }` envelope.
           schema:
-            $ref: '#/definitions/authProviderCore'
+            $ref: '#/definitions/authproviderCore'
           x-examples:
             application/json:
-              authProvider:
+              authprovider:
                 name: default
                 className: org.geoserver.security.auth.UsernamePasswordAuthenticationProvider
                 userGroupServiceName: default
@@ -176,7 +176,7 @@ paths:
         '200':
           description: Updated
           schema:
-            $ref: '#/definitions/authProviderCore'
+            $ref: '#/definitions/authproviderCore'
         '400':
           description: Validation error (e.g., path/payload name mismatch, `className` change, invalid position)
           schema: { $ref: '#/definitions/errorResponse' }
@@ -193,7 +193,7 @@ paths:
     delete:
       summary: Delete provider (also removes it from the active order)
       operationId: deleteAuthProvider
-      tags: [authProviders]
+      tags: [authproviders]
       produces: [application/json, application/xml]
       parameters:
         - name: providerName
@@ -213,11 +213,11 @@ paths:
           description: Server error
           schema: { $ref: '#/definitions/errorResponse' }
 
-  /security/authProviders/order:
+  /security/authproviders/order:
     put:
       summary: Replace active order (enables/disables providers)
       operationId: setAuthProviderOrder
-      tags: [authProviders]
+      tags: [authproviders]
       consumes: [application/json, application/xml]
       produces: [application/json, application/xml]
       parameters:
@@ -225,7 +225,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/authProviderOrder'
+            $ref: '#/definitions/authproviderOrder'
           x-examples:
             application/json:
               order: [default, corporateLdap]
@@ -271,18 +271,18 @@ paths:
           description: Use PUT
 
 definitions:
-  # Envelope used for list responses (JSON); XML root is also <authProviders>
-  authProviders:
+  # Envelope used for list responses (JSON); XML root is also <authproviders>
+  authproviders:
     type: object
     properties:
-      authProviders:
+      authproviders:
         type: array
         items:
-          $ref: '#/definitions/authProviderCore'
+          $ref: '#/definitions/authproviderCore'
     xml:
-      name: authProviders
+      name: authproviders
 
-  authProviderCore:
+  authproviderCore:
     type: object
     required: [name, className, userGroupServiceName]
     additionalProperties: true
@@ -302,7 +302,7 @@ definitions:
     xml:
       name: org.geoserver.security.config.UsernamePasswordAuthenticationProviderConfig
 
-  authProviderOrder:
+  authproviderOrder:
     type: object
     required: [order]
     properties:

--- a/doc/en/user/source/rest/api/authenticationproviders.rst
+++ b/doc/en/user/source/rest/api/authenticationproviders.rst
@@ -19,8 +19,8 @@ Content types
 
 - ``application/xml`` — uses the concrete config class name as the element
 - ``application/json`` — plain objects; request envelopes supported:
-  - ``{ "authProvider": { … } }`` for single
-  - ``{ "authProviders": [ { … }, … ] }`` for lists
+  - ``{ "authprovider": { … } }`` for single
+  - ``{ "authproviders": [ { … }, … ] }`` for lists
 
 Status codes
 ------------
@@ -42,15 +42,15 @@ Error body
 Endpoints
 ---------
 
-``GET /security/authProviders``
+``GET /security/authproviders``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 List providers in **active order**.
 
 - Produces: XML, JSON
-- Returns: object with ``authProviders`` array; each entry is a provider
+- Returns: object with ``authproviders`` array; each entry is a provider
 
-``POST /security/authProviders``
+``POST /security/authproviders``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create a provider; optionally **insert at position** via ``?position=N`` (0-based).
@@ -84,7 +84,7 @@ Rules:
 - Duplicate names rejected
 - ``position`` must be within ``[0..size]``
 
-``GET /security/authProviders/{providerName}``
+``GET /security/authproviders/{providerName}``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Retrieve a provider by name (``.xml``/``.json`` suffix in the name is accepted and normalized).
@@ -92,7 +92,7 @@ Retrieve a provider by name (``.xml``/``.json`` suffix in the name is accepted a
 - Produces: XML, JSON
 - Response: provider object
 
-``PUT /security/authProviders/{providerName}``
+``PUT /security/authproviders/{providerName}``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Update a provider and/or **move** it via ``?position=N``.
@@ -123,7 +123,7 @@ Rules:
 - ``className`` cannot change (omit to keep)
 - ``position`` clamped to list bounds; if omitted, order unchanged
 
-``DELETE /security/authProviders/{providerName}``
+``DELETE /security/authproviders/{providerName}``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Delete a provider and remove it from the active order.
@@ -131,7 +131,7 @@ Delete a provider and remove it from the active order.
 - Produces: XML, JSON
 - Response: ``200`` (empty body)
 
-``PUT /security/authProviders/order``
+``PUT /security/authproviders/order``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Replace the **active order**.

--- a/doc/en/user/source/rest/authenticationproviders.rst
+++ b/doc/en/user/source/rest/authenticationproviders.rst
@@ -21,7 +21,7 @@ Representation
      </org.geoserver.security.config.UsernamePasswordAuthenticationProviderConfig>
 
 - **JSON** requests/responses are **plain objects** (example below). For requests,
-  the controller also accepts the **envelope** ``{ "authProvider": { … } }``.
+  the controller also accepts the **envelope** ``{ "authprovider": { … } }``.
 
 General rules
 -------------
@@ -32,7 +32,7 @@ General rules
   - ``className`` **cannot change**; omit it to keep the current value.
   - ``id`` may be omitted; the existing value is preserved.
 - **Order & enable/disable:**
-  - The active list in the security config (``<authProviderNames>``) defines both **order** and **which providers are enabled**.
+  - The active list in the security config (``<authproviderNames>``) defines both **order** and **which providers are enabled**.
   - Names **present** = enabled (in that order). Names **absent** = disabled (kept on disk).
 
 Base URL
@@ -43,7 +43,7 @@ All examples assume:
 ``http://localhost:8080/geoserver/rest``
 
 ------------------------------------------------
-List providers — ``GET /security/authProviders``
+List providers — ``GET /security/authproviders``
 ------------------------------------------------
 
 Returns providers in the **current active order**.
@@ -52,33 +52,33 @@ Returns providers in the **current active order**.
 
    curl -u admin:•••• \
         -H "Accept: application/xml" \
-        http://localhost:8080/geoserver/rest/security/authProviders
+        http://localhost:8080/geoserver/rest/security/authproviders
 
 **Response 200 (XML)**
 
 .. code-block:: xml
 
-   <authProviders>
+   <authproviders>
      <org.geoserver.security.config.UsernamePasswordAuthenticationProviderConfig>
        <id>52857278:13c7ffd66a8:-7ff0</id>
        <name>default</name>
        <className>org.geoserver.security.auth.UsernamePasswordAuthenticationProvider</className>
        <userGroupServiceName>default</userGroupServiceName>
      </org.geoserver.security.config.UsernamePasswordAuthenticationProviderConfig>
-   </authProviders>
+   </authproviders>
 
 .. admonition:: curl (JSON)
 
    curl -u admin:•••• \
         -H "Accept: application/json" \
-        http://localhost:8080/geoserver/rest/security/authProviders
+        http://localhost:8080/geoserver/rest/security/authproviders
 
 **Response 200 (JSON)**
 
 .. code-block:: json
 
    {
-     "authProviders": [
+     "authproviders": [
        {
          "id": "52857278:13c7ffd66a8:-7ff0",
          "name": "default",
@@ -89,14 +89,14 @@ Returns providers in the **current active order**.
    }
 
 ---------------------------------------------------------------
-Get a provider — ``GET /security/authProviders/{providerName}``
+Get a provider — ``GET /security/authproviders/{providerName}``
 ---------------------------------------------------------------
 
 .. admonition:: curl (XML)
 
    curl -u admin:•••• \
         -H "Accept: application/xml" \
-        http://localhost:8080/geoserver/rest/security/authProviders/default
+        http://localhost:8080/geoserver/rest/security/authproviders/default
 
 **Response 200 (XML)**
 
@@ -123,7 +123,7 @@ Get a provider — ``GET /security/authProviders/{providerName}``
 Status: ``200``, ``403``, ``404``, ``500``
 
 ----------------------------------------------------
-Create a provider — ``POST /security/authProviders``
+Create a provider — ``POST /security/authproviders``
 ----------------------------------------------------
 
 Optional ``?position=N`` (0-based) inserts the new provider at that index; omit to append.
@@ -137,7 +137,7 @@ Optional ``?position=N`` (0-based) inserts the new provider at that index; omit 
            -H "Content-Type: application/xml" \
            -H "Accept: application/xml" \
            --data-binary @- \
-           http://localhost:8080/geoserver/rest/security/authProviders <<'EOF'
+           http://localhost:8080/geoserver/rest/security/authproviders <<'EOF'
       <org.geoserver.security.config.LdapAuthenticationProviderConfig>
         <name>corporateLdap</name>
         <className>org.geoserver.security.auth.LdapAuthenticationProvider</className>
@@ -155,7 +155,7 @@ Optional ``?position=N`` (0-based) inserts the new provider at that index; omit 
            -H "Content-Type: application/json" \
            -H "Accept: application/json" \
            --data '{"name":"corporateLdap","className":"org.geoserver.security.auth.LdapAuthenticationProvider","userGroupServiceName":"ldapUsers"}' \
-           http://localhost:8080/geoserver/rest/security/authProviders
+           http://localhost:8080/geoserver/rest/security/authproviders
 
 .. admonition:: curl (JSON body — envelope)
 
@@ -165,14 +165,14 @@ Optional ``?position=N`` (0-based) inserts the new provider at that index; omit 
            -X POST \
            -H "Content-Type: application/json" \
            -H "Accept: application/json" \
-           --data '{"authProvider":{"name":"corporateLdap","className":"org.geoserver.security.auth.LdapAuthenticationProvider","userGroupServiceName":"ldapUsers"}}' \
-           http://localhost:8080/geoserver/rest/security/authProviders
+           --data '{"authprovider":{"name":"corporateLdap","className":"org.geoserver.security.auth.LdapAuthenticationProvider","userGroupServiceName":"ldapUsers"}}' \
+           http://localhost:8080/geoserver/rest/security/authproviders
 
 **Response 201**
 
 .. code-block:: none
 
-   Location: /geoserver/rest/security/authProviders/corporateLdap
+   Location: /geoserver/rest/security/authproviders/corporateLdap
 
 Body echoes the created provider with a server-assigned ``id``.
 
@@ -180,7 +180,7 @@ Status: ``201``, ``400`` (validation/duplicate/reserved name/position), ``403``,
 
 
 ------------------------------------------------------------------
-Update a provider — ``PUT /security/authProviders/{providerName}``
+Update a provider — ``PUT /security/authproviders/{providerName}``
 ------------------------------------------------------------------
 
 You may also **move** a provider by adding ``?position=N``.
@@ -200,7 +200,7 @@ Rules recap:
            -H "Content-Type: application/xml" \
            -H "Accept: application/xml" \
            --data-binary @- \
-           "http://localhost:8080/geoserver/rest/security/authProviders/corporateLdap?position=0" <<'EOF'
+           "http://localhost:8080/geoserver/rest/security/authproviders/corporateLdap?position=0" <<'EOF'
       <org.geoserver.security.config.LdapAuthenticationProviderConfig>
         <name>corporateLdap</name>
         <className>org.geoserver.security.auth.LdapAuthenticationProvider</className>
@@ -217,7 +217,7 @@ Rules recap:
            -H "Content-Type: application/json" \
            -H "Accept: application/json" \
            --data '{"name":"corporateLdap","className":"org.geoserver.security.auth.LdapAuthenticationProvider","userGroupServiceName":"ldapUsers"}' \
-           "http://localhost:8080/geoserver/rest/security/authProviders/corporateLdap?position=0"
+           "http://localhost:8080/geoserver/rest/security/authproviders/corporateLdap?position=0"
 
 **Response 200** returns the updated provider.
 
@@ -227,7 +227,7 @@ Rules recap:
 
 
 ---------------------------------------------------------------------
-Delete a provider — ``DELETE /security/authProviders/{providerName}``
+Delete a provider — ``DELETE /security/authproviders/{providerName}``
 ---------------------------------------------------------------------
 
 Removes the provider **and** drops it from the active order.
@@ -238,14 +238,14 @@ Removes the provider **and** drops it from the active order.
 
       curl -u admin:•••• \
            -X DELETE \
-           http://localhost:8080/geoserver/rest/security/authProviders/corporateLdap
+           http://localhost:8080/geoserver/rest/security/authproviders/corporateLdap
 
 .. rubric:: Status codes
 
 ``200``, ``403``, ``404`` (not found), ``410`` (already removed), ``500``
 
 -------------------------------------------------------------------
-Re-order / enable / disable — ``PUT /security/authProviders/order``
+Re-order / enable / disable — ``PUT /security/authproviders/order``
 -------------------------------------------------------------------
 
 Send the **complete** list of provider names in the desired order:
@@ -263,7 +263,7 @@ Only **PUT** is allowed.
            -X PUT \
            -H "Content-Type: application/json" \
            --data '{"order":["corporateLdap","default"]}' \
-           http://localhost:8080/geoserver/rest/security/authProviders/order
+           http://localhost:8080/geoserver/rest/security/authproviders/order
 
 .. admonition:: curl (XML)
 
@@ -273,7 +273,7 @@ Only **PUT** is allowed.
            -X PUT \
            -H "Content-Type: application/xml" \
            --data-binary @- \
-           http://localhost:8080/geoserver/rest/security/authProviders/order <<'EOF'
+           http://localhost:8080/geoserver/rest/security/authproviders/order <<'EOF'
       <order>
         <order>corporateLdap</order>
         <order>default</order>

--- a/src/restconfig/src/main/java/org/geoserver/rest/security/AuthenticationProviderRestController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/security/AuthenticationProviderRestController.java
@@ -54,16 +54,16 @@ import org.springframework.web.util.UriComponentsBuilder;
  * <h3>Resources</h3>
  *
  * <ul>
- *   <li><code>GET /security/authProviders</code> – list enabled providers (in effective order).
- *   <li><code>GET /security/authProviders/{name}</code> – fetch a single provider config.
- *   <li><code>POST /security/authProviders?position={pos}</code> – create a provider and insert it into the enabled
+ *   <li><code>GET /security/authproviders</code> – list enabled providers (in effective order).
+ *   <li><code>GET /security/authproviders/{name}</code> – fetch a single provider config.
+ *   <li><code>POST /security/authproviders?position={pos}</code> – create a provider and insert it into the enabled
  *       order at the specified position (default: append).
- *   <li><code>PUT /security/authProviders/{name}?position={pos}</code> – update an existing provider and optionally
+ *   <li><code>PUT /security/authproviders/{name}?position={pos}</code> – update an existing provider and optionally
  *       move it to a new position.
- *   <li><code>DELETE /security/authProviders/{name}</code> – remove from order (disable) then delete the provider
+ *   <li><code>DELETE /security/authproviders/{name}</code> – remove from order (disable) then delete the provider
  *       configuration from disk.
- *   <li><code>PUT /security/authProviders/order</code> – set the <em>entire</em> enabled order. The list provided
- *       becomes the canonical {@code <authProviderNames>} in the global security config. Names omitted here remain
+ *   <li><code>PUT /security/authproviders/order</code> – set the <em>entire</em> enabled order. The list provided
+ *       becomes the canonical {@code <authproviderNames>} in the global security config. Names omitted here remain
  *       saved on disk but are considered <strong>disabled</strong>.
  * </ul>
  *
@@ -72,9 +72,9 @@ import org.springframework.web.util.UriComponentsBuilder;
  * All endpoints accept / return XML or JSON. For create/update you may send:
  *
  * <ul>
- *   <li>JSON: a single provider under <code>{"authProvider": {...}}</code>, or <code>{"authProviders":[{...}]}</code>
+ *   <li>JSON: a single provider under <code>{"authprovider": {...}}</code>, or <code>{"authproviders":[{...}]}</code>
  *       with exactly one item.
- *   <li>XML: a single {@link SecurityAuthProviderConfig} element, or an <code>&lt;authProviders&gt;</code> wrapper with
+ *   <li>XML: a single {@link SecurityAuthProviderConfig} element, or an <code>&lt;authproviders&gt;</code> wrapper with
  *       exactly one provider.
  * </ul>
  *
@@ -94,7 +94,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * All operations require an authenticated admin; otherwise HTTP 403 is returned.
  */
 @RestController
-@RequestMapping(RestBaseController.ROOT_PATH + "/security/authProviders")
+@RequestMapping(RestBaseController.ROOT_PATH + "/security/authproviders")
 public class AuthenticationProviderRestController extends RestBaseController {
 
     /**
@@ -122,7 +122,7 @@ public class AuthenticationProviderRestController extends RestBaseController {
 
         xs.allowTypesByWildcard(new String[] {"org.geoserver.rest.security.xml.*"});
 
-        xs.alias("authProviders", AuthProviderCollection.class);
+        xs.alias("authproviders", AuthProviderCollection.class);
         xs.addImplicitCollection(AuthProviderCollection.class, "providers", null, SecurityAuthProviderConfig.class);
 
         xs.alias("order", AuthProviderOrder.class);
@@ -131,7 +131,7 @@ public class AuthenticationProviderRestController extends RestBaseController {
 
     // ------------------------------------------------------------------------ LIST + ITEM --------
 
-    /** List the enabled providers in the current effective order (i.e. the global {@code <authProviderNames>}). */
+    /** List the enabled providers in the current effective order (i.e. the global {@code <authproviderNames>}). */
     @GetMapping(
             path = {"", ".{ext:xml|json}"},
             produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
@@ -199,7 +199,7 @@ public class AuthenticationProviderRestController extends RestBaseController {
             securityManager.reload();
 
             HttpHeaders h = new HttpHeaders();
-            h.setLocation(builder.path("/security/authProviders/{name}")
+            h.setLocation(builder.path("/security/authproviders/{name}")
                     .buildAndExpand(cfg.getName())
                     .toUri());
             return new ResponseEntity<>(wrapObject(cfg, SecurityAuthProviderConfig.class), h, HttpStatus.CREATED);
@@ -319,7 +319,7 @@ public class AuthenticationProviderRestController extends RestBaseController {
     // --------------------------------------------------------------------------- /order API -------
 
     /**
-     * Replace the entire enabled order. The supplied list becomes the exact content of {@code <authProviderNames>} in
+     * Replace the entire enabled order. The supplied list becomes the exact content of {@code <authproviderNames>} in
      * the global security configuration. Providers not listed remain saved on disk but are disabled.
      *
      * <p>Payloads:
@@ -463,12 +463,12 @@ public class AuthenticationProviderRestController extends RestBaseController {
         JsonNode n = MAPPER.readTree(body);
         if (n == null || n.isNull()) throw new BadRequest("Empty JSON payload");
 
-        // unwrap "authProvider" or single-item "authProviders"
-        if (n.has("authProvider")) n = n.get("authProvider");
-        if (n.has("authProviders")
-                && n.get("authProviders").isArray()
-                && n.get("authProviders").size() == 1) {
-            n = n.get("authProviders").get(0);
+        // unwrap "authprovider" or single-item "authproviders"
+        if (n.has("authprovider")) n = n.get("authprovider");
+        if (n.has("authproviders")
+                && n.get("authproviders").isArray()
+                && n.get("authproviders").size() == 1) {
+            n = n.get("authproviders").get(0);
         }
         if (!n.isObject()) throw new BadRequest("Malformed JSON payload");
 

--- a/src/restconfig/src/main/java/org/geoserver/rest/security/xml/AuthProviderCollection.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/security/xml/AuthProviderCollection.java
@@ -18,16 +18,16 @@ import org.geoserver.security.config.SecurityAuthProviderConfig;
  * serializes like:
  *
  * <pre>{@code
- * <authProviders>
+ * <authproviders>
  *   <org.geoserver.security.config.UsernamePasswordAuthenticationProviderConfig>...</...>
  *   ...
- * </authProviders>
+ * </authproviders>
  * }</pre>
  *
  * <p>This class exposes a null-safe API and uses defensive copies in setters/getters while keeping a mutable field so
  * XStream can populate it directly.
  */
-@XStreamAlias("authProviders")
+@XStreamAlias("authproviders")
 public class AuthProviderCollection {
 
     /** Backing list used by XStream implicit collection. Do not make final. */

--- a/src/restconfig/src/test/java/org/geoserver/rest/security/AuthenticationProviderRestControllerMarshallingTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/security/AuthenticationProviderRestControllerMarshallingTest.java
@@ -38,18 +38,18 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
- * System tests for the REST resource {@code /security/authProviders}.
+ * System tests for the REST resource {@code /security/authproviders}.
  *
  * <p>These tests go through the HTTP layer using the GeoServer test harness and verify:
  *
  * <ul>
  *   <li>JSON/XML marshaling shapes,
  *   <li>headers and status codes,
- *   <li>side effects on the enabled order (authProviderNames).
+ *   <li>side effects on the enabled order (authproviderNames).
  * </ul>
  *
  * <p>XStream may produce different JSON shapes: FQN-keyed ({@code {"<FQN>": {...}}}), enveloped
- * ({@code {"authProvider": {...}}}), or a bare object. Helpers below normalize these shapes for assertions.
+ * ({@code {"authprovider": {...}}}), or a bare object. Helpers below normalize these shapes for assertions.
  */
 public class AuthenticationProviderRestControllerMarshallingTest extends GeoServerSystemTestSupport {
 
@@ -84,7 +84,7 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
             // restore order to just ["default"] (best effort)
             try {
                 adminPUT(
-                        BASE + "/security/authProviders/order",
+                        BASE + "/security/authproviders/order",
                         "{\"order\":[\"default\"]}".getBytes(StandardCharsets.UTF_8),
                         "application/json",
                         200);
@@ -93,7 +93,7 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
             }
             for (String n : created) {
                 try {
-                    adminDELETE(BASE + "/security/authProviders/" + n);
+                    adminDELETE(BASE + "/security/authproviders/" + n);
                 } catch (Exception ignored) {
                     // ignore cleanup hiccups
                 }
@@ -179,7 +179,7 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         inner.put("className", CLASSNAME_UP);
         inner.put("userGroupServiceName", "default");
         JSONObject root = new JSONObject();
-        root.put("authProvider", inner);
+        root.put("authprovider", inner);
         return root.toString();
     }
 
@@ -190,7 +190,7 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         inner.put("className", CLASSNAME_UP);
         inner.put("userGroupServiceName", "default");
         JSONObject root = new JSONObject();
-        root.put("authProvider", inner);
+        root.put("authprovider", inner);
         return root.toString();
     }
 
@@ -215,8 +215,8 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
     // ---------------------------------------------------------------------
 
     private static JSONObject unwrapSingle(JSONObject root) {
-        if (root.containsKey("authProvider")) {
-            return root.getJSONObject("authProvider");
+        if (root.containsKey("authprovider")) {
+            return root.getJSONObject("authprovider");
         }
         if (root.size() == 1) {
             String key = (String) root.keySet().iterator().next();
@@ -232,7 +232,7 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         if (root.containsKey("status")) {
             throw new AssertionError("Server returned error: " + root);
         }
-        Object ap = root.get("authProviders");
+        Object ap = root.get("authproviders");
         if (ap instanceof JSONArray) {
             JSONArray out = new JSONArray();
             for (Object o : ((JSONArray) ap)) out.add(unwrapSingle((JSONObject) o));
@@ -249,7 +249,7 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
                 return out;
             }
         }
-        throw new AssertionError("Unrecognized authProviders JSON shape: " + root);
+        throw new AssertionError("Unrecognized authproviders JSON shape: " + root);
     }
 
     private static List<String> names(JSONArray arr) {
@@ -270,20 +270,20 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         created.add(a);
         created.add(b);
 
-        adminPOST(BASE + "/security/authProviders", xml(xmlCreate(a)), "application/xml");
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(b)), "application/json");
+        adminPOST(BASE + "/security/authproviders", xml(xmlCreate(a)), "application/xml");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(b)), "application/json");
 
         adminPUT(
-                BASE + "/security/authProviders/order",
+                BASE + "/security/authproviders/order",
                 json("{\"order\":[\"" + a + "\",\"" + b + "\"]}"),
                 "application/json",
                 200);
 
-        String xmlList = adminGETString200(BASE + "/security/authProviders.xml");
-        assertThat(xmlList, containsString("<authProviders>"));
+        String xmlList = adminGETString200(BASE + "/security/authproviders.xml");
+        assertThat(xmlList, containsString("<authproviders>"));
         assertThat(xmlList, containsString("<" + FQN_CFG + ">"));
 
-        JSON j = adminGETJSON(BASE + "/security/authProviders.json");
+        JSON j = adminGETJSON(BASE + "/security/authproviders.json");
         JSONArray items = unwrapList(j);
         boolean sawA = false, sawB = false;
         for (Object o : items) {
@@ -300,13 +300,13 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         String name = "MARSHAL-" + System.nanoTime() + "-view";
         created.add(name);
 
-        adminPOST(BASE + "/security/authProviders", xml(xmlCreate(name)), "application/xml");
+        adminPOST(BASE + "/security/authproviders", xml(xmlCreate(name)), "application/xml");
 
-        String xml = adminGETString200(BASE + "/security/authProviders/" + name + ".xml");
+        String xml = adminGETString200(BASE + "/security/authproviders/" + name + ".xml");
         assertThat(xml, containsString("<" + FQN_CFG + ">"));
         assertThat(xml, containsString("<name>" + name + "</name>"));
 
-        JSON j = adminGETJSON(BASE + "/security/authProviders/" + name + ".json");
+        JSON j = adminGETJSON(BASE + "/security/authproviders/" + name + ".json");
         JSONObject core = unwrapSingle((JSONObject) j);
         assertEquals(name, core.getString("name"));
         assertEquals(CLASSNAME_UP, core.getString("className"));
@@ -324,13 +324,13 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         created.add(name);
 
         MockHttpServletResponse r =
-                adminPOST(BASE + "/security/authProviders", json(jsonCreate(name)), "application/json");
+                adminPOST(BASE + "/security/authproviders", json(jsonCreate(name)), "application/json");
         assertEquals(201, r.getStatus());
         String loc = r.getHeader("Location");
         assertNotNull(loc);
-        assertTrue(loc.endsWith("/security/authProviders/" + name));
+        assertTrue(loc.endsWith("/security/authproviders/" + name));
 
-        JSON j = adminGETJSON(BASE + "/security/authProviders/" + name + ".json");
+        JSON j = adminGETJSON(BASE + "/security/authproviders/" + name + ".json");
         JSONObject core = unwrapSingle((JSONObject) j);
         assertEquals(name, core.getString("name"));
         assertEquals(CLASSNAME_UP, core.getString("className"));
@@ -342,9 +342,9 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         String name = "MARSHAL-" + System.nanoTime() + "-create-envelope";
         created.add(name);
 
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(name)), "application/json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(name)), "application/json");
 
-        JSON j = adminGETJSON(BASE + "/security/authProviders.json");
+        JSON j = adminGETJSON(BASE + "/security/authproviders.json");
         JSONArray items = unwrapList(j);
         boolean saw = false;
         for (Object o : items) if (name.equals(((JSONObject) o).optString("name"))) saw = true;
@@ -358,11 +358,11 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         created.add(name);
 
         MockHttpServletResponse r1 =
-                adminPOST(BASE + "/security/authProviders", json(jsonCreate(name)), "application/json");
+                adminPOST(BASE + "/security/authproviders", json(jsonCreate(name)), "application/json");
         assertEquals(201, r1.getStatus());
 
         MockHttpServletResponse r2 =
-                adminPOST(BASE + "/security/authProviders", json(jsonCreate(name)), "application/json");
+                adminPOST(BASE + "/security/authproviders", json(jsonCreate(name)), "application/json");
         assertEquals(400, r2.getStatus());
         assertThat(r2.getContentAsString(), containsString("already exists"));
     }
@@ -374,10 +374,10 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         created.add(name);
 
         MockHttpServletResponse r =
-                adminPOST(BASE + "/security/authProviders?position=0", xml(xmlCreate(name)), "application/xml");
+                adminPOST(BASE + "/security/authproviders?position=0", xml(xmlCreate(name)), "application/xml");
         assertEquals(201, r.getStatus());
 
-        JSON j = adminGETJSON(BASE + "/security/authProviders.json");
+        JSON j = adminGETJSON(BASE + "/security/authproviders.json");
         JSONArray items = unwrapList(j);
         assertEquals(name, ((JSONObject) items.get(0)).optString("name"));
     }
@@ -386,7 +386,7 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
     @Test
     public void create_json_reserved_name_order_400() throws Exception {
         MockHttpServletResponse r =
-                adminPOST(BASE + "/security/authProviders", json(jsonCreate("order")), "application/json");
+                adminPOST(BASE + "/security/authproviders", json(jsonCreate("order")), "application/json");
         assertEquals(400, r.getStatus());
         assertThat(r.getContentAsString(), containsString("reserved"));
     }
@@ -397,10 +397,10 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         JSONObject inner = new JSONObject();
         inner.put("name", "MARSHAL-" + System.nanoTime() + "-nocls");
         JSONObject root = new JSONObject();
-        root.put("authProvider", inner);
+        root.put("authprovider", inner);
 
         MockHttpServletResponse r =
-                adminPOST(BASE + "/security/authProviders", json(root.toString()), "application/json");
+                adminPOST(BASE + "/security/authproviders", json(root.toString()), "application/json");
         assertEquals(400, r.getStatus());
     }
 
@@ -416,23 +416,23 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         created.add(a);
         created.add(b);
 
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(a)), "application/json");
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(b)), "application/json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(a)), "application/json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(b)), "application/json");
 
         adminPUT(
-                BASE + "/security/authProviders/order",
+                BASE + "/security/authproviders/order",
                 json("{\"order\":[\"" + a + "\",\"" + b + "\"]}"),
                 "application/json",
                 200);
 
-        JSON jA = adminGETJSON(BASE + "/security/authProviders/" + a + ".json");
+        JSON jA = adminGETJSON(BASE + "/security/authproviders/" + a + ".json");
         String idA = unwrapSingle((JSONObject) jA).getString("id");
 
         MockHttpServletResponse up = adminPUT(
-                BASE + "/security/authProviders/" + a + "?position=1", json(jsonUpdate(idA, a)), "application/json");
+                BASE + "/security/authproviders/" + a + "?position=1", json(jsonUpdate(idA, a)), "application/json");
         assertEquals(200, up.getStatus());
 
-        JSON list = adminGETJSON(BASE + "/security/authProviders.json");
+        JSON list = adminGETJSON(BASE + "/security/authproviders.json");
         JSONArray items = unwrapList(list);
         List<String> order = new ArrayList<>();
         for (Object o : items) order.add(((JSONObject) o).optString("name"));
@@ -445,8 +445,8 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         String name = "MARSHAL-" + System.nanoTime() + "-cls";
         created.add(name);
 
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(name)), "application/json");
-        JSON j = adminGETJSON(BASE + "/security/authProviders/" + name + ".json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(name)), "application/json");
+        JSON j = adminGETJSON(BASE + "/security/authproviders/" + name + ".json");
         String id = unwrapSingle((JSONObject) j).getString("id");
 
         JSONObject inner = new JSONObject();
@@ -455,10 +455,10 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         inner.put("className", "org.geoserver.security.auth.SomeOtherProvider");
         inner.put("userGroupServiceName", "default");
         JSONObject root = new JSONObject();
-        root.put("authProvider", inner);
+        root.put("authprovider", inner);
 
         MockHttpServletResponse up =
-                adminPUT(BASE + "/security/authProviders/" + name, json(root.toString()), "application/json", 400);
+                adminPUT(BASE + "/security/authproviders/" + name, json(root.toString()), "application/json", 400);
         assertThat(up.getContentAsString(), containsString("Unsupported className"));
     }
 
@@ -468,8 +468,8 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         String name = "MARSHAL-" + System.nanoTime() + "-mismatch";
         created.add(name);
 
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(name)), "application/json");
-        JSON j = adminGETJSON(BASE + "/security/authProviders/" + name + ".json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(name)), "application/json");
+        JSON j = adminGETJSON(BASE + "/security/authproviders/" + name + ".json");
         String id = unwrapSingle((JSONObject) j).getString("id");
 
         String other = name + "-other";
@@ -479,10 +479,10 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         inner.put("className", CLASSNAME_UP);
         inner.put("userGroupServiceName", "default");
         JSONObject root = new JSONObject();
-        root.put("authProvider", inner);
+        root.put("authprovider", inner);
 
         MockHttpServletResponse up =
-                adminPUT(BASE + "/security/authProviders/" + name, json(root.toString()), "application/json", 400);
+                adminPUT(BASE + "/security/authproviders/" + name, json(root.toString()), "application/json", 400);
         assertThat(up.getContentAsString(), containsString("path name and payload name differ"));
     }
 
@@ -491,13 +491,13 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
     public void update_position_out_of_range_400() throws Exception {
         String name = "MARSHAL-" + System.nanoTime() + "-posoor";
         created.add(name);
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(name)), "application/json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(name)), "application/json");
 
-        JSON j = adminGETJSON(BASE + "/security/authProviders/" + name + ".json");
+        JSON j = adminGETJSON(BASE + "/security/authproviders/" + name + ".json");
         String id = unwrapSingle((JSONObject) j).getString("id");
 
         MockHttpServletResponse up = adminPUT(
-                BASE + "/security/authProviders/" + name + "?position=9999",
+                BASE + "/security/authproviders/" + name + "?position=9999",
                 json(jsonUpdate(id, name)),
                 "application/json",
                 400);
@@ -516,22 +516,22 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         created.add(a);
         created.add(b);
 
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(a)), "application/json");
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(b)), "application/json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(a)), "application/json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(b)), "application/json");
 
         adminPUT(
-                BASE + "/security/authProviders/order",
+                BASE + "/security/authproviders/order",
                 json("{\"order\":[\"" + a + "\",\"" + b + "\"]}"),
                 "application/json",
                 200);
 
-        JSON j1 = adminGETJSON(BASE + "/security/authProviders.json");
+        JSON j1 = adminGETJSON(BASE + "/security/authproviders.json");
         List<String> order1 = names(unwrapList(j1));
         assertThat(order1, contains(a, b));
 
-        adminPUT(BASE + "/security/authProviders/order", json("{\"order\":[\"" + b + "\"]}"), "application/json", 200);
+        adminPUT(BASE + "/security/authproviders/order", json("{\"order\":[\"" + b + "\"]}"), "application/json", 200);
 
-        JSON j2 = adminGETJSON(BASE + "/security/authProviders.json");
+        JSON j2 = adminGETJSON(BASE + "/security/authproviders.json");
         List<String> order2 = names(unwrapList(j2));
         assertThat(order2, contains(b));
         assertThat(order2, not(hasItem(a)));
@@ -546,13 +546,13 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
     public void delete_removes_provider_from_list() throws Exception {
         String name = "MARSHAL-" + System.nanoTime() + "-del";
         created.add(name);
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(name)), "application/json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(name)), "application/json");
 
-        MockHttpServletResponse del = adminDELETE(BASE + "/security/authProviders/" + name);
+        MockHttpServletResponse del = adminDELETE(BASE + "/security/authproviders/" + name);
         assertEquals(200, del.getStatus());
         created.remove(name); // already deleted
 
-        JSON j = adminGETJSON(BASE + "/security/authProviders.json");
+        JSON j = adminGETJSON(BASE + "/security/authproviders.json");
         JSONArray items = unwrapList(j);
         boolean present = false;
         for (Object o : items) if (name.equals(((JSONObject) o).optString("name"))) present = true;
@@ -565,10 +565,10 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
         String name = "MARSHAL-" + System.nanoTime() + "-del403";
         created.add(name);
 
-        adminPOST(BASE + "/security/authProviders", json(jsonCreate(name)), "application/json");
+        adminPOST(BASE + "/security/authproviders", json(jsonCreate(name)), "application/json");
 
         clearAuth(); // simulate no user
-        MockHttpServletRequest req = createRequest(BASE + "/security/authProviders/" + name);
+        MockHttpServletRequest req = createRequest(BASE + "/security/authproviders/" + name);
         req.setMethod("DELETE");
         MockHttpServletResponse r = dispatch(req);
         assertEquals(403, r.getStatus());
@@ -580,11 +580,11 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
     // Tests: security / method constraints
     // ---------------------------------------------------------------------
 
-    /** GET /security/authProviders without authentication is forbidden (403). */
+    /** GET /security/authproviders without authentication is forbidden (403). */
     @Test
     public void list_not_authorised_403() throws Exception {
         clearAuth(); // IMPORTANT: @Before logs in as admin; clear it here
-        MockHttpServletRequest req = createRequest(BASE + "/security/authProviders");
+        MockHttpServletRequest req = createRequest(BASE + "/security/authproviders");
         req.setMethod("GET");
         MockHttpServletResponse r = dispatch(req);
         assertEquals(403, r.getStatus());
@@ -594,15 +594,15 @@ public class AuthenticationProviderRestControllerMarshallingTest extends GeoServ
     @Test
     public void order_wrong_methods_405() throws Exception {
         // GET
-        MockHttpServletRequest g = createRequest(BASE + "/security/authProviders/order");
+        MockHttpServletRequest g = createRequest(BASE + "/security/authproviders/order");
         g.setMethod("GET");
         assertEquals(405, dispatch(g).getStatus());
         // POST
-        MockHttpServletRequest p = createRequest(BASE + "/security/authProviders/order");
+        MockHttpServletRequest p = createRequest(BASE + "/security/authproviders/order");
         p.setMethod("POST");
         assertEquals(405, dispatch(p).getStatus());
         // DELETE
-        MockHttpServletRequest d = createRequest(BASE + "/security/authProviders/order");
+        MockHttpServletRequest d = createRequest(BASE + "/security/authproviders/order");
         d.setMethod("DELETE");
         assertEquals(405, dispatch(d).getStatus());
     }

--- a/src/restconfig/src/test/java/org/geoserver/rest/security/AuthenticationProviderRestControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/security/AuthenticationProviderRestControllerTest.java
@@ -59,7 +59,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  *   <li>Tests call the controller directly (no MockMvc) to keep them fast and focused on config semantics.
  *   <li>Each test starts from a clean state by removing TEST-* providers from both the on-disk provider list and the
  *       enabled order.
- *   <li>Where relevant, we verify both JSON/XML payload handling and the side effects on &lt;authProviderNames&gt;
+ *   <li>Where relevant, we verify both JSON/XML payload handling and the side effects on &lt;authproviderNames&gt;
  *       (enabled/disabled semantics).
  * </ul>
  */
@@ -189,7 +189,7 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
         inner.put("name", name);
         inner.put("className", className);
         if (ugService != null) inner.put("userGroupServiceName", ugService);
-        return Collections.singletonMap("authProvider", inner);
+        return Collections.singletonMap("authprovider", inner);
     }
 
     // ---------------------------------------------------------------------
@@ -217,7 +217,7 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
             assertThat(names, hasItems(n1, n2));
 
             String xml = toXml(col);
-            assertThat(xml, containsString("<authProviders>"));
+            assertThat(xml, containsString("<authproviders>"));
             assertThat(
                     xml,
                     containsString("<org.geoserver.security.config.UsernamePasswordAuthenticationProviderConfig>"));
@@ -280,7 +280,7 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
             assertEquals(201, resp.getStatusCodeValue());
             HttpHeaders headers = resp.getHeaders();
             assertNotNull(headers.getLocation());
-            assertThat(headers.getLocation().getPath(), is("/security/authProviders/" + name));
+            assertThat(headers.getLocation().getPath(), is("/security/authproviders/" + name));
 
             SecurityAuthProviderConfig createdCfg =
                     (SecurityAuthProviderConfig) resp.getBody().getObject();
@@ -292,7 +292,7 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
         }
     }
 
-    /** create(XML): round-trip; position=0 places it first in &lt;authProviderNames&gt;. */
+    /** create(XML): round-trip; position=0 places it first in &lt;authproviderNames&gt;. */
     @Test
     public void testCreate_XML_roundtrip() throws Exception {
         try {
@@ -342,11 +342,11 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
                 authenticationProviderHelper.createUsernamePasswordAuthenticationProviderConfig(name, false);
 
         controller.create(
-                jsonRequest(Collections.singletonMap("authProvider", p)), null, UriComponentsBuilder.newInstance());
+                jsonRequest(Collections.singletonMap("authprovider", p)), null, UriComponentsBuilder.newInstance());
         created.add(name); // first create succeeded; track it
 
         controller.create(
-                jsonRequest(Collections.singletonMap("authProvider", p)), null, UriComponentsBuilder.newInstance());
+                jsonRequest(Collections.singletonMap("authprovider", p)), null, UriComponentsBuilder.newInstance());
     }
 
     /** create(JSON): missing className -> 400 BadRequest. */
@@ -356,7 +356,7 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
         Map<String, Object> inner = new LinkedHashMap<>();
         inner.put("name", generateName("bad"));
         controller.create(
-                jsonRequest(Collections.singletonMap("authProvider", inner)), null, UriComponentsBuilder.newInstance());
+                jsonRequest(Collections.singletonMap("authprovider", inner)), null, UriComponentsBuilder.newInstance());
     }
 
     /** create(JSON): position out of range -> 400 BadRequest. */
@@ -367,14 +367,14 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
         UsernamePasswordAuthenticationProviderConfig p =
                 authenticationProviderHelper.createUsernamePasswordAuthenticationProviderConfig(name, false);
         controller.create(
-                jsonRequest(Collections.singletonMap("authProvider", p)), 9999, UriComponentsBuilder.newInstance());
+                jsonRequest(Collections.singletonMap("authprovider", p)), 9999, UriComponentsBuilder.newInstance());
     }
 
     // ---------------------------------------------------------------------
     // update
     // ---------------------------------------------------------------------
 
-    /** update(..., position=1): reorders and persists &lt;authProviderNames&gt; without touching IDs/classes. */
+    /** update(..., position=1): reorders and persists &lt;authproviderNames&gt; without touching IDs/classes. */
     @Test
     public void testUpdate_movePosition_andPersist() throws Exception {
         try {
@@ -398,13 +398,13 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
             UsernamePasswordAuthenticationProviderConfig providerA =
                     authenticationProviderHelper.createUsernamePasswordAuthenticationProviderConfig(a, false);
             RestWrapper<SecurityAuthProviderConfig> updated =
-                    controller.update(a, jsonRequest(Collections.singletonMap("authProvider", providerA)), 1);
+                    controller.update(a, jsonRequest(Collections.singletonMap("authprovider", providerA)), 1);
             assertEquals(a, ((SecurityAuthProviderConfig) updated.getObject()).getName());
 
             List<String> after = getSecurityManager().loadSecurityConfig().getAuthProviderNames();
             assertThat(after, is(Arrays.asList(b, a)));
 
-            // enabled == names present in <authProviderNames>
+            // enabled == names present in <authproviderNames>
             Set<String> enabled = new LinkedHashSet<>(after);
             Set<String> saved = getSecurityManager().listAuthenticationProviders();
             assertThat(enabled, is(new LinkedHashSet<>(Arrays.asList(b, a))));
@@ -434,7 +434,7 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
             UsernamePasswordAuthenticationProviderConfig wrong =
                     authenticationProviderHelper.createUsernamePasswordAuthenticationProviderConfig(
                             a + "-other", false);
-            controller.update(a, jsonRequest(Collections.singletonMap("authProvider", wrong)), null);
+            controller.update(a, jsonRequest(Collections.singletonMap("authprovider", wrong)), null);
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -451,7 +451,7 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
         UsernamePasswordAuthenticationProviderConfig payload =
                 authenticationProviderHelper.createUsernamePasswordAuthenticationProviderConfig(a, false);
         payload.setClassName("org.geoserver.security.auth.SomeOtherProvider");
-        controller.update(a, jsonRequest(Collections.singletonMap("authProvider", payload)), null);
+        controller.update(a, jsonRequest(Collections.singletonMap("authprovider", payload)), null);
     }
 
     /** update: out-of-range position -> 400 BadRequest (controller validates/clamps per implementation). */
@@ -464,7 +464,7 @@ public class AuthenticationProviderRestControllerTest extends GeoServerTestSuppo
 
         UsernamePasswordAuthenticationProviderConfig payload =
                 authenticationProviderHelper.createUsernamePasswordAuthenticationProviderConfig(a, false);
-        controller.update(a, jsonRequest(Collections.singletonMap("authProvider", payload)), 9999);
+        controller.update(a, jsonRequest(Collections.singletonMap("authprovider", payload)), 9999);
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
…rs - API change: authProviders --> authproviders


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.
