### PR TITLE
2.26.x - Reverting breifMap to briefMap rename, that was breaking community plugins

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
@@ -217,7 +217,7 @@ public abstract class BackupRestoreItem<T> {
                 String concatenatedPasswordTokens = jobParameters.getString(Backup.PARAM_PASSWORD_TOKENS);
                 Map<String, String> passwordTokens = parseConcatenatedPasswordTokens(concatenatedPasswordTokens);
                 this.xp.registerConverter(new TokenizedFieldConverter(passwordTokens));
-                xstream.registerBriefMapComplexType("tokenizedPassword", BackupRestoreItem.class);
+                xstream.registerBreifMapComplexType("tokenizedPassword", BackupRestoreItem.class);
             }
         }
 
@@ -347,7 +347,7 @@ public abstract class BackupRestoreItem<T> {
     }
 
     private MapConverter createParameterizingMapConverter(XStreamPersister xstream) {
-        return xstream.new BriefMapConverter() {
+        return xstream.new BreifMapConverter() {
             @Override
             public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
                 ParameterizedFieldsHolder fieldsToParametrize =

--- a/src/community/cog/cog-core/src/main/java/org/geoserver/cog/CogSettingsXStreamInitializer.java
+++ b/src/community/cog/cog-core/src/main/java/org/geoserver/cog/CogSettingsXStreamInitializer.java
@@ -13,8 +13,8 @@ public class CogSettingsXStreamInitializer implements XStreamPersisterInitialize
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("cogSettings", CogSettings.class);
-        persister.registerBriefMapComplexType("cogSettingsStore", CogSettingsStore.class);
+        persister.registerBreifMapComplexType("cogSettings", CogSettings.class);
+        persister.registerBreifMapComplexType("cogSettingsStore", CogSettingsStore.class);
         XStream xs = persister.getXStream();
         xs.alias("cogSettings", CogSettings.class);
         xs.alias("cogSettingsStore", CogSettingsStore.class);

--- a/src/community/dyndimension/src/main/java/org/geoserver/wms/dimension/DynamicDefaultXStreamInitializer.java
+++ b/src/community/dyndimension/src/main/java/org/geoserver/wms/dimension/DynamicDefaultXStreamInitializer.java
@@ -19,8 +19,7 @@ public class DynamicDefaultXStreamInitializer implements XStreamPersisterInitial
 
     @Override
     public void init(XStreamPersister persister) {
-
-        persister.registerBriefMapComplexType("DynamicDefaultValues", DefaultValueConfigurations.class);
+        persister.registerBreifMapComplexType("DynamicDefaultValues", DefaultValueConfigurations.class);
         XStream xs = persister.getXStream();
         xs.alias("configuration", DefaultValueConfiguration.class);
         xs.allowTypeHierarchy(org.geoserver.wms.dimension.DefaultValueConfiguration.class);

--- a/src/community/elasticsearch/src/main/java/org/geoserver/elasticsearch/ElasticXStreamInitializer.java
+++ b/src/community/elasticsearch/src/main/java/org/geoserver/elasticsearch/ElasticXStreamInitializer.java
@@ -17,7 +17,7 @@ class ElasticXStreamInitializer implements XStreamPersisterInitializer {
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("elasticLayerConfiguration", ElasticLayerConfiguration.class);
+        persister.registerBreifMapComplexType("elasticLayerConfiguration", ElasticLayerConfiguration.class);
         XStream xs = persister.getXStream();
         xs.alias("esAttribute", ElasticAttribute.class);
     }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/TemplateLayerConfigXStreamPersisterInitializer.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/TemplateLayerConfigXStreamPersisterInitializer.java
@@ -14,7 +14,7 @@ public class TemplateLayerConfigXStreamPersisterInitializer implements XStreamPe
     public void init(XStreamPersister persister) {
         persister.getXStream().alias("Rule", TemplateRule.class);
         persister.getXStream().alias("TemplateLayerConfig", TemplateLayerConfig.class);
-        persister.registerBriefMapComplexType("TemplateRuleType", TemplateRule.class);
-        persister.registerBriefMapComplexType("LayerConfigType", TemplateLayerConfig.class);
+        persister.registerBreifMapComplexType("TemplateRuleType", TemplateRule.class);
+        persister.registerBreifMapComplexType("LayerConfigType", TemplateLayerConfig.class);
     }
 }

--- a/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/schema/SchemaLayerConfigXStreamPersisterInitializer.java
+++ b/src/community/features-templating/features-templating-core/src/main/java/org/geoserver/featurestemplating/configuration/schema/SchemaLayerConfigXStreamPersisterInitializer.java
@@ -14,7 +14,7 @@ public class SchemaLayerConfigXStreamPersisterInitializer implements XStreamPers
     public void init(XStreamPersister persister) {
         persister.getXStream().alias("SchemaRule", SchemaRule.class);
         persister.getXStream().alias("SchemaLayerConfig", SchemaLayerConfig.class);
-        persister.registerBriefMapComplexType("SchemaRuleType", SchemaRule.class);
-        persister.registerBriefMapComplexType("SchemaLayerConfigType", SchemaLayerConfig.class);
+        persister.registerBreifMapComplexType("SchemaRuleType", SchemaRule.class);
+        persister.registerBreifMapComplexType("SchemaLayerConfigType", SchemaLayerConfig.class);
     }
 }

--- a/src/community/libdeflate/src/main/java/org/geoserver/libdeflate/LibdeflateSettingsXStreamInitializer.java
+++ b/src/community/libdeflate/src/main/java/org/geoserver/libdeflate/LibdeflateSettingsXStreamInitializer.java
@@ -13,7 +13,7 @@ public class LibdeflateSettingsXStreamInitializer implements XStreamPersisterIni
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("libdeflateSettings", LibdeflateSettings.class);
+        persister.registerBreifMapComplexType("libdeflateSettings", LibdeflateSettings.class);
         XStream xs = persister.getXStream();
         xs.alias("libdeflateSettings", LibdeflateSettings.class);
     }

--- a/src/community/ncwms/src/main/java/org/geoserver/wms/ncwms/NcWmsXStreamInitializer.java
+++ b/src/community/ncwms/src/main/java/org/geoserver/wms/ncwms/NcWmsXStreamInitializer.java
@@ -12,7 +12,7 @@ public class NcWmsXStreamInitializer implements XStreamPersisterInitializer {
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("ncwms", NcWmsInfo.class);
+        persister.registerBreifMapComplexType("ncwms", NcWmsInfo.class);
         XStream xs = persister.getXStream();
         xs.allowTypes(new Class[] {NcWmsInfo.class, NcWMSInfoImpl.class});
         xs.addDefaultImplementation(NcWMSInfoImpl.class, NcWmsInfo.class);

--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/OGCAPIXStreamPersisterInitializer.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/OGCAPIXStreamPersisterInitializer.java
@@ -19,7 +19,7 @@ public class OGCAPIXStreamPersisterInitializer implements XStreamPersisterInitia
         XStream xs = persister.getXStream();
         xs.alias("link", LinkInfo.class);
         xs.addDefaultImplementation(LinkInfoImpl.class, LinkInfo.class);
-        persister.registerBriefMapComplexType("list", List.class);
+        persister.registerBreifMapComplexType("list", List.class);
         xs.allowTypes(new Class[] {LinkInfo.class});
     }
 }

