### PR TITLE
oidc: dont require oidc-specific filter chain (use "web/")

### DIFF
--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginAuthenticationFilterBuilder.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginAuthenticationFilterBuilder.java
@@ -78,6 +78,8 @@ import org.springframework.util.Assert;
  */
 public class GeoServerOAuth2LoginAuthenticationFilterBuilder implements GeoServerOAuth2ClientRegistrationId {
 
+    public final String DEFAULT_AUTHORIZATION_REQUEST_BASE_URI = "/web/oauth2/authorization";
+
     /** Filter types required for GeoServer */
     private static final List<Class<?>> REQ_FILTER_TYPES = asList(
             OAuth2AuthorizationRequestRedirectFilter.class,
@@ -165,6 +167,7 @@ public class GeoServerOAuth2LoginAuthenticationFilterBuilder implements GeoServe
             oauthConfig.userInfoEndpoint().oidcUserService(getOidcUserService());
             oauthConfig.authorizationEndpoint().authorizationRequestResolver(getAuthorizationRequestResolver());
             oauthConfig.tokenEndpoint().accessTokenResponseClient(getAccessTokenResponseClient());
+            oauthConfig.loginProcessingUrl("/web/login/oauth2/code/*");
         });
 
         httpSecurityCustomizer.accept(http);

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginFilterConfig.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginFilterConfig.java
@@ -121,7 +121,7 @@ public class GeoServerOAuth2LoginFilterConfig extends PreAuthenticatedUserNameFi
 
     private String redirectUri(String pRegId) {
         String lBase = baseRedirectUriNormalized();
-        return lBase + "login/oauth2/code/" + pRegId;
+        return lBase + "web/login/oauth2/code/" + pRegId;
     }
 
     private String createPostLogoutRedirectUri() {
@@ -157,7 +157,7 @@ public class GeoServerOAuth2LoginFilterConfig extends PreAuthenticatedUserNameFi
             return null;
         }
         String lBase = baseRedirectUriNormalized();
-        return lBase + "oauth2/authorization/" + lRegIds.get(0);
+        return lBase + "web/oauth2/authorization/" + lRegIds.get(0);
     }
 
     /**

--- a/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/DiscoveryClient.java
+++ b/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/DiscoveryClient.java
@@ -58,6 +58,7 @@ public class DiscoveryClient {
         Optional.ofNullable(response.get(SCOPES_SUPPORTED)).ifPresent(s -> {
             @SuppressWarnings("unchecked")
             List<String> scopes = (List<String>) s;
+            scopes.remove("service_account"); // in keycloak this causes problems...
             conf.setOidcScopes(collectScopes(scopes));
         });
     }

--- a/src/community/security/oidc/oidc-web/src/main/resources/applicationContext.xml
+++ b/src/community/security/oidc/oidc-web/src/main/resources/applicationContext.xml
@@ -58,7 +58,7 @@
  		<property name="name" value="openidconnect-google" />
  		<property name="icon" value="google.png" />
  		<property name="filterClass" value="org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter" />
- 		<property name="loginPath" value="/oauth2/authorization/google" />
+ 		<property name="loginPath" value="/web/oauth2/authorization/google" />
  		<property name="method" value="GET" />
  		<property name="enabled" value="false" />
  	</bean>
@@ -71,7 +71,7 @@
         <property name="name" value="openidconnect-github" />
         <property name="icon" value="github.png" />
         <property name="filterClass" value="org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter" />
-        <property name="loginPath" value="/oauth2/authorization/gitHub" />
+        <property name="loginPath" value="/web/oauth2/authorization/gitHub" />
         <property name="method" value="GET" />
         <property name="enabled" value="false" />
     </bean>
@@ -84,7 +84,7 @@
         <property name="name" value="openidconnect-microsoft" />
         <property name="icon" value="microsoft.png" />
         <property name="filterClass" value="org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter" />
-        <property name="loginPath" value="/oauth2/authorization/microsoft" />
+        <property name="loginPath" value="/web/oauth2/authorization/microsoft" />
         <property name="method" value="GET" />
         <property name="enabled" value="false" />
     </bean>
@@ -97,7 +97,7 @@
         <property name="name" value="openidconnect-oidc" />
         <property name="icon" value="openid.png" />
         <property name="filterClass" value="org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter" />
-        <property name="loginPath" value="/oauth2/authorization/oidc" />
+        <property name="loginPath" value="/web/oauth2/authorization/oidc" />
         <property name="method" value="GET" />
         <property name="enabled" value="false" />
     </bean>


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

During testing, I noticed that the login/logout wasn't working.
This is because it was using a URL like `http://localhost:8080/geoserver/oauth2/authorization/oidc`.
The user would have to setup their own (new) filter chain so that this would be processed.

I've change the login/logout urls so they are under `web/` ie. `http://localhost:8080/geoserver/web/oauth2/authorization/oidc`.  I had to also modify the redirect-from-idp (i.e. with the code) and the logout.

I also noticed that it was taking the `service_account` scope from keycloak by default - this causes problems so I remove it in the Discovery Client.  This shouldn't cause any issues.

1. used "web/" endpoints so you don't need to create an entirely new filter chain.  This would have caused no end of problems for users.
2. remove  `service_account` scope
3. update intgration test case so it doesn't add the new filter chain


Next (not this PR), I am looking at the login-button.  Its not `Content-security-policy` compliant because the form response will redirect to the IDP - which isn't allowed.  I'll see if that's fixable by - but it buried deep inside wicket.


<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.
