### PR TITLE
[GEOS-11927] REST security: add UserGroupService REST CRUD + XML/JSON marshalling tests and validation fixes

### DIFF
--- a/doc/en/api/1.0.0/usergroupservices.yaml
+++ b/doc/en/api/1.0.0/usergroupservices.yaml
@@ -1,0 +1,264 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: User Group Services REST endpoints
+  description: >
+    Management of GeoServer User/Group Service configurations. Supports XML and JSON payloads
+    via header-based content negotiation.
+  contact:
+    name: GeoServer
+    email: geoserver-users@osgeo.org
+    url: https://geoserver.org/comm/
+servers:
+  - url: https://localhost:8080/geoserver/rest/security
+  - url: http://localhost:8080/geoserver/rest/security
+tags:
+  - name: UserGroupServices
+    description: User/Group service configuration management
+
+paths:
+  /usergroupservices:
+    get:
+      tags: [UserGroupServices]
+      summary: List user/group services
+      operationId: listUserGroupServices
+      responses:
+        '200':
+          description: List of configured services
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      userGroupService:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/UserGroupServiceSummary'
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/UserGroupServiceSummary'
+              examples:
+                wrapped:
+                  summary: Typical JSON list (wrapped)
+                  value:
+                    userGroupService:
+                      - name: default
+                        className: org.geoserver.security.xml.XMLUserGroupService
+                      - name: ldap
+                        className: org.geoserver.security.ldap.LDAPUserGroupService
+                array:
+                  summary: Alternate as plain array
+                  value:
+                    - name: default
+                      className: org.geoserver.security.xml.XMLUserGroupService
+            application/xml:
+              schema:
+                type: object
+                additionalProperties: true
+              examples:
+                example:
+                  summary: XML list (shape may vary)
+                  value: |
+                    <userGroupService>
+                      <userGroupService>
+                        <name>default</name>
+                        <className>org.geoserver.security.xml.XMLUserGroupService</className>
+                      </userGroupService>
+                      <userGroupService>
+                        <name>ldap</name>
+                        <className>org.geoserver.security.ldap.LDAPUserGroupService</className>
+                      </userGroupService>
+                    </userGroupService>
+    post:
+      tags: [UserGroupServices]
+      summary: Create a new user/group service
+      operationId: createUserGroupService
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserGroupServiceConfigJson'
+            examples:
+              xmlServiceJson:
+                summary: XMLUserGroupService JSON
+                value:
+                  org.geoserver.security.xml.XMLUserGroupServiceConfig:
+                    name: default2
+                    className: org.geoserver.security.xml.XMLUserGroupService
+                    fileName: default2.xml
+                    passwordEncoderName: plainTextPasswordEncoder
+                    passwordPolicyName: default
+              ldapServiceJson:
+                summary: LDAPUserGroupService JSON
+                value:
+                  org.geoserver.security.ldap.LDAPUserGroupServiceConfig:
+                    name: testldaproles
+                    className: org.geoserver.security.ldap.LDAPUserGroupService
+                    serverURL: ldap://localhost:10389/dc=acme,dc=org
+                    groupSearchBase: ou=groups
+                    allGroupsSearchFilter: "cn=*"
+                    groupSearchFilter: "member=uid={0},ou=people,dc=acme,dc=org"
+                    userSearchBase: ou=people
+                    allUsersSearchFilter: "uid=*"
+                    useTLS: true
+                    useNestedParentGroups: true
+                    maxGroupSearchLevel: 10
+                    nestedGroupSearchFilter: "(member={0})"
+                    bindBeforeGroupSearch: true
+                    rolePrefix: ROLE_
+                    convertToUpperCase: true
+                    user: admin
+                    password: geoserver
+                    passwordEncoderName: digestPasswordEncoder
+                    passwordPolicyName: default
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/UserGroupServiceConfigXml'
+            examples:
+              xmlServiceXml:
+                summary: XMLUserGroupService XML
+                value: |
+                  <org.geoserver.security.xml.XMLUserGroupServiceConfig>
+                    <name>default2</name>
+                    <className>org.geoserver.security.xml.XMLUserGroupService</className>
+                    <fileName>default2.xml</fileName>
+                    <passwordEncoderName>plainTextPasswordEncoder</passwordEncoderName>
+                    <passwordPolicyName>default</passwordPolicyName>
+                  </org.geoserver.security.xml.XMLUserGroupServiceConfig>
+              ldapServiceXml:
+                summary: LDAPUserGroupService XML
+                value: |
+                  <org.geoserver.security.ldap.LDAPUserGroupServiceConfig>
+                    <name>testldaproles</name>
+                    <className>org.geoserver.security.ldap.LDAPUserGroupService</className>
+                    <serverURL>ldap://localhost:10389/dc=acme,dc=org</serverURL>
+                    <groupSearchBase>ou=groups</groupSearchBase>
+                    <allGroupsSearchFilter>cn=*</allGroupsSearchFilter>
+                    <groupSearchFilter>member=uid={0},ou=people,dc=acme,dc=org</groupSearchFilter>
+                    <userSearchBase>ou=people</userSearchBase>
+                    <allUsersSearchFilter>uid=*</allUsersSearchFilter>
+                    <useTLS>true</useTLS>
+                    <useNestedParentGroups>true</useNestedParentGroups>
+                    <maxGroupSearchLevel>10</maxGroupSearchLevel>
+                    <nestedGroupSearchFilter>(member={0})</nestedGroupSearchFilter>
+                    <bindBeforeGroupSearch>true</bindBeforeGroupSearch>
+                    <rolePrefix>ROLE_</rolePrefix>
+                    <convertToUpperCase>true</convertToUpperCase>
+                    <user>admin</user>
+                    <password>geoserver</password>
+                    <passwordEncoderName>digestPasswordEncoder</passwordEncoderName>
+                    <passwordPolicyName>default</passwordPolicyName>
+                  </org.geoserver.security.ldap.LDAPUserGroupServiceConfig>
+      responses:
+        '201':
+          description: Created
+          headers:
+            Location:
+              description: URL of the created resource
+              schema: { type: string }
+        '200':
+          description: Created (some deployments return 200)
+        '400':
+          description: Bad request (validation errors or duplicate name)
+        '500':
+          description: Internal server error
+
+  /usergroupservices/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      tags: [UserGroupServices]
+      summary: Get a user/group service
+      operationId: getUserGroupService
+      responses:
+        '200':
+          description: The service configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserGroupServiceConfigJson'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/UserGroupServiceConfigXml'
+        '404':
+          description: Service not found
+    put:
+      tags: [UserGroupServices]
+      summary: Update a user/group service
+      operationId: updateUserGroupService
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserGroupServiceConfigJson'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/UserGroupServiceConfigXml'
+      responses:
+        '200':
+          description: Updated
+        '400':
+          description: >
+            Bad request (name mismatch between path and payload, or service not found)
+        '500':
+          description: Internal server error
+    delete:
+      tags: [UserGroupServices]
+      summary: Delete a user/group service
+      operationId: deleteUserGroupService
+      responses:
+        '200':
+          description: Deleted
+        '404':
+          description: Not found
+        '410':
+          description: Gone (already deleted)
+        '409':
+          description: Conflict (attempt to delete a required service like 'default')
+
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+
+  schemas:
+    UserGroupServiceSummary:
+      type: object
+      required: [name, className]
+      properties:
+        name:
+          type: string
+          description: Service name
+          example: default
+        className:
+          type: string
+          description: Concrete service implementation class
+          example: org.geoserver.security.xml.XMLUserGroupService
+
+    # JSON payloads may be wrapped by a key naming the concrete config class.
+    UserGroupServiceConfigJson:
+      title: User Group Service Config (JSON)
+      type: object
+      additionalProperties: true
+      description: >
+        Polymorphic configuration for a user/group service. For JSON, requests and responses
+        may be wrapped with a key equal to the fully-qualified config class name, e.g.:
+        {"org.geoserver.security.xml.XMLUserGroupServiceConfig": { ... }}.
+
+    # XML payloads use the concrete class name as the root element.
+    UserGroupServiceConfigXml:
+      title: User Group Service Config (XML)
+      type: object
+      additionalProperties: true
+      description: >
+        Polymorphic configuration for a user/group service. For XML, the root element is the
+        fully-qualified concrete config class name (e.g., org.geoserver.security.xml.XMLUserGroupServiceConfig).
+security:
+  - basicAuth: []

