### PR TITLE
2.27.x - Reverting breifMap to briefMap rename, that was breaking community plugins

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
@@ -217,7 +217,7 @@ public abstract class BackupRestoreItem<T> {
                 String concatenatedPasswordTokens = jobParameters.getString(Backup.PARAM_PASSWORD_TOKENS);
                 Map<String, String> passwordTokens = parseConcatenatedPasswordTokens(concatenatedPasswordTokens);
                 this.xp.registerConverter(new TokenizedFieldConverter(passwordTokens));
-                xstream.registerBriefMapComplexType("tokenizedPassword", BackupRestoreItem.class);
+                xstream.registerBreifMapComplexType("tokenizedPassword", BackupRestoreItem.class);
             }
         }
 
@@ -347,7 +347,7 @@ public abstract class BackupRestoreItem<T> {
     }
 
     private MapConverter createParameterizingMapConverter(XStreamPersister xstream) {
-        return xstream.new BriefMapConverter() {
+        return xstream.new BreifMapConverter() {
             @Override
             public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
                 ParameterizedFieldsHolder fieldsToParametrize =

--- a/src/community/cog/cog-core/src/main/java/org/geoserver/cog/CogSettingsXStreamInitializer.java
+++ b/src/community/cog/cog-core/src/main/java/org/geoserver/cog/CogSettingsXStreamInitializer.java
@@ -13,8 +13,8 @@ public class CogSettingsXStreamInitializer implements XStreamPersisterInitialize
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("cogSettings", CogSettings.class);
-        persister.registerBriefMapComplexType("cogSettingsStore", CogSettingsStore.class);
+        persister.registerBreifMapComplexType("cogSettings", CogSettings.class);
+        persister.registerBreifMapComplexType("cogSettingsStore", CogSettingsStore.class);
         XStream xs = persister.getXStream();
         xs.alias("cogSettings", CogSettings.class);
         xs.alias("cogSettingsStore", CogSettingsStore.class);

--- a/src/community/dyndimension/src/main/java/org/geoserver/wms/dimension/DynamicDefaultXStreamInitializer.java
+++ b/src/community/dyndimension/src/main/java/org/geoserver/wms/dimension/DynamicDefaultXStreamInitializer.java
@@ -19,7 +19,7 @@ public class DynamicDefaultXStreamInitializer implements XStreamPersisterInitial
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType(
+        persister.registerBreifMapComplexType(
                 "DynamicDefaultValues", DefaultValueConfigurations.class);
         XStream xs = persister.getXStream();
         xs.alias("configuration", DefaultValueConfiguration.class);

--- a/src/community/elasticsearch/src/main/java/org/geoserver/elasticsearch/ElasticXStreamInitializer.java
+++ b/src/community/elasticsearch/src/main/java/org/geoserver/elasticsearch/ElasticXStreamInitializer.java
@@ -17,7 +17,7 @@ class ElasticXStreamInitializer implements XStreamPersisterInitializer {
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("elasticLayerConfiguration", ElasticLayerConfiguration.class);
+        persister.registerBreifMapComplexType("elasticLayerConfiguration", ElasticLayerConfiguration.class);
         XStream xs = persister.getXStream();
         xs.alias("esAttribute", ElasticAttribute.class);
     }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/TemplateLayerConfigXStreamPersisterInitializer.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/TemplateLayerConfigXStreamPersisterInitializer.java
@@ -14,7 +14,7 @@ public class TemplateLayerConfigXStreamPersisterInitializer implements XStreamPe
     public void init(XStreamPersister persister) {
         persister.getXStream().alias("Rule", TemplateRule.class);
         persister.getXStream().alias("TemplateLayerConfig", TemplateLayerConfig.class);
-        persister.registerBriefMapComplexType("TemplateRuleType", TemplateRule.class);
-        persister.registerBriefMapComplexType("LayerConfigType", TemplateLayerConfig.class);
+        persister.registerBreifMapComplexType("TemplateRuleType", TemplateRule.class);
+        persister.registerBreifMapComplexType("LayerConfigType", TemplateLayerConfig.class);
     }
 }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/schema/SchemaLayerConfigXStreamPersisterInitializer.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/schema/SchemaLayerConfigXStreamPersisterInitializer.java
@@ -14,7 +14,7 @@ public class SchemaLayerConfigXStreamPersisterInitializer implements XStreamPers
     public void init(XStreamPersister persister) {
         persister.getXStream().alias("SchemaRule", SchemaRule.class);
         persister.getXStream().alias("SchemaLayerConfig", SchemaLayerConfig.class);
-        persister.registerBriefMapComplexType("SchemaRuleType", SchemaRule.class);
-        persister.registerBriefMapComplexType("SchemaLayerConfigType", SchemaLayerConfig.class);
+        persister.registerBreifMapComplexType("SchemaRuleType", SchemaRule.class);
+        persister.registerBreifMapComplexType("SchemaLayerConfigType", SchemaLayerConfig.class);
     }
 }

--- a/src/community/libdeflate/src/main/java/org/geoserver/libdeflate/LibdeflateSettingsXStreamInitializer.java
+++ b/src/community/libdeflate/src/main/java/org/geoserver/libdeflate/LibdeflateSettingsXStreamInitializer.java
@@ -13,7 +13,7 @@ public class LibdeflateSettingsXStreamInitializer implements XStreamPersisterIni
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("libdeflateSettings", LibdeflateSettings.class);
+        persister.registerBreifMapComplexType("libdeflateSettings", LibdeflateSettings.class);
         XStream xs = persister.getXStream();
         xs.alias("libdeflateSettings", LibdeflateSettings.class);
     }

--- a/src/community/ncwms/src/main/java/org/geoserver/wms/ncwms/NcWmsXStreamInitializer.java
+++ b/src/community/ncwms/src/main/java/org/geoserver/wms/ncwms/NcWmsXStreamInitializer.java
@@ -12,7 +12,7 @@ public class NcWmsXStreamInitializer implements XStreamPersisterInitializer {
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("ncwms", NcWmsInfo.class);
+        persister.registerBreifMapComplexType("ncwms", NcWmsInfo.class);
         XStream xs = persister.getXStream();
         xs.allowTypes(new Class[] {NcWmsInfo.class, NcWMSInfoImpl.class});
         xs.addDefaultImplementation(NcWMSInfoImpl.class, NcWmsInfo.class);

--- a/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StylesXStreamPersisterInitializer.java
+++ b/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StylesXStreamPersisterInitializer.java
@@ -16,7 +16,7 @@ public class StylesXStreamPersisterInitializer implements XStreamPersisterInitia
         XStream xs = persister.getXStream();
         xs.alias("StyleMetadata", StyleMetadataInfo.class);
         xs.aliasField("abstract", StyleMetadataInfo.class, "abstrct");
-        persister.registerBriefMapComplexType("styleMetadata", StyleMetadataInfo.class);
+        persister.registerBreifMapComplexType("styleMetadata", StyleMetadataInfo.class);
         xs.allowTypes(new Class[] {StyleMetadataInfo.class});
     }
 }