--- a/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StylesXStreamPersisterInitializer.java
+++ b/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StylesXStreamPersisterInitializer.java
@@ -16,7 +16,7 @@ public class StylesXStreamPersisterInitializer implements XStreamPersisterInitia
         XStream xs = persister.getXStream();
         xs.alias("StyleMetadata", StyleMetadataInfo.class);
         xs.aliasField("abstract", StyleMetadataInfo.class, "abstrct");
-        persister.registerBriefMapComplexType("styleMetadata", StyleMetadataInfo.class);
+        persister.registerBreifMapComplexType("styleMetadata", StyleMetadataInfo.class);
         xs.allowTypes(new Class[] {StyleMetadataInfo.class});
     }
 }

--- a/src/community/solr/src/main/java/org/geoserver/solr/SolrXStreamInitializer.java
+++ b/src/community/solr/src/main/java/org/geoserver/solr/SolrXStreamInitializer.java
@@ -17,7 +17,7 @@ public class SolrXStreamInitializer implements XStreamPersisterInitializer {
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("solrLayerConfiguration", SolrLayerConfiguration.class);
+        persister.registerBreifMapComplexType("solrLayerConfiguration", SolrLayerConfiguration.class);
         XStream xs = persister.getXStream();
         xs.alias("solrAttribute", SolrAttribute.class);
         xs.allowTypes(new Class[] {SolrAttribute.class, SolrLayerConfiguration.class});

--- a/src/extension/csw/core/src/main/java/org/geoserver/csw/DirectDownloadSettingsXStreamInitializer.java
+++ b/src/extension/csw/core/src/main/java/org/geoserver/csw/DirectDownloadSettingsXStreamInitializer.java
@@ -12,7 +12,7 @@ public class DirectDownloadSettingsXStreamInitializer implements XStreamPersiste
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("directDownloadSettings", DirectDownloadSettings.class);
+        persister.registerBreifMapComplexType("directDownloadSettings", DirectDownloadSettings.class);
         XStream xs = persister.getXStream();
         xs.alias("directDownloadSettings", DirectDownloadSettings.class);
     }

