### PR TITLE
Single file ,single line fix:  wmts getcapabilities error "400: Error searching max and min scale denominators for style ''

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -1165,7 +1165,9 @@ public class ConfigDatabase implements ApplicationContextAware {
             return;
         }
         real = ModificationProxy.unwrap(real);
-        if (real instanceof StyleInfoImpl || real instanceof StoreInfoImpl || real instanceof ResourceInfoImpl) {
+        if ((real instanceof StyleInfoImpl && ((StyleInfoImpl) real).getName() != "")
+                || real instanceof StoreInfoImpl
+                || real instanceof ResourceInfoImpl) {
             OwsUtils.set(real, "catalog", catalog);
         }
         if (real instanceof ResourceInfoImpl) {


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
Singel file, single line changes

From geoserver2.26, the extension 'jdbcconfig-plugin' causes wmts getcapabilities failure, and this bug is not caused by logic change in geoserer core code.
Reproduce steps:
1. Create a wmsstore with a external wms server
2. Add layer from this wmsstore
3. Request wmts getcapabilities, you will get the error message: Error searching max and min scale denominators for style ''.
   The detail java stack trace is following:
	geoserver-1  | java.lang.RuntimeException: Error searching max and min scale denominators for style ''..
	geoserver-1  | >at org.geoserver.gwc.layer.GeoServerTileLayer.getLayerLegendsInfo(GeoServerTileLayer.java:1625).
	geoserver-1  | >at org.geowebcache.service.wmts.WMTSGetCapabilities.getLegendsInfo(WMTSGetCapabilities.java:536).
	geoserver-1  | >at org.geowebcache.service.wmts.WMTSGetCapabilities.layerStyles(WMTSGetCapabilities.java:557).
	geoserver-1  | >at org.geowebcache.service.wmts.WMTSGetCapabilities.layer(WMTSGetCapabilities.java:476).
	geoserver-1  | >at org.geowebcache.service.wmts.WMTSGetCapabilities.contents(WMTSGetCapabilities.java:429).
	geoserver-1  | >at org.geowebcache.service.wmts.WMTSGetCapabilities.generateGetCapabilities(WMTSGetCapabilities.java:169).
	geoserver-1  | >at org.geowebcache.service.wmts.WMTSGetCapabilities.writeResponse(WMTSGetCapabilities.java:112).
	geoserver-1  | >at org.geowebcache.service.wmts.WMTSService.handleRequest(WMTSService.java:577).
	geoserver-1  | >at org.geowebcache.service.wmts.WMTSService$$FastClassBySpringCGLIB$$e221a779.invoke(<generated>).
	geoserver-1  | >at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218).
	geoserver-1  | >at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:792).
	geoserver-1  | >at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163).
	geoserver-1  | >at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:762).
	geoserver-1  | >at org.geoserver.gwc.config.GWCServiceEnablementInterceptor.invoke(GWCServiceEnablementInterceptor.java:56).
	geoserver-1  | >at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186).
	geoserver-1  | >at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:762).
	geoserver-1  | >at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:707).
	geoserver-1  | >at org.geowebcache.service.wmts.WMTSService$$EnhancerBySpringCGLIB$$acbd35b2.handleRequest(<generated>).
	geoserver-1  | >at org.geowebcache.GeoWebCacheDispatcher.handleServiceRequest(GeoWebCacheDispatcher.java:405).
	geoserver-1  | >at org.geowebcache.GeoWebCacheDispatcher.handleRequestInternal(GeoWebCacheDispatcher.java:276).
	geoserver-1  | >at org.springframework.web.servlet.mvc.AbstractController.handleRequest(AbstractController.java:177).
	geoserver-1  | >at org.geoserver.gwc.dispatch.GwcServiceProxy.dispatch(GwcServiceProxy.java:83).
	geoserver-1  | >at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method).                                                                                          
	geoserver-1  | >at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77).
	geoserver-1  | >at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43).
	geoserver-1  | >at java.base/java.lang.reflect.Method.invoke(Method.java:569).
	geoserver-1  | >at org.geoserver.ows.Dispatcher.execute(Dispatcher.java:952).
	geoserver-1  | >at org.geoserver.ows.Dispatcher.handleRequestInternal(Dispatcher.java:271).
	geoserver-1  | >at org.springframework.web.servlet.mvc.AbstractController.handleRequest(AbstractController.java:177).
	geoserver-1  | >at org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter.handle(SimpleControllerHandlerAdapter.java:51).
	geoserver-1  | >at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1072).    

Root cause:
   The class 'main/src/main/java/org/geoserver/catalog/impl/WMSLayerInfoImpl.java' decalres a default style "DEFAULT_ON_REMOTE" for wms layer, which should not exist in geoserver catalog, but the existing code in jdbcconfig-plugin will always set the catalog property to current geoserver catalog object for all StyleInfoImpl, StoreInfoImpl and ResourceInfoImpl, and the above exception will be  thrown when geoserver try to fetch the style definition from catalog object.
 
Solution:
   The solution is pretty simple, Only set the property 'catalog' to current geoserver catalog object if the StyleInfoImpl object has a non-empty name, because the StyleInfoImpl for wmslayer style alwasy has a empty name.
 
Test:
   1. Passed all unitests.
   2. Tested the change on geoserver2.27.2
 
   
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
Not applicable
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
Not applicable
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
Not applicable
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
Not applicable
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
Not related Jira ticket
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.