--- a/src/community/solr/src/main/java/org/geoserver/solr/SolrXStreamInitializer.java
+++ b/src/community/solr/src/main/java/org/geoserver/solr/SolrXStreamInitializer.java
@@ -17,7 +17,7 @@ public class SolrXStreamInitializer implements XStreamPersisterInitializer {
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("solrLayerConfiguration", SolrLayerConfiguration.class);
+        persister.registerBreifMapComplexType("solrLayerConfiguration", SolrLayerConfiguration.class);
         XStream xs = persister.getXStream();
         xs.alias("solrAttribute", SolrAttribute.class);
         xs.allowTypes(new Class[] {SolrAttribute.class, SolrLayerConfiguration.class});

--- a/src/extension/csw/core/src/main/java/org/geoserver/csw/DirectDownloadSettingsXStreamInitializer.java
+++ b/src/extension/csw/core/src/main/java/org/geoserver/csw/DirectDownloadSettingsXStreamInitializer.java
@@ -12,7 +12,7 @@ public class DirectDownloadSettingsXStreamInitializer implements XStreamPersiste
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("directDownloadSettings", DirectDownloadSettings.class);
+        persister.registerBreifMapComplexType("directDownloadSettings", DirectDownloadSettings.class);
         XStream xs = persister.getXStream();
         xs.alias("directDownloadSettings", DirectDownloadSettings.class);
     }

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/TestInspireXstream.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/TestInspireXstream.java
@@ -22,7 +22,7 @@ public class TestInspireXstream {
         XStreamPersisterFactory factory = new XStreamPersisterFactory();
         XStreamPersister xp = factory.createXMLPersister();
         // Register list type
-        xp.registerBriefMapComplexType("list", List.class);
+        xp.registerBreifMapComplexType("list", List.class);
         // Set UniqueResourceIdentifiers to be ignored by XStream type lookup
         xp.addBackwardsBriefIgnored(UniqueResourceIdentifiers.class);
 
@@ -42,7 +42,7 @@ public class TestInspireXstream {
         XStreamPersisterFactory factory = new XStreamPersisterFactory();
         XStreamPersister xp = factory.createXMLPersister();
         // Register list type
-        xp.registerBriefMapComplexType("list", List.class);
+        xp.registerBreifMapComplexType("list", List.class);
 
         WFSInfoImpl wfsInfo = new WFSInfoImpl();
         MetadataMap metadata = wfsInfo.getMetadata();

--- a/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/MetadataXStreamInitializer.java
+++ b/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/MetadataXStreamInitializer.java
@@ -15,7 +15,7 @@ public class MetadataXStreamInitializer implements XStreamPersisterInitializer {
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("map", HashMap.class);
-        persister.registerBriefMapComplexType("date", Date.class);
+        persister.registerBreifMapComplexType("map", HashMap.class);
+        persister.registerBreifMapComplexType("date", Date.class);
     }
 }

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/ExtraVariableXStreamInitializer.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/ExtraVariableXStreamInitializer.java
@@ -14,7 +14,7 @@ public class ExtraVariableXStreamInitializer implements XStreamPersisterInitiali
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("extraVariable", ExtraVariable.class);
+        persister.registerBreifMapComplexType("extraVariable", ExtraVariable.class);
         XStream xs = persister.getXStream();
         xs.alias("extraVariable", ExtraVariable.class);
     }

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/GlobalAttributeXStreamInitializer.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/GlobalAttributeXStreamInitializer.java
@@ -13,7 +13,7 @@ public class GlobalAttributeXStreamInitializer implements XStreamPersisterInitia
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("globalAttribute", GlobalAttribute.class);
+        persister.registerBreifMapComplexType("globalAttribute", GlobalAttribute.class);
         XStream xs = persister.getXStream();
         xs.alias("globalAttribute", GlobalAttribute.class);
     }

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFContainerXStreamInitializer.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFContainerXStreamInitializer.java
@@ -13,8 +13,8 @@ public class NetCDFContainerXStreamInitializer implements XStreamPersisterInitia
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("netcdfSettingsContainer", NetCDFSettingsContainer.class);
-        persister.registerBriefMapComplexType("netcdfLayerSettingsContainer", NetCDFLayerSettingsContainer.class);
+        persister.registerBreifMapComplexType("netcdfSettingsContainer", NetCDFSettingsContainer.class);
+        persister.registerBreifMapComplexType("netcdfLayerSettingsContainer", NetCDFLayerSettingsContainer.class);
         XStream xs = persister.getXStream();
         xs.alias("netCDFSettings", NetCDFSettingsContainer.class);
         xs.alias("netCDFLayerSettings", NetCDFLayerSettingsContainer.class);

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/VariableAttributeXStreamInitializer.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/VariableAttributeXStreamInitializer.java
@@ -14,7 +14,7 @@ public class VariableAttributeXStreamInitializer implements XStreamPersisterInit
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("variableAttribute", VariableAttribute.class);
+        persister.registerBreifMapComplexType("variableAttribute", VariableAttribute.class);
         XStream xs = persister.getXStream();
         xs.alias("variableAttribute", VariableAttribute.class);
     }