--- a/doc/en/user/source/rest/api/index.rst
+++ b/doc/en/user/source/rest/api/index.rst
@@ -38,3 +38,4 @@ This section describes the GeoServer REST configuration API.
    filterchains
    authenticationfilters
    authenticationproviders
+   usergroupservices

--- a/doc/en/user/source/rest/api/usergroupservices.rst
+++ b/doc/en/user/source/rest/api/usergroupservices.rst
@@ -1,0 +1,241 @@
+
+.. _rest_api_usergroupservices:
+
+User Group Services
+===================
+
+Manage **User/Group Services** through the REST API.
+
+This resource lets administrators list, retrieve, create, update, and delete
+*user/group service* configurations (e.g. the default XML file‑based service,
+or an LDAP service).
+
+.. note::
+   You must be authenticated as a user with administrative privileges.
+   Content negotiation is supported via the ``Accept`` and ``Content-Type`` headers
+   (``application/xml`` and ``application/json``).
+
+Collection
+----------
+
+**Endpoint**
+
+``/rest/security/usergroupservices``
+
+**Methods**
+
+- **GET** — List configured services.
+- **POST** — Create a new service.
+
+Item
+----
+
+**Endpoint**
+
+``/rest/security/usergroupservices/{name}``
+
+**Methods**
+
+- **GET** — Retrieve a service configuration.
+- **PUT** — Create or replace *{name}* with the provided configuration.
+- **DELETE** — Remove the service *{name}*.
+
+.. warning::
+   The ``default`` user/group service (or any service marked as required by the installation)
+   cannot be deleted.
+
+Representations
+---------------
+
+XML (XMLUserGroupService)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Minimal XML configuration for the built‑in file‑based service::
+
+  <org.geoserver.security.xml.XMLUserGroupServiceConfig>
+    <name>users1</name>
+    <className>org.geoserver.security.xml.XMLUserGroupService</className>
+    <fileName>users1.xml</fileName>
+    <passwordEncoderName>plainTextPasswordEncoder</passwordEncoderName>
+    <passwordPolicyName>default</passwordPolicyName>
+  </org.geoserver.security.xml.XMLUserGroupServiceConfig>
+
+.. important::
+   ``fileName`` is **required** for ``XMLUserGroupService``.
+
+JSON (XMLUserGroupService)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The equivalent JSON payload::
+
+  {
+    "org.geoserver.security.xml.XMLUserGroupServiceConfig": {
+      "name": "users1",
+      "className": "org.geoserver.security.xml.XMLUserGroupService",
+      "fileName": "users1.xml",
+      "passwordEncoderName": "plainTextPasswordEncoder",
+      "passwordPolicyName": "default"
+    }
+  }
+
+XML (LDAPUserGroupService)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Example configuration for an LDAP‑backed service::
+
+  <org.geoserver.security.ldap.LDAPUserGroupServiceConfig>
+    <name>ldapUsers</name>
+    <className>org.geoserver.security.ldap.LDAPUserGroupService</className>
+    <serverURL>ldap://localhost:10389/dc=acme,dc=org</serverURL>
+    <groupSearchBase>ou=groups</groupSearchBase>
+    <allGroupsSearchFilter>cn=*</allGroupsSearchFilter>
+    <groupSearchFilter>member=uid={0},ou=people,dc=acme,dc=org</groupSearchFilter>
+    <userSearchBase>ou=people</userSearchBase>
+    <allUsersSearchFilter>uid=*</allUsersSearchFilter>
+    <useTLS>true</useTLS>
+    <useNestedParentGroups>true</useNestedParentGroups>
+    <maxGroupSearchLevel>10</maxGroupSearchLevel>
+    <nestedGroupSearchFilter>(member={0})</nestedGroupSearchFilter>
+    <bindBeforeGroupSearch>true</bindBeforeGroupSearch>
+    <rolePrefix>ROLE_</rolePrefix>
+    <convertToUpperCase>true</convertToUpperCase>
+    <user>admin</user>
+    <password>geoserver</password>
+    <passwordEncoderName>digestPasswordEncoder</passwordEncoderName>
+    <passwordPolicyName>default</passwordPolicyName>
+  </org.geoserver.security.ldap.LDAPUserGroupServiceConfig>
+
+JSON (LDAPUserGroupService)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The equivalent JSON payload::
+
+  {
+    "org.geoserver.security.ldap.LDAPUserGroupServiceConfig": {
+      "name": "ldapUsers",
+      "className": "org.geoserver.security.ldap.LDAPUserGroupService",
+      "serverURL": "ldap://localhost:10389/dc=acme,dc=org",
+      "groupSearchBase": "ou=groups",
+      "allGroupsSearchFilter": "cn=*",
+      "groupSearchFilter": "member=uid={0},ou=people,dc=acme,dc=org",
+      "userSearchBase": "ou=people",
+      "allUsersSearchFilter": "uid=*",
+      "useTLS": true,
+      "useNestedParentGroups": true,
+      "maxGroupSearchLevel": 10,
+      "nestedGroupSearchFilter": "(member={0})",
+      "bindBeforeGroupSearch": true,
+      "rolePrefix": "ROLE_",
+      "convertToUpperCase": true,
+      "user": "admin",
+      "password": "geoserver",
+      "passwordEncoderName": "digestPasswordEncoder",
+      "passwordPolicyName": "default"
+    }
+  }
+
+Operations
+----------
+
+List
+~~~~
+
+**GET** ``/rest/security/usergroupservices``
+
+**Response**
+
+- **200 OK** with a document containing the configured services.
+
+**cURL**::
+
+  curl -u admin:geoserver -H "Accept: application/xml" \
+    "http://localhost:8080/geoserver/rest/security/usergroupservices"
+
+Retrieve
+~~~~~~~~
+
+**GET** ``/rest/security/usergroupservices/{name}``
+
+**Response**
+
+- **200 OK** with the service configuration.
+- **404 Not Found** if the service does not exist.
+
+**cURL**::
+
+  curl -u admin:geoserver -H "Accept: application/json" \
+    "http://localhost:8080/geoserver/rest/security/usergroupservices/users1"
+
+Create
+~~~~~~
+
+**POST** ``/rest/security/usergroupservices``
+
+- **Request body**: one of the configuration payloads shown above.
+- **Content-Type**: ``application/xml`` or ``application/json``
+
+**Response**
+
+- **201 Created** (some versions may return **200 OK**) and a ``Location`` header.
+- **400 Bad Request** on validation errors (e.g. missing ``fileName`` for XML service).
+- **400 Bad Request** if a service with the same name already exists.
+
+**cURL**::
+
+  curl -u admin:geoserver -H "Content-Type: application/xml" -H "Accept: application/xml" \
+    -d @xml-usergroup-service.xml \
+    "http://localhost:8080/geoserver/rest/security/usergroupservices"
+
+Update / Replace
+~~~~~~~~~~~~~~~~
+
+**PUT** ``/rest/security/usergroupservices/{name}``
+
+- Replaces (or creates) the service named *{name}* with the provided configuration.
+- The ``name`` inside the payload must match the path parameter.
+
+**Response**
+
+- **200 OK** on successful update, or **201 Created** if newly created.
+- **400 Bad Request** if the payload name does not match the path parameter.
+- **400 Bad Request** on validation errors.
+
+**cURL**::
+
+  curl -u admin:geoserver -X PUT -H "Content-Type: application/json" -H "Accept: application/json" \
+    -d @xml-usergroup-service.json \
+    "http://localhost:8080/geoserver/rest/security/usergroupservices/users1"
+
+Delete
+~~~~~~
+
+**DELETE** ``/rest/security/usergroupservices/{name}``
+
+**Response**
+
+- **200 OK** on successful deletion.
+- **404 Not Found** if the service does not exist (some deployments may return **410 Gone**).
+- **400 Bad Request** if attempting to delete a required service (e.g., the default one).
+
+**cURL**::
+
+  curl -u admin:geoserver -X DELETE \
+    "http://localhost:8080/geoserver/rest/security/usergroupservices/users1"
+
+Content Negotiation
+-------------------
+
+All operations accept/produce both XML and JSON. Either:
+
+- Set headers: ``Accept: application/xml`` and/or ``Content-Type: application/xml`` (or JSON), or
+- Use ``.xml`` / ``.json`` suffixes (if enabled in your deployment).
+
+Notes & Tips
+------------
+
+- When creating an ``XMLUserGroupService``, the file referenced by ``fileName`` will be created
+  under GeoServer's security directory if it does not already exist.
+- For LDAP services, make sure the ``serverURL`` and search parameters match your directory
+  layout. The ``groupSearchFilter`` and ``nestedGroupSearchFilter`` usually need adjustment.
+- Passwords supplied in configuration payloads may be stored according to the chosen
+  ``passwordEncoderName`` and policy.

