### PR TITLE
[GEOS-11935] GS Base Page Header: Allow non-form login to be simple links (html anchors)

### DIFF
--- a/src/community/security/oidc/oidc-web/src/main/resources/applicationContext.xml
+++ b/src/community/security/oidc/oidc-web/src/main/resources/applicationContext.xml
@@ -61,7 +61,8 @@
  		<property name="loginPath" value="/oauth2/authorization/google" />
  		<property name="method" value="GET" />
  		<property name="enabled" value="false" />
- 	</bean>
+        <property name="justUseExternalLink" value="true" />
+    </bean>
  	  <bean id="openIdConnectGitHubLoginButton" class="org.geoserver.web.LoginFormInfo">
  	  <!-- id must contain Spring oauthClient registrationId for enablement to work -->
         <property name="id" value="openIdConnectGitHubLoginButton" />
@@ -74,8 +75,9 @@
         <property name="loginPath" value="/oauth2/authorization/gitHub" />
         <property name="method" value="GET" />
         <property name="enabled" value="false" />
-    </bean>
-          <bean id="openIdConnectMicrosoftLoginButton" class="org.geoserver.web.LoginFormInfo">
+        <property name="justUseExternalLink" value="true" />
+      </bean>
+      <bean id="openIdConnectMicrosoftLoginButton" class="org.geoserver.web.LoginFormInfo">
       <!-- id must contain Spring oauthClient registrationId for enablement to work -->
         <property name="id" value="openIdConnectMicrosoftLoginButton" />
         <property name="titleKey" value="" />
@@ -87,7 +89,8 @@
         <property name="loginPath" value="/oauth2/authorization/microsoft" />
         <property name="method" value="GET" />
         <property name="enabled" value="false" />
-    </bean>
+        <property name="justUseExternalLink" value="true" />
+          </bean>
     <bean id="openIdConnectOidcLoginButton" class="org.geoserver.web.LoginFormInfo">
         <!-- id must contain Spring oauthClient registrationId for enablement to work -->
         <property name="id" value="openIdConnectOidcLoginButton" />
@@ -100,6 +103,7 @@
         <property name="loginPath" value="/oauth2/authorization/oidc" />
         <property name="method" value="GET" />
         <property name="enabled" value="false" />
+        <property name="justUseExternalLink" value="true" />
     </bean>
     <bean id="oauth2LoginButtonManager" class="org.geoserver.web.security.oauth2.login.OAuth2LoginButtonManager" lazy-init="false">
         <property name="loginFormInfos">

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
@@ -12,6 +12,7 @@
     <div class="wrap">
       <h2><a wicket:id="home" class="pngfix" href="#"></a></h2>
       <div class="button-group selfclear">
+
 	      <span wicket:id="loginforms">
 	      	<form class="d-inline-block" wicket:id="loginform" method="post" action="../j_spring_security_check">
 	      		<span wicket:id="login.include"></span>
@@ -20,13 +21,18 @@
 	      		</button>
 	      	</form>
 	      </span>
+
+        <span wicket:id="loginExternalLinks">
+           <a class="d-inline-block" wicket:id="loginform" >
+              <div><img src="#" wicket:id="link.icon"/><span wicket:id="link.label"></span></div>
+           </a>
+	      </span>
+
 	      
 	      <span wicket:id="loggedinasform" class="username"><wicket:message key="loggedInAs">Logged in as</wicket:message> <span wicket:id="loggedInUsername">User von Testenheimer</span>.</span>
-            <form class="d-inline-block" wicket:id="logoutform" method="post" action="j_spring_security_logout">
-                <button class="positive icon" type="submit">
+            <a class="d-inline-block" wicket:id="logoutform">
                     <div><img src="#" wicket:id="link.icon"/><span wicket:id="link.label"></span></div>
-                </button>
-            </form>
+            </a>
         <span id="localeSwitcher"><wicket:link><img src="img/icons/globe.png"/></wicket:link> <select  wicket:id="localeSwitcher"></select></span>
       </div>
     </div><!-- /.wrap -->