--- a/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/OGCAPIXStreamPersisterInitializer.java
+++ b/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/OGCAPIXStreamPersisterInitializer.java
@@ -19,7 +19,7 @@ public class OGCAPIXStreamPersisterInitializer implements XStreamPersisterInitia
         XStream xs = persister.getXStream();
         xs.alias("link", LinkInfo.class);
         xs.addDefaultImplementation(LinkInfoImpl.class, LinkInfo.class);
-        persister.registerBriefMapComplexType("list", List.class);
+        persister.registerBreifMapComplexType("list", List.class);
         xs.allowTypes(new Class[] {LinkInfo.class});
     }
 }

--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureServiceXStreamPersisterInitializer.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureServiceXStreamPersisterInitializer.java
@@ -12,9 +12,9 @@ import org.geoserver.config.util.XStreamPersisterInitializer;
 public class FeatureServiceXStreamPersisterInitializer implements XStreamPersisterInitializer {
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("ogcapiFeatures", FeatureConformance.class);
-        persister.registerBriefMapComplexType("cql2", CQL2Conformance.class);
-        persister.registerBriefMapComplexType("ecql", ECQLConformance.class);
+        persister.registerBreifMapComplexType("ogcapiFeatures", FeatureConformance.class);
+        persister.registerBreifMapComplexType("cql2", CQL2Conformance.class);
+        persister.registerBreifMapComplexType("ecql", ECQLConformance.class);
 
         XStream xs = persister.getXStream();
         xs.allowTypes(new Class[] {FeatureConformance.class});

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -1228,7 +1228,7 @@ public class XStreamPersisterTest {
         factory.addInitializer(persister -> {
             persister.getXStream().alias("sweetBanana", SweetBanana.class);
             persister.getXStream().aliasAttribute(SweetBanana.class, "scientificName", "name");
-            persister.registerBriefMapComplexType("sweetBanana", SweetBanana.class);
+            persister.registerBreifMapComplexType("sweetBanana", SweetBanana.class);
         });
         XStreamPersister persister = factory.createXMLPersister();
 

--- a/src/main/src/test/java/org/geoserver/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/util/XStreamPersisterTest.java
@@ -21,7 +21,7 @@ public class XStreamPersisterTest {
         XStreamPersisterFactory factory = new XStreamPersisterFactory();
         XStreamPersister xp = factory.createXMLPersister();
         // Register number type
-        xp.registerBriefMapComplexType("number", Number.class);
+        xp.registerBreifMapComplexType("number", Number.class);
         // Set Integer to be ignored by XStream type lookup
         xp.addBackwardsBriefIgnored(Integer.class);
 
@@ -42,7 +42,7 @@ public class XStreamPersisterTest {
         XStreamPersisterFactory factory = new XStreamPersisterFactory();
         XStreamPersister xp = factory.createXMLPersister();
         // Register number type
-        xp.registerBriefMapComplexType("number", Number.class);
+        xp.registerBreifMapComplexType("number", Number.class);
 
         DataStoreInfoImpl dataStoreInfo = new DataStoreInfoImpl(null);
         MetadataMap metadata = dataStoreInfo.getMetadata();

--- a/src/wfs/src/main/java/org/geoserver/wfs/WFSXStreamPersisterInitializer.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/WFSXStreamPersisterInitializer.java
@@ -34,6 +34,6 @@ public class WFSXStreamPersisterInitializer implements XStreamPersisterInitializ
             ParameterMappingBlockValue.class
         });
 
-        persister.registerBriefMapComplexType("storedQueryConfiguration", StoredQueryConfiguration.class);
+        persister.registerBreifMapComplexType("storedQueryConfiguration", StoredQueryConfiguration.class);
     }
 }


### PR DESCRIPTION
A recent update of some XStream method (due to an old typo having Breif instead of Brief) broken some community plugins that still use 2.27.2.
Reverting the rename so that the community modules still work with 2.27.2


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.