--- a/src/extension/inspire/src/test/java/org/geoserver/inspire/TestInspireXstream.java
+++ b/src/extension/inspire/src/test/java/org/geoserver/inspire/TestInspireXstream.java
@@ -22,7 +22,7 @@ public class TestInspireXstream {
         XStreamPersisterFactory factory = new XStreamPersisterFactory();
         XStreamPersister xp = factory.createXMLPersister();
         // Register list type
-        xp.registerBriefMapComplexType("list", List.class);
+        xp.registerBreifMapComplexType("list", List.class);
         // Set UniqueResourceIdentifiers to be ignored by XStream type lookup
         xp.addBackwardsBriefIgnored(UniqueResourceIdentifiers.class);
 
@@ -42,7 +42,7 @@ public class TestInspireXstream {
         XStreamPersisterFactory factory = new XStreamPersisterFactory();
         XStreamPersister xp = factory.createXMLPersister();
         // Register list type
-        xp.registerBriefMapComplexType("list", List.class);
+        xp.registerBreifMapComplexType("list", List.class);
 
         WFSInfoImpl wfsInfo = new WFSInfoImpl();
         MetadataMap metadata = wfsInfo.getMetadata();

--- a/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/MetadataXStreamInitializer.java
+++ b/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/MetadataXStreamInitializer.java
@@ -15,7 +15,7 @@ public class MetadataXStreamInitializer implements XStreamPersisterInitializer {
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("map", HashMap.class);
-        persister.registerBriefMapComplexType("date", Date.class);
+        persister.registerBreifMapComplexType("map", HashMap.class);
+        persister.registerBreifMapComplexType("date", Date.class);
     }
 }

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/ExtraVariableXStreamInitializer.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/ExtraVariableXStreamInitializer.java
@@ -14,7 +14,7 @@ public class ExtraVariableXStreamInitializer implements XStreamPersisterInitiali
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("extraVariable", ExtraVariable.class);
+        persister.registerBreifMapComplexType("extraVariable", ExtraVariable.class);
         XStream xs = persister.getXStream();
         xs.alias("extraVariable", ExtraVariable.class);
     }

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/GlobalAttributeXStreamInitializer.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/GlobalAttributeXStreamInitializer.java
@@ -13,7 +13,7 @@ public class GlobalAttributeXStreamInitializer implements XStreamPersisterInitia
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("globalAttribute", GlobalAttribute.class);
+        persister.registerBreifMapComplexType("globalAttribute", GlobalAttribute.class);
         XStream xs = persister.getXStream();
         xs.alias("globalAttribute", GlobalAttribute.class);
     }

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFContainerXStreamInitializer.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/NetCDFContainerXStreamInitializer.java
@@ -13,8 +13,8 @@ public class NetCDFContainerXStreamInitializer implements XStreamPersisterInitia
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("netcdfSettingsContainer", NetCDFSettingsContainer.class);
-        persister.registerBriefMapComplexType("netcdfLayerSettingsContainer", NetCDFLayerSettingsContainer.class);
+        persister.registerBreifMapComplexType("netcdfSettingsContainer", NetCDFSettingsContainer.class);
+        persister.registerBreifMapComplexType("netcdfLayerSettingsContainer", NetCDFLayerSettingsContainer.class);
         XStream xs = persister.getXStream();
         xs.alias("netCDFSettings", NetCDFSettingsContainer.class);
         xs.alias("netCDFLayerSettings", NetCDFLayerSettingsContainer.class);