--- a/src/web/core/src/main/java/org/geoserver/web/LoginFormInfo.java
+++ b/src/web/core/src/main/java/org/geoserver/web/LoginFormInfo.java
@@ -22,6 +22,13 @@ public class LoginFormInfo extends ComponentInfo<GeoServerBasePage> implements C
     private String method = "post";
     private boolean enabled = true;
 
+    /**
+     * Set this to true if you want the login button to just be an external link - instead of a form. This allows for
+     * easier content-security-policy management since a form that redirect externally is typically not allowed. a)
+     * shouldn't have any form field (i.e. user/password) #include = null b) should be GET (method="GET")
+     */
+    private boolean justUseExternalLink = false;
+
     /** Name of the login extension; it will determine also the order displayed for the icons */
     public void setName(String name) {
         this.name = name;
@@ -120,5 +127,15 @@ public class LoginFormInfo extends ComponentInfo<GeoServerBasePage> implements C
     /** @param pEnabled the enabled to set */
     public void setEnabled(boolean pEnabled) {
         enabled = pEnabled;
+    }
+
+    /** @return the justUseExternalLink */
+    public boolean isJustUseExternalLink() {
+        return justUseExternalLink;
+    }
+
+    /** @param pJustUseExternalLink mark this form as Just-Use-External-Link */
+    public void setJustUseExternalLink(boolean pJustUseExternalLink) {
+        justUseExternalLink = pJustUseExternalLink;
     }
 }

--- a/src/web/core/src/test/java/org/geoserver/web/GeoServerBasePageTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/GeoServerBasePageTest.java
@@ -38,8 +38,8 @@ public class GeoServerBasePageTest extends GeoServerWicketTestSupport {
         assertEquals(1, loginForms.getList().size());
         Component logoutforms = tester.getLastRenderedPage().get("logoutform");
         String responseTxt = ComponentRenderer.renderComponent(logoutforms).toString();
-        TagTester tagTester = TagTester.createTagByName(responseTxt, "form");
-        assertEquals("http://localhost/context/j_spring_security_logout", tagTester.getAttribute("action"));
+        TagTester tagTester = TagTester.createTagByName(responseTxt, "a");
+        assertEquals("http://localhost/context/j_spring_security_logout", tagTester.getAttribute("href"));
     }
 
     @Test

--- a/src/web/security/core/src/test/java/org/geoserver/security/web/auth/AuthenticationPageTest.java
+++ b/src/web/security/core/src/test/java/org/geoserver/security/web/auth/AuthenticationPageTest.java
@@ -82,6 +82,6 @@ public class AuthenticationPageTest extends AbstractSecurityWicketTestSupport {
         tester.assertRenderedPage(AuthenticationPage.class);
         TagTester logoutform = tester.getTagByWicketId("logoutform");
         // used to be http://localhost/j_spring_security_logout
-        assertEquals("http://localhost/context/j_spring_security_logout", logoutform.getAttribute("action"));
+        assertEquals("http://localhost/context/j_spring_security_logout", logoutform.getAttribute("href"));
     }
 }


### PR DESCRIPTION
[![GEOS-11935](https://badgen.net/badge/JIRA/GEOS-11935/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11935) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--Include a few sentences describing the overall goals for this Pull Request-->

For external authentication (i.e. OIDC), GS's current behaviour is a form-submit-which-redirects-to-external-location (i.e. the off-site IDP provider).

Unfortunately, this isn't "legal" from the `content-security-policy` and the browser will block the redirect.  This can be solved by adding the IDP's address to the `content-security-policy` (Security -> Content Security Policy), but this is user-hostile.

Instead, this PR changes the behaviour so that SOME login buttons are simple anchors (`<a href=...>`) to avoid the form-submit-which-redirects-to-external-location.

1. I've introduced `justUseExternalLink` (default is FALSE) to the login button model
2.    If FALSE then do exactly as before (no change)
3.    If TRUE then instead of a `<form>` submit, just use a `<a href=...>`
4. This also sets the new OIDC login buttons as `justUseExternalLink=true` (new behaviour)
5.  I also changed the `logout` button to be a simple anchor (`<a href=...>`) because, for OIDC, it will re-direct to the IDP's logout (and redirect back to GS).  The old behaviour would be block by Content-Security-Policy.



<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.