### PR TITLE
[GEOS-11934] Image processing tile cache: better logging and deeper cleanups

### DIFF
--- a/src/main/src/main/java/applicationContext.xml
+++ b/src/main/src/main/java/applicationContext.xml
@@ -368,4 +368,6 @@
     <constructor-arg value="1000"/>
   </bean>
 
+  <bean id="geoserverTileCache" class="org.geoserver.jai.GeoServerTileCache"/>
+
 </beans>

--- a/src/main/src/main/java/org/geoserver/GeoserverInitStartupListener.java
+++ b/src/main/src/main/java/org/geoserver/GeoserverInitStartupListener.java
@@ -38,7 +38,6 @@ import org.eclipse.imagen.OperationRegistry;
 import org.eclipse.imagen.RegistryElementDescriptor;
 import org.eclipse.imagen.RegistryMode;
 import org.eclipse.imagen.media.ConcurrentOperationRegistry;
-import org.eclipse.imagen.media.cache.ConcurrentTileCacheMultiMap;
 import org.eclipse.imagen.util.ImagingListener;
 import org.geoserver.config.impl.CoverageAccessInfoImpl;
 import org.geoserver.logging.LoggingUtils;
@@ -96,11 +95,6 @@ public class GeoserverInitStartupListener implements ServletContextListener {
         JAI jaiDef = JAI.getDefaultInstance();
         if (!(jaiDef.getOperationRegistry() instanceof ConcurrentOperationRegistry)) {
             jaiDef.setOperationRegistry(ConcurrentOperationRegistry.initializeRegistry());
-        }
-
-        // setup the concurrent tile cache (has proper memory limit handling also for small tiles)
-        if (!(jaiDef.getTileCache() instanceof ConcurrentTileCacheMultiMap)) {
-            jaiDef.setTileCache(new ConcurrentTileCacheMultiMap());
         }
 
         // make sure we remember if GeoServer controls logging or not

--- a/src/main/src/main/java/org/geoserver/jai/GeoServerTileCache.java
+++ b/src/main/src/main/java/org/geoserver/jai/GeoServerTileCache.java
@@ -1,0 +1,164 @@
+/* (c) 2025 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.jai;
+
+import static java.util.logging.Level.FINE;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.awt.Point;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+import org.eclipse.imagen.media.cache.ConcurrentTileCacheMultiMap;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.DispatcherCallback;
+import org.geoserver.ows.Request;
+import org.geoserver.ows.Response;
+import org.geoserver.platform.Operation;
+import org.geoserver.platform.Service;
+import org.geoserver.platform.ServiceException;
+import org.geotools.util.logging.Logging;
+
+/**
+ * A tile cache implementation based on ConcurrentTileCacheMultiMap, which integrates with the OGC request lifecycle
+ * ensuring that tiles are properly disposed of at the end of the request.
+ *
+ * <p>In addition, it provides improved logging.
+ */
+public class GeoServerTileCache extends ConcurrentTileCacheMultiMap implements DispatcherCallback {
+
+    static final Logger LOGGER = Logging.getLogger(GeoServerTileCache.class);
+
+    final Cache<Request, Set<RenderedImage>> images =
+            CacheBuilder.newBuilder().weakKeys().build();
+
+    @Override
+    public void add(RenderedImage owner, int tileX, int tileY, Raster data) {
+        recordImage(owner);
+        if (LOGGER.isLoggable(FINE)) {
+            LOGGER.fine(
+                    "Adding tile (%d,%d) for image %s[%d]".formatted(tileX, tileY, owner.getClass(), owner.hashCode()));
+        }
+        super.add(owner, tileX, tileY, data);
+    }
+
+    @Override
+    public void add(RenderedImage owner, int tileX, int tileY, Raster data, Object tileCacheMetric) {
+        recordImage(owner);
+        if (LOGGER.isLoggable(FINE)) {
+            LOGGER.fine(
+                    "Adding tile (%d,%d) for image %s[%d]".formatted(tileX, tileY, owner.getClass(), owner.hashCode()));
+        }
+        super.add(owner, tileX, tileY, data, tileCacheMetric);
+    }
+
+    @Override
+    public void addTiles(RenderedImage owner, Point[] tileIndices, Raster[] tiles, Object tileCacheMetric) {
+        recordImage(owner);
+        if (LOGGER.isLoggable(FINE)) {
+            LOGGER.fine("Adding tiles (%s) for image %s[%d]"
+                    .formatted(Arrays.toString(tileIndices), owner.getClass(), owner.hashCode()));
+        }
+        super.addTiles(owner, tileIndices, tiles, tileCacheMetric);
+    }
+
+    @Override
+    public Raster getTile(RenderedImage owner, int tileX, int tileY) {
+        if (LOGGER.isLoggable(FINE)) {
+            LOGGER.fine("Getting tile (%d,%d) for image %s[%d]"
+                    .formatted(tileX, tileY, owner.getClass(), owner.hashCode()));
+        }
+        return super.getTile(owner, tileX, tileY);
+    }
+
+    @Override
+    public Raster[] getTiles(RenderedImage owner) {
+        if (LOGGER.isLoggable(FINE)) {
+            LOGGER.fine("Getting all tiles for image %s[%d]".formatted(owner.getClass(), owner.hashCode()));
+        }
+        return super.getTiles(owner);
+    }
+
+    @Override
+    public Raster[] getTiles(RenderedImage owner, Point[] tileIndices) {
+        if (LOGGER.isLoggable(FINE)) {
+            LOGGER.fine("Getting tiles (%s) for image %s[%d]"
+                    .formatted(Arrays.toString(tileIndices), owner.getClass(), owner.hashCode()));
+        }
+        return super.getTiles(owner, tileIndices);
+    }
+
+    @Override
+    public void remove(RenderedImage owner, int tileX, int tileY) {
+        if (LOGGER.isLoggable(FINE)) {
+            LOGGER.fine("Removing tile (%d,%d) for image %s[%d]"
+                    .formatted(tileX, tileY, owner.getClass(), owner.hashCode()));
+        }
+        super.remove(owner, tileX, tileY);
+    }
+
+    /**
+     * Records the image as associated to the current request, so that we can clear its tiles at the end of the request.
+     */
+    private void recordImage(RenderedImage owner) {
+        Request request = Dispatcher.REQUEST.get();
+        if (request == null) return;
+
+        Set<RenderedImage> images = this.images.asMap().computeIfAbsent(request, r -> ConcurrentHashMap.newKeySet());
+        images.add(owner);
+    }
+
+    @Override
+    public void removeTiles(RenderedImage owner) {
+        if (LOGGER.isLoggable(FINE) && super.getTiles(owner) != null) {
+            LOGGER.fine("Removing all tiles for image %s[%d]".formatted(owner.getClass(), owner.hashCode()));
+        }
+        super.removeTiles(owner);
+    }
+
+    // ------------------------- DispatcherCallback methods -------------------------
+    // These methods ensure that the tile cache is cleared at the end of each request
+    // ------------------------------------------------------------------------------
+
+    @Override
+    public Request init(Request request) {
+        return request;
+    }
+
+    @Override
+    public Service serviceDispatched(Request request, Service service) throws ServiceException {
+        return service;
+    }
+
+    @Override
+    public Operation operationDispatched(Request request, Operation operation) {
+        return operation;
+    }
+
+    @Override
+    public Object operationExecuted(Request request, Operation operation, Object result) {
+        return result;
+    }
+
+    @Override
+    public Response responseDispatched(Request request, Operation operation, Object result, Response response) {
+        return response;
+    }
+
+    @Override
+    public void finished(Request request) {
+        Set<RenderedImage> images = this.images.getIfPresent(request);
+        if (images != null) {
+            for (RenderedImage image : images) {
+                removeTiles(image);
+            }
+        }
+        this.images.invalidate(request);
+    }
+}

--- a/src/main/src/main/java/org/geoserver/jai/JAIInitializer.java
+++ b/src/main/src/main/java/org/geoserver/jai/JAIInitializer.java
@@ -21,6 +21,12 @@ import org.geoserver.config.JAIInfo;
  */
 public class JAIInitializer implements GeoServerInitializer {
 
+    private final GeoServerTileCache tileCache;
+
+    public JAIInitializer(GeoServerTileCache tileCache) {
+        this.tileCache = tileCache;
+    }
+
     @Override
     public void initialize(GeoServer geoServer) throws Exception {
         initJAI(geoServer.getGlobal().getJAI());
@@ -48,6 +54,13 @@ public class JAIInitializer implements GeoServerInitializer {
 
         // setting JAI wide hints
         jaiDef.setRenderingHint(JAI.KEY_CACHED_TILE_RECYCLING_ENABLED, jai.isRecycling());
+
+        // force the tile cache to be the one provided by GeoServer
+        TileCache oldTileCache = jai.getTileCache();
+        if (oldTileCache != tileCache) {
+            jaiDef.setTileCache(tileCache);
+            oldTileCache.flush();
+        }
 
         // tile factory and recycler
         if (jai.isRecycling() && !(jaiDef.getRenderingHint(JAI.KEY_TILE_FACTORY) instanceof ConcurrentTileFactory)) {


### PR DESCRIPTION
[![GEOS-11934](https://badgen.net/badge/JIRA/GEOS-11934/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11934) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

With ImageN op images do not have finalizers anymore, which means the ImageN tile cache is either cleaned up at the end of request, or it will have to wait for memory pressure to be cleaned up.

Much better the first, and we can have a specific implementation that tracks images added in the context of a request, and forcefully clean them at the end of the request (dispatcher callback).

While we are at it, there’s also improved logging for that, integrated wit the geoserver loggers (tile adding/cleaning/getting, at fine level)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.