### PR TITLE
Fixing PngEncoderType converter for missing enum due to ImageN migration

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/EnumWithDefaultConverter.java
+++ b/src/main/src/main/java/org/geoserver/config/util/EnumWithDefaultConverter.java
@@ -1,0 +1,45 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.config.util;
+
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.enums.EnumConverter;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+
+/**
+ * XStream converter for enums that returns a default value when the provided value cannot be matched.
+ *
+ * <p>This is useful to handle enum values that have been removed, or when the enum class has been renamed and we want
+ * to provide a default value instead of failing the whole unmarshalling process.
+ */
+public final class EnumWithDefaultConverter extends EnumConverter {
+
+    private final Enum<?> defaultValue;
+
+    public EnumWithDefaultConverter(Enum<?> defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        Class<?> type = context.getRequiredType();
+        if (type.getSuperclass() != Enum.class) {
+            type = type.getSuperclass();
+        }
+        String name = reader.getValue();
+
+        try {
+            return Enum.valueOf((Class) type, name);
+        } catch (IllegalArgumentException ignore) {
+            for (Enum<?> c : (Enum<?>[]) (type).getEnumConstants()) {
+                if (c.name().equalsIgnoreCase(name)) {
+                    return c;
+                }
+            }
+            return defaultValue;
+        }
+    }
+}

--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -436,6 +436,10 @@ public class XStreamPersister {
                 impl(CoverageInfo.class), "interpolationMethods", new LaxCollectionConverter(xs.getMapper()));
         xs.registerLocalConverter(impl(CoverageInfo.class), "dimensions", new LaxCollectionConverter(xs.getMapper()));
 
+        // JAIInfo
+        xs.registerLocalConverter(
+                impl(JAIInfo.class), "pngEncoderType", new EnumWithDefaultConverter(JAIInfo.PngEncoderType.JDK));
+
         // CoverageDimensionInfo
         xs.registerLocalConverter(impl(CoverageDimensionInfo.class), "range", new NumberRangeConverter());
 


### PR DESCRIPTION
Fixing CITE tests broken by imageN upgrade.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.