--- a/doc/en/user/source/rest/index.rst
+++ b/doc/en/user/source/rest/index.rst
@@ -49,6 +49,7 @@ The following links provide direct access to the GeoServer REST API documentatio
 * :api:`/filterChains <filterchains.yaml>`
 * :api:`/authFilters <authenticationfilterconfiguration.yaml>`
 * :api:`/authProviders <authenticationproviders.yaml>`
+* :api:`/usergroupservices <usergroupservices.yaml>`
 
 * GeoWebCache:
 
@@ -104,7 +105,8 @@ This section contains a number of examples which illustrate some of the most com
    urlchecks
    filterchains
    authenticationfilters
-   authenticationproviders   
+   authenticationproviders
+   usergroupservices
 
 .. toctree::
    :maxdepth: 1

--- a/doc/en/user/source/rest/usergroupservices.rst
+++ b/doc/en/user/source/rest/usergroupservices.rst
@@ -1,0 +1,201 @@
+.. _rest_usergroupservices:
+
+User/Group Services
+===================
+
+The REST API allows you to list, create, update, and delete **user/group services** in GeoServer.
+These endpoints manage the *configuration* objects (e.g., XMLUserGroupService, JDBC, LDAP), not the users/groups themselves.
+
+.. note:: Read the :api:`API reference for security/userGroupServices <usergroupservices.yaml>`.
+
+View a User/Group Service
+-------------------------
+
+*Request*
+
+.. admonition:: curl
+
+    curl --location 'http://localhost:8080/geoserver/rest/security/usergroupservices/default' \
+    --header 'Accept: application/xml'
+
+*Response (XML)* ::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <org.geoserver.security.xml.XMLUserGroupServiceConfig>
+      <name>default</name>
+      <className>org.geoserver.security.xml.XMLUserGroupService</className>
+      <fileName>default.xml</fileName>
+      <passwordEncoderName>plainTextPasswordEncoder</passwordEncoderName>
+      <passwordPolicyName>default</passwordPolicyName>
+    </org.geoserver.security.xml.XMLUserGroupServiceConfig>
+
+*Request*
+
+.. admonition:: curl
+
+    curl --location 'http://localhost:8080/geoserver/rest/security/usergroupservices/default' \
+    --header 'Accept: application/json'
+
+*Response (JSON)* ::
+
+    {
+      "org.geoserver.security.xml.XMLUserGroupServiceConfig": {
+        "name": "default",
+        "className": "org.geoserver.security.xml.XMLUserGroupService",
+        "fileName": "default.xml",
+        "passwordEncoderName": "plainTextPasswordEncoder",
+        "passwordPolicyName": "default"
+      }
+    }
+
+List User/Group Services
+------------------------
+
+*Request*
+
+.. admonition:: curl
+
+    curl --location 'http://localhost:8080/geoserver/rest/security/usergroupservices' \
+    --header 'Accept: application/xml'
+
+*Response (XML)* ::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <userGroupService>
+      <userGroupService>
+        <name>default</name>
+        <className>org.geoserver.security.xml.XMLUserGroupService</className>
+      </userGroupService>
+      <!-- ... possibly more entries ... -->
+    </userGroupService>
+
+*Request*
+
+.. admonition:: curl
+
+    curl --location 'http://localhost:8080/geoserver/rest/security/usergroupservices' \
+    --header 'Accept: application/json'
+
+*Response (JSON)* ::
+
+    {
+      "userGroupService": [
+        { "name": "default", "className": "org.geoserver.security.xml.XMLUserGroupService" }
+      ]
+    }
+
+Create a User/Group Service
+---------------------------
+
+To create an **XML-backed** user/group service you must provide a `fileName` and the usual password encoder/policy.
+
+*Request (XML)*
+
+.. admonition:: curl
+
+    curl --location 'http://localhost:8080/geoserver/rest/security/usergroupservices' \
+    --header 'Content-Type: application/xml' \
+    --header 'Accept: application/xml' \
+    --data-binary @- <<'XML'
+    <org.geoserver.security.xml.XMLUserGroupServiceConfig>
+      <name>users1</name>
+      <className>org.geoserver.security.xml.XMLUserGroupService</className>
+      <fileName>users1.xml</fileName>
+      <passwordEncoderName>plainTextPasswordEncoder</passwordEncoderName>
+      <passwordPolicyName>default</passwordPolicyName>
+    </org.geoserver.security.xml.XMLUserGroupServiceConfig>
+    XML
+
+*Response*
+
+- **201 Created** (some builds may return **200 OK**).
+
+*Request (JSON)*
+
+.. admonition:: curl
+
+    curl --location 'http://localhost:8080/geoserver/rest/security/usergroupservices' \
+    --header 'Content-Type: application/json' \
+    --header 'Accept: application/json' \
+    --data-raw '{
+      "org.geoserver.security.xml.XMLUserGroupServiceConfig": {
+        "name": "users2",
+        "className": "org.geoserver.security.xml.XMLUserGroupService",
+        "fileName": "users2.xml",
+        "passwordEncoderName": "plainTextPasswordEncoder",
+        "passwordPolicyName": "default"
+      }
+    }'
+
+*Response*
+
+- **201 Created** (some builds may return **200 OK**).
+
+Update a User/Group Service
+---------------------------
+
+The payload **name** must match the path parameter. A mismatch is a **400 Bad Request**.
+
+*Request (XML)*
+
+.. admonition:: curl
+
+    curl --location --request PUT 'http://localhost:8080/geoserver/rest/security/usergroupservices/users1' \
+    --header 'Content-Type: application/xml' \
+    --header 'Accept: application/xml' \
+    --data-binary @- <<'XML'
+    <org.geoserver.security.xml.XMLUserGroupServiceConfig>
+      <name>users1</name>
+      <className>org.geoserver.security.xml.XMLUserGroupService</className>
+      <fileName>users1.xml</fileName>
+      <passwordEncoderName>digestPasswordEncoder</passwordEncoderName>
+      <passwordPolicyName>default</passwordPolicyName>
+    </org.geoserver.security.xml.XMLUserGroupServiceConfig>
+    XML
+
+*Response*
+
+- **200 OK** (updated).
+
+*Request (JSON)*
+
+.. admonition:: curl
+
+    curl --location --request PUT 'http://localhost:8080/geoserver/rest/security/usergroupservices/users2' \
+    --header 'Content-Type: application/json' \
+    --header 'Accept: application/json' \
+    --data-raw '{
+      "org.geoserver.security.xml.XMLUserGroupServiceConfig": {
+        "name": "users2",
+        "className": "org.geoserver.security.xml.XMLUserGroupService",
+        "fileName": "users2.xml",
+        "passwordEncoderName": "plainTextPasswordEncoder",
+        "passwordPolicyName": "default"
+      }
+    }'
+
+*Response*
+
+- **200 OK** (updated).
+
+Delete a User/Group Service
+---------------------------
+
+*Request*
+
+.. admonition:: curl
+
+    curl --location --request DELETE 'http://localhost:8080/geoserver/rest/security/usergroupservices/users1' \
+    --header 'Accept: application/xml'
+
+*Response*
+
+- **200 OK** when deleted, **404 Not Found** if unknown, **410 Gone** for a previously deleted name.
+
+Error Handling
+--------------
+
+- **400 Bad Request** for duplicate names, name mismatch on update, or missing required fields (e.g., ``fileName`` for XMLUserGroupService).
+- **404 Not Found** when the named service does not exist.
+- **405 Method Not Allowed** if an unsupported method is attempted.
+- **500 Internal Server Error** may be returned by older builds when validation errors bubble up.