--- a/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/VariableAttributeXStreamInitializer.java
+++ b/src/extension/netcdf-out/src/main/java/org/geoserver/web/netcdf/VariableAttributeXStreamInitializer.java
@@ -14,7 +14,7 @@ public class VariableAttributeXStreamInitializer implements XStreamPersisterInit
 
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("variableAttribute", VariableAttribute.class);
+        persister.registerBreifMapComplexType("variableAttribute", VariableAttribute.class);
         XStream xs = persister.getXStream();
         xs.alias("variableAttribute", VariableAttribute.class);
     }

--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureServiceXStreamPersisterInitializer.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureServiceXStreamPersisterInitializer.java
@@ -12,9 +12,9 @@ import org.geoserver.config.util.XStreamPersisterInitializer;
 public class FeatureServiceXStreamPersisterInitializer implements XStreamPersisterInitializer {
     @Override
     public void init(XStreamPersister persister) {
-        persister.registerBriefMapComplexType("ogcapiFeatures", FeatureConformance.class);
-        persister.registerBriefMapComplexType("cql2", CQL2Conformance.class);
-        persister.registerBriefMapComplexType("ecql", ECQLConformance.class);
+        persister.registerBreifMapComplexType("ogcapiFeatures", FeatureConformance.class);
+        persister.registerBreifMapComplexType("cql2", CQL2Conformance.class);
+        persister.registerBreifMapComplexType("ecql", ECQLConformance.class);
 
         XStream xs = persister.getXStream();
         xs.allowTypes(new Class[] {FeatureConformance.class});

--- a/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
+++ b/src/main/src/main/java/org/geoserver/config/util/XStreamPersister.java
@@ -262,10 +262,10 @@ public class XStreamPersister {
     /** Flag controlling how references to objects are encoded. */
     boolean referenceByName = false;
 
-    /** The type map used in {@link BriefMapConverter} to handle complex objects */
-    Map<String, Class<?>> forwardBriefMap = new HashMap<>();
+    /** The type map used in {@link BreifMapConverter} to handle complex objects */
+    Map<String, Class<?>> forwardBreifMap = new HashMap<>();
 
-    Map<Class<?>, String> backwardBriefMap = new HashMap<>();
+    Map<Class<?>, String> backwardBreifMap = new HashMap<>();
 
     /**
      * List containing classes that should be ignored by XStream. This is required because sometimes generic converter
@@ -401,7 +401,7 @@ public class XStreamPersister {
         xs.omitField(impl(StoreInfo.class), "error");
         // xs.omitField(StoreInfo.class), "workspace"); //handled by StoreInfoConverter
         xs.registerLocalConverter(impl(StoreInfo.class), "workspace", new ReferenceConverter(WorkspaceInfo.class));
-        xs.registerLocalConverter(impl(StoreInfo.class), "connectionParameters", new BriefMapConverter());
+        xs.registerLocalConverter(impl(StoreInfo.class), "connectionParameters", new BreifMapConverter());
         xs.registerLocalConverter(impl(StoreInfo.class), "metadata", new MetadataMapConverter());
         xs.registerLocalConverter(impl(WMSStoreInfo.class), "password", new EncryptedFieldConverter());
         xs.registerLocalConverter(impl(WMTSStoreInfo.class), "password", new EncryptedFieldConverter());
@@ -525,9 +525,9 @@ public class XStreamPersister {
         xs.registerConverter(new MeasureConverter());
         xs.registerConverter(new MultimapConverter(xs.getMapper()));
         // register Virtual structure handling
-        registerBriefMapComplexType("virtualTable", VirtualTable.class);
-        registerBriefMapComplexType("coverageView", CoverageView.class);
-        registerBriefMapComplexType("dimensionInfo", DimensionInfoImpl.class);
+        registerBreifMapComplexType("virtualTable", VirtualTable.class);
+        registerBreifMapComplexType("coverageView", CoverageView.class);
+        registerBreifMapComplexType("dimensionInfo", DimensionInfoImpl.class);
 
         callback = new Callback();
 
@@ -544,24 +544,13 @@ public class XStreamPersister {
     }
 
     /**
-     * Old method with typo in the name. Remains for backwards compatibility
-     *
-     * @param typeId
-     * @param clazz
-     */
-    @Deprecated
-    public void registerBreifMapComplexType(String typeId, Class<?> clazz) {
-        registerBriefMapComplexType(typeId, clazz);
-    }
-
-    /**
      * Use this method to register complex types that cannot be simply represented as a string in a
-     * {@link BriefMapConverter}. The {@code typeId} will be used as a type discriminator in the brief map, as well as
+     * {@link BreifMapConverter}. The {@code typeId} will be used as a type discriminator in the brief map, as well as
      * the element root for the complex object to be converted.
      */
-    public void registerBriefMapComplexType(String typeId, Class<?> clazz) {
-        forwardBriefMap.put(typeId, clazz);
-        backwardBriefMap.put(clazz, typeId);
+    public void registerBreifMapComplexType(String typeId, Class<?> clazz) {
+        forwardBreifMap.put(typeId, clazz);
+        backwardBreifMap.put(clazz, typeId);
         xs.allowTypes(new Class[] {clazz});
     }
 
@@ -807,11 +796,11 @@ public class XStreamPersister {
 
     // simple object converters
     /** Map converter which encodes a map more briefly than the standard map converter. */
-    public class BriefMapConverter extends MapConverter {
+    public class BreifMapConverter extends MapConverter {
 
         static final String ENCRYPTED_FIELDS_KEY = "org.geoserver.config.encryptedFields";
 
-        public BriefMapConverter() {
+        public BreifMapConverter() {
             super(getXStream().getMapper());
         }
 
@@ -935,20 +924,20 @@ public class XStreamPersister {
         }
 
         private Class<?> getComplexTypeClass(String typeId) {
-            return forwardBriefMap.get(typeId);
+            return forwardBreifMap.get(typeId);
         }
 
         protected String getComplexTypeId(Class<?> clazz) {
             if (backwardBriefIgnored.contains(clazz)) {
                 return null;
             }
-            String typeId = backwardBriefMap.get(clazz);
+            String typeId = backwardBreifMap.get(clazz);
             if (typeId == null) {
                 List<Class<?>> matches = new ArrayList<>();
                 collectSuperclasses(clazz, matches);
                 for (Iterator<Class<?>> it = matches.iterator(); it.hasNext(); ) {
                     Class<?> sper = it.next();
-                    if (backwardBriefMap.get(sper) == null) {
+                    if (backwardBreifMap.get(sper) == null) {
                         it.remove();
                     }
                 }
@@ -966,7 +955,7 @@ public class XStreamPersister {
                 }
 
                 if (!matches.isEmpty()) {
-                    typeId = backwardBriefMap.get(matches.get(0));
+                    typeId = backwardBreifMap.get(matches.get(0));
                 }
             }
 
@@ -1053,7 +1042,7 @@ public class XStreamPersister {
     }
 
     /** Custom converter for the special metadata map. */
-    class MetadataMapConverter extends BriefMapConverter {
+    class MetadataMapConverter extends BreifMapConverter {
 
         @Override
         public boolean canConvert(Class type) {
@@ -1097,7 +1086,7 @@ public class XStreamPersister {
         @SuppressWarnings("unchecked")
         public void marshal(Object value, HierarchicalStreamWriter writer, MarshallingContext context) {
             Multimap map = (Multimap) value;
-            // similar to BriefMapConverter, but handling the multimap nature of this thing
+            // similar to BreifMapConverter, but handling the multimap nature of this thing
             for (Object key : map.keySet()) {
                 for (Object v : map.get(key)) {
                     if (v != null) {
@@ -1687,7 +1676,7 @@ public class XStreamPersister {
                 // set the hint for the map converter as to which fields to encode in the connection
                 // parameter of this store
                 context.put(
-                        BriefMapConverter.ENCRYPTED_FIELDS_KEY,
+                        BreifMapConverter.ENCRYPTED_FIELDS_KEY,
                         secMgr.getConfigPasswordEncryptionHelper().getEncryptedFields((StoreInfo) source));
             }
 

--- a/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/XStreamPersisterTest.java
@@ -1228,7 +1228,7 @@ public class XStreamPersisterTest {
         factory.addInitializer(persister -> {
             persister.getXStream().alias("sweetBanana", SweetBanana.class);
             persister.getXStream().aliasAttribute(SweetBanana.class, "scientificName", "name");
-            persister.registerBriefMapComplexType("sweetBanana", SweetBanana.class);
+            persister.registerBreifMapComplexType("sweetBanana", SweetBanana.class);
         });
         XStreamPersister persister = factory.createXMLPersister();
 

--- a/src/main/src/test/java/org/geoserver/util/XStreamPersisterTest.java
+++ b/src/main/src/test/java/org/geoserver/util/XStreamPersisterTest.java
@@ -21,7 +21,7 @@ public class XStreamPersisterTest {
         XStreamPersisterFactory factory = new XStreamPersisterFactory();
         XStreamPersister xp = factory.createXMLPersister();
         // Register number type
-        xp.registerBriefMapComplexType("number", Number.class);
+        xp.registerBreifMapComplexType("number", Number.class);
         // Set Integer to be ignored by XStream type lookup
         xp.addBackwardsBriefIgnored(Integer.class);
 
@@ -42,7 +42,7 @@ public class XStreamPersisterTest {
         XStreamPersisterFactory factory = new XStreamPersisterFactory();
         XStreamPersister xp = factory.createXMLPersister();
         // Register number type
-        xp.registerBriefMapComplexType("number", Number.class);
+        xp.registerBreifMapComplexType("number", Number.class);
 
         DataStoreInfoImpl dataStoreInfo = new DataStoreInfoImpl(null);
         MetadataMap metadata = dataStoreInfo.getMetadata();

--- a/src/wfs/src/main/java/org/geoserver/wfs/WFSXStreamPersisterInitializer.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/WFSXStreamPersisterInitializer.java
@@ -34,6 +34,6 @@ public class WFSXStreamPersisterInitializer implements XStreamPersisterInitializ
             ParameterMappingBlockValue.class
         });
 
-        persister.registerBriefMapComplexType("storedQueryConfiguration", StoredQueryConfiguration.class);
+        persister.registerBreifMapComplexType("storedQueryConfiguration", StoredQueryConfiguration.class);
     }
 }


### PR DESCRIPTION
Backport to 2.26.x