### PR TITLE
[GEOS-11924] Application reload fails with NullPointerException when relinquishLog4jControl parameter is enabled

### DIFF
--- a/src/main/src/main/java/org/geoserver/logging/LoggingInitializer.java
+++ b/src/main/src/main/java/org/geoserver/logging/LoggingInitializer.java
@@ -40,21 +40,24 @@ public class LoggingInitializer implements GeoServerInitializer, ApplicationCont
     @Override
     public void onReload() {
 
-        LoggingInfo previousLogging = listener.getCurrentLogging();
-        LoggingInfo newLogging = geoServer.getLogging();
+        if (!LoggingUtils.relinquishLog4jControl) {
 
-        if (previousLogging != null && !previousLogging.equals(newLogging)) {
-            // No need to re-init logging when nothing changed
-            try {
-                String logLocation = LoggingUtils.getLogFileLocation(newLogging.getLocation(), servletContext);
+            LoggingInfo previousLogging = listener.getCurrentLogging();
+            LoggingInfo newLogging = geoServer.getLogging();
 
-                LoggingUtils.initLogging(
-                        resourceLoader, newLogging.getLevel(), !newLogging.isStdOutLogging(), false, logLocation);
+            if (previousLogging != null && !previousLogging.equals(newLogging)) {
+                // No need to re-init logging when nothing changed
+                try {
+                    String logLocation = LoggingUtils.getLogFileLocation(newLogging.getLocation(), servletContext);
 
-                newLogging.setLocation(logLocation);
-                listener.setCurrentLogging(newLogging);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+                    LoggingUtils.initLogging(
+                            resourceLoader, newLogging.getLevel(), !newLogging.isStdOutLogging(), false, logLocation);
+
+                    newLogging.setLocation(logLocation);
+                    listener.setCurrentLogging(newLogging);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
             }
         }
     }


### PR DESCRIPTION
[![GEOS-11924](https://badgen.net/badge/JIRA/GEOS-11924/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11924) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes a NullPointerException on application reload when relinquishLog4jControl parameter is enabled.

Stack trace:

```
java.lang.NullPointerException: Cannot invoke "org.geoserver.logging.LoggingInitializer$LoggingListener.getCurrentLogging()" because "this.listener" is null
at org.geoserver.logging.LoggingInitializer.onReload(LoggingInitializer.java:43)
at org.geoserver.config.impl.GeoServerImpl.callLifecycleHandlers(GeoServerImpl.java:514)
at org.geoserver.config.impl.GeoServerImpl.reload(GeoServerImpl.java:488)
at org.geoserver.config.impl.GeoServerImpl.reload(GeoServerImpl.java:453)
at org.geoserver.rest.CatalogReloadController.reload(CatalogReloadController.java:28)
```  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).