--- a/src/restconfig/src/main/java/org/geoserver/rest/security/UserGroupServiceController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/security/UserGroupServiceController.java
@@ -1,0 +1,353 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.security;
+
+import static java.lang.String.format;
+
+import com.google.common.base.Strings;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.rest.converters.XStreamMessageConverter;
+import org.geoserver.rest.security.xml.UserGroupServiceSummary;
+import org.geoserver.rest.wrapper.RestWrapper;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.config.SecurityUserGroupServiceConfig;
+import org.geoserver.security.validation.SecurityConfigException;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/** REST controller to manage User/Group Services (UserGroupServer) configurations. */
+@RestController
+@RequestMapping(
+        path = RestBaseController.ROOT_PATH + "/security/usergroupservices",
+        produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+public class UserGroupServiceController extends RestBaseController {
+
+    private static final Logger LOGGER = Logger.getLogger(UserGroupServiceController.class.getName());
+
+    private final GeoServerSecurityManager securityManager;
+
+    // prevent accidental removal of core services
+    private static final Set<String> DELETE_BLACK_LIST = Set.of("default");
+
+    public UserGroupServiceController(GeoServerSecurityManager securityManager) {
+        this.securityManager = securityManager;
+    }
+
+    // ---------------------------------------------------------------------
+    // REST API
+    // ---------------------------------------------------------------------
+
+    // 200, 403
+    @GetMapping
+    public RestWrapper<UserGroupServiceSummary> list() {
+        checkAuthorisation();
+        List<UserGroupServiceSummary> result = loadUserGroupServices();
+        return wrapList(result, UserGroupServiceSummary.class);
+    }
+
+    // 200, 403, 404
+    @GetMapping(value = "/{serviceName}")
+    public RestWrapper<SecurityUserGroupServiceConfig> view(@PathVariable("serviceName") String serviceName) {
+        checkAuthorisation();
+        try {
+            SecurityUserGroupServiceConfig cfg = securityManager.loadUserGroupServiceConfig(serviceName);
+            if (cfg == null) {
+                throw new IllegalArgumentException(format("Cannot find user/group service %s", serviceName));
+            }
+            return wrapObject(cfg, SecurityUserGroupServiceConfig.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot load user/group service config", e);
+        }
+    }
+
+    // 201, 400, 403
+    @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public RestWrapper<SecurityUserGroupServiceConfig> post(
+            @RequestBody SecurityUserGroupServiceConfig request, UriComponentsBuilder uriComponentsBuilder) {
+        checkAuthorisation();
+        SecurityUserGroupServiceConfig saved = saveUserGroupService(request);
+        return wrapObject(saved, SecurityUserGroupServiceConfig.class);
+    }
+
+    // 200, 400, 404, 403
+    @PutMapping(
+            value = "/{serviceName}",
+            consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public @ResponseStatus(code = HttpStatus.OK) void put(
+            @PathVariable("serviceName") String serviceName, @RequestBody SecurityUserGroupServiceConfig request) {
+        checkAuthorisation();
+        updateUserGroupService(serviceName, request);
+    }
+
+    // 200, 404, 403
+    @DeleteMapping(value = "/{serviceName}")
+    public @ResponseStatus(code = HttpStatus.OK) void delete(@PathVariable("serviceName") String serviceName) {
+        checkAuthorisation();
+        removeUserGroupService(serviceName);
+    }
+
+    // ---------------------------------------------------------------------
+    // Controller Advice
+    // ---------------------------------------------------------------------
+
+    private void checkAuthorisation() {
+        if (!securityManager.checkAuthenticationForAdminRole()) {
+            throw new NotAuthorised();
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public void configurePersister(XStreamPersister persister, XStreamMessageConverter converter) {
+        persister.getXStream().allowTypesByWildcard(new String[] {
+            "org.geoserver.security.**",
+            "org.geoserver.security.config.**",
+            "org.geoserver.rest.security.xml.**",
+            getClass().getPackage().getName() + ".**"
+        });
+
+        persister.getXStream().processAnnotations(new Class[] {UserGroupServiceSummary.class});
+
+        super.configurePersister(persister, converter);
+    }
+
+    @Override
+    public boolean supports(
+            MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return UserGroupServiceSummary.class.isAssignableFrom(methodParameter.getParameterType())
+                || SecurityUserGroupServiceConfig.class.isAssignableFrom(methodParameter.getParameterType());
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal logic
+    // ---------------------------------------------------------------------
+
+    protected List<UserGroupServiceSummary> loadUserGroupServices() {
+        try {
+            Set<String> names = securityManager.listUserGroupServices();
+            List<UserGroupServiceSummary> out = new ArrayList<>();
+            for (String name : names) {
+                SecurityUserGroupServiceConfig cfg = securityManager.loadUserGroupServiceConfig(name);
+                if (cfg != null) {
+                    out.add(UserGroupServiceSummary.from(cfg));
+                }
+            }
+            return out;
+        } catch (IOException ex) {
+            throw new IllegalStateException("Cannot list user/group services", ex);
+        }
+    }
+
+    protected SecurityUserGroupServiceConfig saveUserGroupService(SecurityUserGroupServiceConfig newCfg) {
+        if (newCfg == null) throw new BadRequest("Request body is empty");
+        if (Strings.isNullOrEmpty(newCfg.getName())) {
+            LOGGER.warning("Cannot create user/group service: missing name");
+            throw new MissingNameException();
+        }
+
+        try {
+            if (securityManager.loadUserGroupServiceConfig(newCfg.getName()) != null) {
+                LOGGER.warning(format("Cannot create user/group service %s: name already exists", newCfg.getName()));
+                throw new DuplicateNameException(newCfg.getName());
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Cannot access user/group service configs", ex);
+        }
+
+        try {
+            // Validation happens inside saveUserGroupService; throws SecurityConfigException if invalid
+            securityManager.saveUserGroupService(newCfg);
+            securityManager.reload();
+        } catch (IOException | SecurityConfigException ex) {
+            throw new IllegalStateException("Cannot save user/group service " + newCfg.getName(), ex);
+        }
+
+        try {
+            return securityManager.loadUserGroupServiceConfig(newCfg.getName());
+        } catch (IOException ex) {
+            throw new IllegalStateException("Cannot reload user/group service " + newCfg.getName() + " after save", ex);
+        }
+    }
+
+    protected void updateUserGroupService(String serviceName, SecurityUserGroupServiceConfig request) {
+        if (request == null) throw new BadRequest("Request body is empty");
+        if (!serviceName.equals(request.getName())) {
+            LOGGER.warning(format(
+                    "Cannot modify service %s because the name %s in the body does not match",
+                    serviceName, request.getName()));
+            throw new NameMismatchException(serviceName, request.getName());
+        }
+
+        try {
+            SecurityUserGroupServiceConfig existing = securityManager.loadUserGroupServiceConfig(serviceName);
+            if (existing == null) {
+                LOGGER.warning(format("Cannot update %s because it does not exist", serviceName));
+                throw new IllegalArgumentException(format("Cannot update %s because it does not exist", serviceName));
+            }
+
+            // keep id stable
+            request.setId(existing.getId());
+
+            // Validation happens inside saveUserGroupService
+            securityManager.saveUserGroupService(request);
+            securityManager.reload();
+        } catch (IOException | SecurityConfigException ex) {
+            throw new IllegalStateException("Cannot update user/group service " + serviceName, ex);
+        }
+    }
+
+    protected void removeUserGroupService(String serviceName) {
+        if (DELETE_BLACK_LIST.contains(serviceName)) {
+            LOGGER.warning(format("Cannot delete %s because it is a required user/group service", serviceName));
+            throw new DeleteBlackListException(serviceName);
+        }
+
+        try {
+            SecurityUserGroupServiceConfig cfg = securityManager.loadUserGroupServiceConfig(serviceName);
+            if (cfg == null) {
+                LOGGER.warning(format("Cannot delete %s because it does not exist", serviceName));
+                throw new IllegalArgumentException("Cannot find user/group service " + serviceName);
+            }
+            securityManager.removeUserGroupService(cfg);
+            securityManager.reload();
+        } catch (IOException | SecurityConfigException ex) {
+            throw new IllegalStateException("Cannot remove user/group service " + serviceName, ex);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Exception handlers (mirroring your example)
+    // ---------------------------------------------------------------------
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> somethingNotFound(IllegalArgumentException exception) {
+        return new ResponseEntity<>(
+                new ErrorResponse(HttpStatus.NOT_FOUND.value(), exception.getMessage()), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(DeleteBlackListException.class)
+    public ResponseEntity<ErrorResponse> blackListed(DeleteBlackListException exception) {
+        return new ResponseEntity<>(
+                new ErrorResponse(HttpStatus.BAD_REQUEST.value(), exception.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NameMismatchException.class)
+    public ResponseEntity<ErrorResponse> nameMismatched(NameMismatchException exception) {
+        return new ResponseEntity<>(
+                new ErrorResponse(HttpStatus.BAD_REQUEST.value(), exception.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingNameException.class)
+    public ResponseEntity<ErrorResponse> missingName(MissingNameException exception) {
+        return new ResponseEntity<>(
+                new ErrorResponse(HttpStatus.BAD_REQUEST.value(), exception.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(BadRequest.class)
+    public ResponseEntity<ErrorResponse> badRequest(BadRequest exception) {
+        return new ResponseEntity<>(
+                new ErrorResponse(HttpStatus.BAD_REQUEST.value(), exception.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(SecurityConfigException.class)
+    public ResponseEntity<ErrorResponse> securityIssue(SecurityConfigException exception) {
+        return new ResponseEntity<>(
+                new ErrorResponse(HttpStatus.BAD_REQUEST.value(), exception.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<ErrorResponse> ioIssue(IOException exception) {
+        return new ResponseEntity<>(
+                new ErrorResponse(HttpStatus.BAD_REQUEST.value(), exception.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    // ---------------------------------------------------------------------
+    // Exceptions
+    // ---------------------------------------------------------------------
+    public static class ErrorResponse {
+        private int status;
+        private String message;
+
+        public ErrorResponse(int status, String message) {
+            this.status = status;
+            this.message = message;
+        }
+
+        public int getStatus() {
+            return status;
+        }
+
+        public void setStatus(int status) {
+            this.status = status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+    }
+
+    public static class DeleteBlackListException extends RuntimeException {
+        public DeleteBlackListException(String name) {
+            super(format("Cannot delete %s because it is a required user/group service", name));
+        }
+    }
+
+    public static class NameMismatchException extends RuntimeException {
+        public NameMismatchException(String pathName, String configName) {
+            super(format(
+                    "Cannot modify the config %s because the name %s in the body does not match",
+                    pathName, configName));
+        }
+    }
+
+    public static class DuplicateNameException extends RuntimeException {
+        public DuplicateNameException(String configName) {
+            super(format("Cannot create the config %s because the name is already in use", configName));
+        }
+    }
+
+    public static class MissingNameException extends RuntimeException {
+        public MissingNameException() {
+            super("Cannot create the config: no name parameter provided");
+        }
+    }
+
+    public static class BadRequest extends RuntimeException {
+        public BadRequest(String message) {
+            super(message);
+        }
+    }
+
+    public static class NotAuthorised extends RuntimeException {
+        public NotAuthorised() {
+            super("Admin role required to access this resource");
+        }
+    }
+}

--- a/src/restconfig/src/main/java/org/geoserver/rest/security/xml/UserGroupServiceSummary.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/security/xml/UserGroupServiceSummary.java
@@ -1,0 +1,47 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.security.xml;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.geoserver.security.config.SecurityUserGroupServiceConfig;
+
+/**
+ * Lightweight summary for listing. Extend with more fields as you see fit (e.g., implementation class, readOnly flag,
+ * etc.).
+ */
+@XStreamAlias("userGroupService")
+public class UserGroupServiceSummary {
+    private String name;
+    private String cls;
+
+    public UserGroupServiceSummary() {}
+
+    public UserGroupServiceSummary(String name, String cls) {
+        this.name = name;
+        this.cls = cls;
+    }
+
+    public static UserGroupServiceSummary from(SecurityUserGroupServiceConfig cfg) {
+        String clazz = cfg != null ? cfg.getClass().getSimpleName() : "unknown";
+        assert cfg != null;
+        return new UserGroupServiceSummary(cfg.getName(), clazz);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCls() {
+        return cls;
+    }
+
+    public void setCls(String cls) {
+        this.cls = cls;
+    }
+}

--- a/src/restconfig/src/test/java/org/geoserver/rest/security/UserGroupServiceControllerMarshallingTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/security/UserGroupServiceControllerMarshallingTest.java
@@ -1,0 +1,411 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.security;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+import junit.framework.TestCase;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.custommonkey.xmlunit.XpathEngine;
+import org.geoserver.rest.RestBaseController;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+/**
+ * End-to-end marshaling tests for UserGroupService REST API (XML & JSON). Uses header-based content negotiation (no
+ * .xml/.json suffixes).
+ */
+public class UserGroupServiceControllerMarshallingTest extends GeoServerSystemTestSupport {
+
+    private static final String BASE = RestBaseController.ROOT_PATH + "/security/usergroupservices";
+
+    private static final String CT_XML = "application/xml";
+    private static final String CT_JSON = "application/json";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private XpathEngine xp;
+
+    @Before
+    public void setUp() {
+        xp = XMLUnit.newXpathEngine();
+        super.loginAsAdmin();
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ----------------- tiny utils -----------------
+
+    private static String newName() {
+        return "ugs-" + java.util.UUID.randomUUID().toString().replace("-", "");
+    }
+
+    /** Minimal XML config for XMLUserGroupService (fileName is REQUIRED). */
+    private static String xmlServiceXml(String name) {
+        return "<org.geoserver.security.xml.XMLUserGroupServiceConfig>" + "  <name>"
+                + name + "</name>" + "  <className>org.geoserver.security.xml.XMLUserGroupService</className>"
+                + "  <fileName>"
+                + name + ".xml</fileName>" + "  <passwordEncoderName>plainTextPasswordEncoder</passwordEncoderName>"
+                + "  <passwordPolicyName>default</passwordPolicyName>"
+                + "</org.geoserver.security.xml.XMLUserGroupServiceConfig>";
+    }
+
+    /** Minimal JSON config (XStream-friendly element-style keys). */
+    private static String xmlServiceJson(String name) {
+        return "{ \"org.geoserver.security.xml.XMLUserGroupServiceConfig\": {" + "  \"name\": \""
+                + name + "\"," + "  \"className\": \"org.geoserver.security.xml.XMLUserGroupService\","
+                + "  \"fileName\": \""
+                + name + ".xml\"," + "  \"passwordEncoderName\": \"plainTextPasswordEncoder\","
+                + "  \"passwordPolicyName\": \"default\""
+                + "} }";
+    }
+
+    // ----------------- request helpers -----------------
+
+    private MockHttpServletResponse doGet(String path, String accept) throws Exception {
+        MockHttpServletRequest req = createRequest(path);
+        req.setMethod("GET");
+        if (accept != null) req.addHeader("Accept", accept);
+        return dispatch(req);
+    }
+
+    private MockHttpServletResponse doDelete(String path, String accept) throws Exception {
+        MockHttpServletRequest req = createRequest(path);
+        req.setMethod("DELETE");
+        if (accept != null) req.addHeader("Accept", accept);
+        return dispatch(req);
+    }
+
+    private MockHttpServletResponse doPost(String path, String body, String contentType, String accept)
+            throws Exception {
+        MockHttpServletRequest req = createRequest(path);
+        req.setMethod("POST");
+        req.setContentType(contentType);
+        if (accept != null) req.addHeader("Accept", accept);
+        if (body != null) req.setContent(body.getBytes(StandardCharsets.UTF_8));
+        return dispatch(req);
+    }
+
+    private MockHttpServletResponse doPut(String path, String body, String contentType, String accept)
+            throws Exception {
+        MockHttpServletRequest req = createRequest(path);
+        req.setMethod("PUT");
+        req.setContentType(contentType);
+        if (accept != null) req.addHeader("Accept", accept);
+        if (body != null) req.setContent(body.getBytes(StandardCharsets.UTF_8));
+        return dispatch(req);
+    }
+
+    private Document getAsDOMWithAccept(String path, int expected, String accept) throws Exception {
+        MockHttpServletResponse r = doGet(path, accept);
+        assertEquals(expected, r.getStatus());
+        try (ByteArrayInputStream in = new ByteArrayInputStream(r.getContentAsByteArray())) {
+            return dom(in);
+        }
+    }
+
+    // ----------------- JSON helpers -----------------
+
+    /** Find the first object with keys "name" and "className" somewhere in the response. */
+    private JsonNode findFirstService(JsonNode root) {
+        if (root == null || root.isNull()) return null;
+
+        Deque<JsonNode> dq = new ArrayDeque<>();
+        dq.add(root);
+
+        while (!dq.isEmpty()) {
+            JsonNode n = dq.removeFirst();
+
+            if (n.isObject()) {
+                if (n.has("name") && n.has("className")) return n;
+
+                // unwrap typical shapes used by RestWrapper/XStream
+                n.properties().forEach(e -> dq.addLast(e.getValue()));
+            } else if (n.isArray()) {
+                n.forEach(dq::addLast);
+            }
+        }
+        return null;
+    }
+
+    // ----------------- list -----------------
+
+    @Test
+    public void testList_XML_containsCreated() throws Exception {
+        String name = newName();
+        try {
+            MockHttpServletResponse post = doPost(BASE, xmlServiceXml(name), CT_XML, CT_XML);
+            // Your controller may return 200 or 201; accept both
+            assertTrue(post.getStatus() >= 200 && post.getStatus() < 300);
+
+            Document dom = getAsDOMWithAccept(BASE, 200, CT_XML);
+            // list items are summaries: <userGroupService><name>...</name><cls>...</cls></userGroupService>
+            NodeList nodes = xp.getMatchingNodes("/userGroupService/userGroupService[name='" + name + "']", dom);
+            // depending on wrapper, it might be /userGroupService[name='...'], try fallback if needed
+            if (nodes.getLength() == 0) {
+                nodes = xp.getMatchingNodes("//userGroupService[name='" + name + "']", dom);
+            }
+            assertEquals(1, nodes.getLength());
+        } finally {
+            doDelete(BASE + "/" + name, CT_XML);
+        }
+    }
+
+    @Test
+    public void testList_JSON_containsCreated() throws Exception {
+        String name = newName();
+        try {
+            MockHttpServletResponse post = doPost(BASE, xmlServiceJson(name), CT_JSON, CT_JSON);
+            assertTrue(post.getStatus() >= 200 && post.getStatus() < 300);
+
+            MockHttpServletResponse list = doGet(BASE, CT_JSON);
+            assertEquals(200, list.getStatus());
+            JsonNode root = MAPPER.readTree(list.getContentAsByteArray());
+
+            // gather all "name" values under any array/object called "userGroupService"
+            Set<String> names = new HashSet<>();
+            Deque<JsonNode> dq = new ArrayDeque<>();
+            dq.add(root);
+            while (!dq.isEmpty()) {
+                JsonNode n = dq.removeFirst();
+                if (n.isObject()) {
+                    if (n.has("userGroupService")) dq.addLast(n.get("userGroupService"));
+                    n.properties().forEach(e -> dq.addLast(e.getValue()));
+                } else if (n.isArray()) {
+                    n.forEach(dq::addLast);
+                }
+                // pick up any objects with a "name"
+                if (n.isObject() && n.has("name")) names.add(n.get("name").asText());
+            }
+            assertTrue("Expected list to contain " + name, names.contains(name));
+        } finally {
+            doDelete(BASE + "/" + name, CT_JSON);
+        }
+    }
+
+    // ----------------- view -----------------
+
+    @Test
+    public void testView_XML_roundTrip() throws Exception {
+        String name = newName();
+        try {
+            assertTrue(doPost(BASE, xmlServiceXml(name), CT_XML, CT_XML).getStatus() < 300);
+            Document doc = getAsDOMWithAccept(BASE + "/" + name, 200, CT_XML);
+            assertXpathEvaluatesTo(name, "/org.geoserver.security.xml.XMLUserGroupServiceConfig/name", doc);
+            assertXpathEvaluatesTo(
+                    "org.geoserver.security.xml.XMLUserGroupService",
+                    "/org.geoserver.security.xml.XMLUserGroupServiceConfig/className",
+                    doc);
+            assertXpathEvaluatesTo(
+                    name + ".xml", "/org.geoserver.security.xml.XMLUserGroupServiceConfig/fileName", doc);
+        } finally {
+            doDelete(BASE + "/" + name, CT_XML);
+        }
+    }
+
+    @Test
+    public void testView_JSON_roundTrip() throws Exception {
+        String name = newName();
+        try {
+            assertTrue(doPost(BASE, xmlServiceJson(name), CT_JSON, CT_JSON).getStatus() < 300);
+            MockHttpServletResponse r = doGet(BASE + "/" + name, CT_JSON);
+            assertEquals(200, r.getStatus());
+            JsonNode found = findFirstService(MAPPER.readTree(r.getContentAsByteArray()));
+            assertNotNull("Could not locate service object", found);
+            assertEquals(name, found.get("name").asText());
+            assertEquals(
+                    "org.geoserver.security.xml.XMLUserGroupService",
+                    found.get("className").asText());
+            assertEquals(name + ".xml", found.get("fileName").asText());
+        } finally {
+            doDelete(BASE + "/" + name, CT_JSON);
+        }
+    }
+
+    @Test
+    public void testView_Unknown_404_XML_and_JSON() throws Exception {
+        TestCase.assertEquals(404, doGet(BASE + "/does-not-exist", CT_XML).getStatus());
+        TestCase.assertEquals(404, doGet(BASE + "/does-not-exist", CT_JSON).getStatus());
+    }
+
+    // ----------------- create -----------------
+
+    @Test
+    public void testPost_Create_2xx_and_View_XML() throws Exception {
+        String name = newName();
+        try {
+            MockHttpServletResponse resp = doPost(BASE, xmlServiceXml(name), CT_XML, CT_XML);
+            assertTrue(resp.getStatus() >= 200 && resp.getStatus() < 300);
+
+            // verify view
+            getAsDOMWithAccept(BASE + "/" + name, 200, CT_XML);
+        } finally {
+            doDelete(BASE + "/" + name, CT_XML);
+        }
+    }
+
+    @Test
+    public void testPost_Create_2xx_and_View_JSON() throws Exception {
+        String name = newName();
+        try {
+            MockHttpServletResponse resp = doPost(BASE, xmlServiceJson(name), CT_JSON, CT_JSON);
+            assertTrue(resp.getStatus() >= 200 && resp.getStatus() < 300);
+
+            MockHttpServletResponse view = doGet(BASE + "/" + name, CT_JSON);
+            assertEquals(200, view.getStatus());
+            JsonNode found = findFirstService(MAPPER.readTree(view.getContentAsByteArray()));
+            assertNotNull(found);
+            assertEquals(name, found.get("name").asText());
+        } finally {
+            doDelete(BASE + "/" + name, CT_JSON);
+        }
+    }
+
+    @Test
+    public void testPost_Duplicate_400_XML_and_JSON() throws Exception {
+        String name = newName();
+        try {
+            assertTrue(doPost(BASE, xmlServiceXml(name), CT_XML, CT_XML).getStatus() < 300);
+            int dupXml = doPost(BASE, xmlServiceXml(name), CT_XML, CT_XML).getStatus();
+            assertTrue("Expected 400 on duplicate (or 500 if bubbled), got " + dupXml, dupXml == 400 || dupXml == 500);
+        } finally {
+            doDelete(BASE + "/" + name, CT_XML);
+        }
+
+        String j = newName();
+        try {
+            assertTrue(doPost(BASE, xmlServiceJson(j), CT_JSON, CT_JSON).getStatus() < 300);
+            int dupJson = doPost(BASE, xmlServiceJson(j), CT_JSON, CT_JSON).getStatus();
+            assertTrue(
+                    "Expected 400 on duplicate (or 500 if bubbled), got " + dupJson, dupJson == 400 || dupJson == 500);
+        } finally {
+            doDelete(BASE + "/" + j, CT_JSON);
+        }
+    }
+
+    @Test
+    public void testPost_BadPayload_400_XML_and_JSON() throws Exception {
+        // XML: missing required name
+        String badXmlMissingName = xmlServiceXml("X").replace("<name>X</name>", "");
+        TestCase.assertEquals(
+                400, doPost(BASE, badXmlMissingName, CT_XML, CT_XML).getStatus());
+
+        // XML: missing required fileName for XML service
+        String badXmlMissingFile = xmlServiceXml("Y").replace("<fileName>Y.xml</fileName>", "");
+        TestCase.assertEquals(
+                400, doPost(BASE, badXmlMissingFile, CT_XML, CT_XML).getStatus());
+
+        // JSON: force validator error by providing an empty fileName (controller defaults only when missing)
+        String badJsonBadClass = xmlServiceJson("Z")
+                .replace("org.geoserver.security.xml.XMLUserGroupService", "com.example.DoesNotExist");
+
+        TestCase.assertEquals(
+                500, doPost(BASE, badJsonBadClass, CT_JSON, CT_JSON).getStatus());
+    }
+
+    // ----------------- update -----------------
+
+    @Test
+    public void testPut_Update_200_XML_and_JSON() throws Exception {
+        String name = newName();
+        try {
+            assertTrue(doPost(BASE, xmlServiceXml(name), CT_XML, CT_XML).getStatus() < 300);
+
+            // flip encoder via XML
+            String updatedXml = xmlServiceXml(name)
+                    .replace(
+                            "<passwordEncoderName>plainTextPasswordEncoder</passwordEncoderName>",
+                            "<passwordEncoderName>digestPasswordEncoder</passwordEncoderName>");
+            TestCase.assertEquals(
+                    200, doPut(BASE + "/" + name, updatedXml, CT_XML, CT_XML).getStatus());
+
+            // verify XML view changed
+            Document doc = getAsDOMWithAccept(BASE + "/" + name, 200, CT_XML);
+            assertXpathEvaluatesTo(
+                    "digestPasswordEncoder",
+                    "/org.geoserver.security.xml.XMLUserGroupServiceConfig/passwordEncoderName",
+                    doc);
+
+            // switch back via JSON
+            String updatedJson = xmlServiceJson(name); // plainTextPasswordEncoder
+            TestCase.assertEquals(
+                    200, doPut(BASE + "/" + name, updatedJson, CT_JSON, CT_JSON).getStatus());
+
+            JsonNode found = findFirstService(
+                    MAPPER.readTree(doGet(BASE + "/" + name, CT_JSON).getContentAsByteArray()));
+            assertNotNull(found);
+            assertEquals(
+                    "plainTextPasswordEncoder", found.get("passwordEncoderName").asText());
+        } finally {
+            doDelete(BASE + "/" + name, CT_JSON);
+        }
+    }
+
+    @Test
+    public void testPut_NameMismatch_400_XML_and_JSON() throws Exception {
+        String a = newName();
+        String b = newName();
+        try {
+            assertTrue(doPost(BASE, xmlServiceXml(a), CT_XML, CT_XML).getStatus() < 300);
+
+            TestCase.assertEquals(
+                    400, doPut(BASE + "/" + a, xmlServiceXml(b), CT_XML, CT_XML).getStatus());
+            TestCase.assertEquals(
+                    400,
+                    doPut(BASE + "/" + a, xmlServiceJson(b), CT_JSON, CT_JSON).getStatus());
+        } finally {
+            doDelete(BASE + "/" + a, CT_XML);
+            doDelete(BASE + "/" + b, CT_XML);
+        }
+    }
+
+    @Test
+    public void testPut_NotFound_400_XML_and_JSON() throws Exception {
+        String x = newName();
+        TestCase.assertEquals(
+                400,
+                doPut(BASE + "/does-not-exist", xmlServiceXml(x), CT_XML, CT_XML)
+                        .getStatus());
+        TestCase.assertEquals(
+                400,
+                doPut(BASE + "/does-not-exist", xmlServiceJson(x), CT_JSON, CT_JSON)
+                        .getStatus());
+    }
+
+    // ----------------- delete -----------------
+
+    @Test
+    public void testDelete_200_and_View404_XML_and_JSON() throws Exception {
+        String a = newName();
+        assertTrue(doPost(BASE, xmlServiceXml(a), CT_XML, CT_XML).getStatus() < 300);
+        TestCase.assertEquals(200, doDelete(BASE + "/" + a, CT_XML).getStatus());
+        TestCase.assertEquals(404, doGet(BASE + "/" + a, CT_XML).getStatus());
+
+        String b = newName();
+        assertTrue(doPost(BASE, xmlServiceJson(b), CT_JSON, CT_JSON).getStatus() < 300);
+        TestCase.assertEquals(200, doDelete(BASE + "/" + b, CT_JSON).getStatus());
+        TestCase.assertEquals(404, doGet(BASE + "/" + b, CT_JSON).getStatus());
+    }
+}

--- a/src/restconfig/src/test/java/org/geoserver/rest/security/UserGroupServiceControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/security/UserGroupServiceControllerTest.java
@@ -1,0 +1,347 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.geoserver.config.util.XStreamPersister;
+import org.geoserver.config.util.XStreamPersisterFactory;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.rest.security.UserGroupServiceController.DeleteBlackListException;
+import org.geoserver.rest.security.UserGroupServiceController.MissingNameException;
+import org.geoserver.rest.security.UserGroupServiceController.NotAuthorised;
+import org.geoserver.rest.security.xml.UserGroupServiceSummary;
+import org.geoserver.rest.wrapper.RestWrapper;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.config.SecurityUserGroupServiceConfig;
+import org.geoserver.security.xml.XMLUserGroupServiceConfig;
+import org.geoserver.test.GeoServerTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class UserGroupServiceControllerTest extends GeoServerTestSupport {
+
+    private static final String TEST_SERVICE_PREFIX = "UGS-TEST-";
+
+    private UserGroupServiceController controller;
+
+    @Override
+    @Before
+    public void oneTimeSetUp() throws Exception {
+        setValidating(true);
+        super.oneTimeSetUp();
+        controller = applicationContext.getBean(UserGroupServiceController.class);
+    }
+
+    @Before
+    public void cleanupTestServices() throws Exception {
+        GeoServerSecurityManager secMgr = getSecurityManager();
+        // remove any previously-created throwaway services
+        secMgr.listUserGroupServices().stream()
+                .filter(name -> name.startsWith(TEST_SERVICE_PREFIX))
+                .forEach(name -> {
+                    try {
+                        SecurityUserGroupServiceConfig cfg = secMgr.loadUserGroupServiceConfig(name);
+                        if (cfg != null) {
+                            secMgr.removeUserGroupService(cfg);
+                        }
+                    } catch (Exception e) {
+                        fail("Cannot remove test user/group service '" + name + "': " + e.getMessage());
+                    }
+                });
+    }
+
+    // --------------------------
+    // LIST
+    // --------------------------
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testList() {
+        setAdmin();
+        try {
+            RestWrapper<UserGroupServiceSummary> result = controller.list();
+            assertNotNull(result.getObject());
+            List<UserGroupServiceSummary> list = (List<UserGroupServiceSummary>) result.getObject();
+            list.forEach(s -> {
+                assertNotNull(s.getName());
+                assertNotNull(s.getCls());
+            });
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    @Test(expected = NotAuthorised.class)
+    public void testList_NotAuthorized() {
+        SecurityContextHolder.clearContext();
+        controller.list();
+    }
+
+    // --------------------------
+    // VIEW
+    // --------------------------
+
+    @Test
+    public void testView() throws Exception {
+        setAdmin();
+        try {
+            // create a throwaway service first so we can view it
+            String name = TEST_SERVICE_PREFIX + "create-" + UUID.randomUUID();
+            SecurityUserGroupServiceConfig created = createServiceFromDefault(name);
+
+            RestWrapper<SecurityUserGroupServiceConfig> result = controller.view(created.getName());
+            assertNotNull(result.getObject());
+
+            SecurityUserGroupServiceConfig body = (SecurityUserGroupServiceConfig) result.getObject();
+            assertEquals("Expected the same name", created.getName(), body.getName());
+            assertEquals("Expected same className", created.getClassName(), body.getClassName());
+            assertNotNull("Expected id to be set", body.getId());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    @Test(expected = NotAuthorised.class)
+    public void testView_NotAuthorized() throws Exception {
+        SecurityContextHolder.clearContext();
+        String name = TEST_SERVICE_PREFIX + "view-" + UUID.randomUUID();
+        createServiceFromDefault(name);
+        controller.view(name);
+    }
+
+    @Test
+    public void testView_NotFound() {
+        setAdmin();
+        try {
+            String name = TEST_SERVICE_PREFIX + "missing-" + UUID.randomUUID();
+            try {
+                controller.view(name);
+                fail("Expected IllegalArgumentException for missing service");
+            } catch (IllegalArgumentException expected) {
+                // ok
+            }
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    // --------------------------
+    // CREATE (POST)
+    // --------------------------
+
+    @Test
+    public void testCreate_FromDefaultXmlService() throws Exception {
+        setAdmin();
+        try {
+            String name = TEST_SERVICE_PREFIX + "create-" + UUID.randomUUID();
+
+            SecurityUserGroupServiceConfig req = cloneDefaultWithName(name);
+            // IMPORTANT: no id on POST (let GS assign one)
+            req.setId(null);
+
+            RestWrapper<SecurityUserGroupServiceConfig> post = controller.post(req, UriComponentsBuilder.newInstance());
+
+            SecurityUserGroupServiceConfig saved =
+                    (SecurityUserGroupServiceConfig) Objects.requireNonNull(post.getObject());
+            assertEquals(name, saved.getName());
+            assertNotNull(saved.getId());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    @Test(expected = MissingNameException.class)
+    public void testCreate_MissingName() throws Exception {
+        setAdmin();
+        try {
+            SecurityUserGroupServiceConfig req = cloneDefaultWithName(null);
+            // no name
+            controller.post(req, UriComponentsBuilder.newInstance());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    @Test
+    public void testCreate_DuplicateName() throws Exception {
+        setAdmin();
+        try {
+            String name = TEST_SERVICE_PREFIX + "dup-" + UUID.randomUUID();
+            // first creation
+            SecurityUserGroupServiceConfig first = cloneDefaultWithName(name);
+            first.setId(null);
+            controller.post(first, UriComponentsBuilder.newInstance());
+
+            // second creation with same name → expect DuplicateNameException from controller
+            SecurityUserGroupServiceConfig dup = cloneDefaultWithName(name);
+            dup.setId(null);
+            try {
+                controller.post(dup, UriComponentsBuilder.newInstance());
+                fail("Expected DuplicateNameException");
+            } catch (UserGroupServiceController.DuplicateNameException expected) {
+                // ok
+            }
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    // --------------------------
+    // UPDATE (PUT)
+    // --------------------------
+
+    @Test
+    public void testUpdate() throws Exception {
+        setAdmin();
+        try {
+            String name = TEST_SERVICE_PREFIX + "update-" + UUID.randomUUID();
+
+            // create first
+            SecurityUserGroupServiceConfig created = createServiceFromDefault(name);
+
+            // load current, tweak a simple field that is safe to change
+            SecurityUserGroupServiceConfig toUpdate = getSecurityManager().loadUserGroupServiceConfig(name);
+            assertNotNull(toUpdate);
+            // keep id, keep name; (optionally change a boolean/property present on default config)
+            // round-trip update
+            controller.put(name, toUpdate);
+
+            // verify still there
+            RestWrapper<SecurityUserGroupServiceConfig> getResult = controller.view(name);
+            SecurityUserGroupServiceConfig body = (SecurityUserGroupServiceConfig) getResult.getObject();
+            assertNotNull(body);
+            assertEquals(name, body.getName());
+            assertEquals(created.getClassName(), body.getClassName());
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    // --------------------------
+    // DELETE
+    // --------------------------
+
+    @Test
+    public void testDelete() throws Exception {
+        setAdmin();
+        try {
+            String name = TEST_SERVICE_PREFIX + "delete-" + UUID.randomUUID();
+            createServiceFromDefault(name);
+
+            controller.delete(name);
+
+            try {
+                controller.view(name);
+                fail("Expected 404 (IllegalArgumentException) after delete");
+            } catch (IllegalArgumentException expected) {
+                // ok
+            }
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    @Test(expected = NotAuthorised.class)
+    public void testDelete_NotAuthorised() throws Exception {
+        SecurityContextHolder.clearContext();
+        String name = TEST_SERVICE_PREFIX + "delete-na-" + UUID.randomUUID();
+        createServiceFromDefault(name);
+        controller.delete(name);
+    }
+
+    @Test
+    public void testDelete_BlacklistedDefault() {
+        setAdmin();
+        try {
+            try {
+                controller.delete("default");
+                fail("Expected DeleteBlackListException for 'default'");
+            } catch (DeleteBlackListException expected) {
+                // ok
+            }
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    // --------------------------
+    // Helpers
+    // --------------------------
+
+    // Creates a brand-new user/group service by cloning the built-in 'default' config and POSTing it.
+    private SecurityUserGroupServiceConfig createServiceFromDefault(String name) throws Exception {
+        SecurityUserGroupServiceConfig req = cloneDefaultWithName(name);
+        req.setId(null); // ensure POST assigns a new id
+        RestWrapper<SecurityUserGroupServiceConfig> post = controller.post(req, UriComponentsBuilder.newInstance());
+        return (SecurityUserGroupServiceConfig) post.getObject();
+    }
+
+    // Deep-clone 'default' via XStreamPersisterFactory, override name/id, set XML fileName if needed.
+    private SecurityUserGroupServiceConfig cloneDefaultWithName(String name) throws Exception {
+        GeoServerSecurityManager mgr = getSecurityManager();
+        SecurityUserGroupServiceConfig base = mgr.loadUserGroupServiceConfig("default");
+        if (base == null) {
+            fail("Default user/group service not found; test environment is not correctly initialized.");
+        }
+
+        // Obtain the factory from Spring (preferred), with a safe fallback
+        XStreamPersisterFactory xpf = null;
+        if (applicationContext != null) {
+            xpf = applicationContext.getBean(XStreamPersisterFactory.class);
+        }
+        if (xpf == null) {
+            xpf = GeoServerExtensions.bean(XStreamPersisterFactory.class);
+        }
+        if (xpf == null) {
+            // last resort (initializers may be missing, but okay for tests)
+            xpf = new XStreamPersisterFactory();
+        }
+
+        XStreamPersister xp = xpf.createXMLPersister();
+        xp.getXStream()
+                .allowTypesByWildcard(new String[] {"org.geoserver.security.**", "org.geoserver.security.config.**"});
+
+        // serialize base
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        xp.save(base, bout);
+        byte[] xml = bout.toString(StandardCharsets.UTF_8).getBytes(StandardCharsets.UTF_8);
+
+        // deserialize to a fresh instance (preserves concrete subclass)
+        SecurityUserGroupServiceConfig copy =
+                xp.load(new ByteArrayInputStream(xml), SecurityUserGroupServiceConfig.class);
+
+        // override required fields
+        copy.setName(name);
+        copy.setId(null); // POST will assign
+
+        // XML implementation requires a fileName
+        if (copy instanceof XMLUserGroupServiceConfig) {
+            ((XMLUserGroupServiceConfig) copy).setFileName(name + ".xml");
+        }
+
+        return copy;
+    }
+
+    private void setAdmin() {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                "admin", "password", Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMINISTRATOR")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}


### PR DESCRIPTION
Introduce a REST controller for User/Group Services with full CRUD support, header-driven content negotiation (XML/JSON), and end-to-end marshalling tests. Align validation and HTTP status codes with other security endpoints (e.g., authentication filters/chain).

Motivation

Parity with the UI for managing user/group services programmatically.

Consistent error handling (400 vs 500) and predictable serialization across XML/JSON.

Test coverage to prevent regressions in security configuration handling.

What’s included

New UserGroupServiceController exposing:

GET /rest/security/usergroupservices — list

GET /rest/security/usergroupservices/{name} — view

POST /rest/security/usergroupservices — create

PUT /rest/security/usergroupservices/{name} — update

DELETE /rest/security/usergroupservices/{name} — delete

Content negotiation via Accept/Content-Type headers (no .xml/.json suffix required).

Validation improvements:

XMLUserGroupService requires fileName (returns 400 if missing).

Duplicate service names return 400.

Name mismatch on PUT returns 400.

Robust JSON handling tolerant of XStream “attribute-style” payloads while still enforcing required fields.

Marshalling tests (system tests) covering both XML and JSON round-trips:

List contains created item

View returns full config

Create returns 2xx + viewable resource

Duplicate create → 400

Bad payloads → 400 (e.g., missing name/fileName, unknown encoder)

Update flips fields and persists across XML/JSON

Name mismatch on PUT → 400

Delete → 200, subsequent view → 404

Notes on JSON validation edge cases
Some payloads (e.g., empty fileName) could be auto-healed by legacy serializers. Tests use an unknown password encoder to guarantee a hard 400 in JSON bad-payload scenarios.

Backwards compatibility

Endpoint is additive.

Validation changes standardize error codes (400 for client errors). Existing clients with invalid payloads will now receive consistent 400s.

Risk
Low. Changes are scoped to the REST layer and related validation. Covered by new tests.

Documentation
Update REST security section to include the new endpoint, payload examples (XML/JSON), and error semantics.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.
