### PR TITLE
[GEOS-11938] Add support for property selection in OGC API Features

### DIFF
--- a/doc/en/user/source/services/features/config.rst
+++ b/doc/en/user/source/services/features/config.rst
@@ -1,3 +1,5 @@
+.. _ogcapi-features-config:
+
 Configuration of OGC API - Features module
 ------------------------------------------
 

--- a/doc/en/user/source/services/features/status.rst
+++ b/doc/en/user/source/services/features/status.rst
@@ -16,24 +16,25 @@ OGC API - Features Implementation status
      - Passes compliance tests
    * - Part 3: Filtering
      - `1.0.0 <https://docs.ogc.org/is/19-079r2/19-079r2.html>`__
-     - Implemented an earlier draft, being updated to final (no CITE tests yet)
+     - Implemented (no CITE tests yet)
    * - Common Query Language (CQL2)
      - `1.0.0 <https://docs.ogc.org/is/21-065r2/21-065r2.html>`__
-     - Implemented an earlier draft, being updated to final (no CITE tests yet)
+     - Implemented (no CITE tests yet)
    * - Part 4: Create, Replace, Update and Delete
      - `1.0.0 <https://docs.ogc.org/DRAFTS/20-002r1.html>`__
      - Not implemented (volunteers/sponsoring wanted)
-   * - Part 5: search
-     - `Proposal DRAFT <https://github.com/opengeospatial/ogcapi-features/tree/master/proposals/search>`__
-     - A search endpoint for complex queries is implemented at the single collection level (POST to immediately get a response, no support for stored queries).
-   * - Part 6 - Schemas
-     - `Proposal DRAFT <https://github.com/opengeospatial/ogcapi-features/tree/master/proposals/search>`__
+   * - Part 5 - Schemas
+     - `Proposal DRAFT <https://github.com/opengeospatial/ogcapi-features/tree/master/extensions/schemas>`__
      - Not implemented (volunteers/sponsoring wanted)
+   * - Part 6 - Property selection
+     - `Proposal DRAFT <https://github.com/opengeospatial/ogcapi-features/tree/master/extensions/property-selection>`__
+     - Implemented (disabled by default, see :ref:`ogcapi-features-config`).
+   * - Search
+     - `Proposal DRAFT <https://github.com/opengeospatial/ogcapi-features/tree/master/proposals/search>`__
+     - A search endpoint for complex queries is implemented at the single collection level (POST to immediately get a response, no support for stored queries). (disabled by default, see :ref:`ogcapi-features-config`).
    * - Part n: Query by IDs
      - `Proposal DRAFT <https://github.com/opengeospatial/ogcapi-features/tree/master/proposals/query-by-ids>`__
-     - Proposal implemented, but syntax and semantic is subject to change in a future release. Thus said, usage should be carefully considered.
+     - Proposal implemented, but syntax and semantic is subject to change in a future release. Thus said, usage should be carefully considered. (disabled by default, see :ref:`ogcapi-features-config`).
    * - Sorting
-     - `DRAFT in github <https://github.com/opengeospatial/ogcapi-features/tree/master/extensions/sorting/standard>`__
-     - Partial implementation borrowed by OGC API Records, using the sortby parameter. Sortables are not exposed.
-
-
+     - `Proposal DRAFT <https://github.com/opengeospatial/ogcapi-features/tree/master/extensions/sorting/standard>`__
+     - Partial implementation borrowed by OGC API Records, using the sortby parameter. Sortables are not exposed. (disabled by default, see :ref:`ogcapi-features-config`).

--- a/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/ConformanceClass.java
+++ b/src/extension/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/ConformanceClass.java
@@ -57,4 +57,8 @@ public class ConformanceClass {
     public static final String CQL2_PROPERTY_PROPERTY = "http://www.opengis.net/spec/cql2/1.0/req/property-property";
     public static final String CQL2_FUNCTIONS = "http://www.opengis.net/spec/cql2/1.0/req/functions";
     public static final String CQL2_ARITHMETIC = "http://www.opengis.net/spec/cql2/1.0/req/arithmetic";
+
+    /** Property selection */
+    public static final String PROPERTY_SELECTION =
+            "http://www.opengis.net/spec/ogcapi-features-6/1.0/conf/properties-features";
 }

--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureConformance.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureConformance.java
@@ -56,6 +56,8 @@ public class FeatureConformance extends ConformanceInfo<WFSInfo> {
     public static final APIConformance IDS = new APIConformance(ConformanceClass.IDS, DRAFT_STANDARD);
     public static final APIConformance SEARCH = new APIConformance(ConformanceClass.SEARCH, DRAFT_STANDARD);
     public static final APIConformance SORTBY = new APIConformance(ConformanceClass.SORTBY, DRAFT_STANDARD, "sortBy");
+    public static final APIConformance PROPERTY_SELECTION =
+            new APIConformance(ConformanceClass.PROPERTY_SELECTION, DRAFT_STANDARD, "propertySelection");
 
     private Boolean core = null;
     private Boolean gml321 = null;
@@ -68,6 +70,7 @@ public class FeatureConformance extends ConformanceInfo<WFSInfo> {
     private Boolean queryables = null;
     private Boolean ids = null;
     private Boolean sortBy = null;
+    private Boolean propertySelection = null;
 
     /** Configuration for OGCAPI Features. */
     public FeatureConformance() {}
@@ -117,6 +120,7 @@ public class FeatureConformance extends ConformanceInfo<WFSInfo> {
         conformance.add(IDS);
         conformance.add(SEARCH);
         conformance.add(SORTBY);
+        conformance.add(PROPERTY_SELECTION);
 
         return conformance;
     }
@@ -173,6 +177,9 @@ public class FeatureConformance extends ConformanceInfo<WFSInfo> {
             }
             if (sortBy(serviceInfo)) {
                 conformance.add(FeatureConformance.SORTBY);
+            }
+            if (propertySelection(serviceInfo)) {
+                conformance.add(FeatureConformance.PROPERTY_SELECTION);
             }
         }
         return conformance;
@@ -493,6 +500,34 @@ public class FeatureConformance extends ConformanceInfo<WFSInfo> {
         sortBy = enabled;
     }
 
+    /**
+     * PROPERTY_SELECTION conformance enabled by configuration.
+     *
+     * @return PROPERTY_SELECTION conformance enabled, or <code>null</code> for default.
+     */
+    public Boolean isPropertySelection() {
+        return propertySelection;
+    }
+
+    /**
+     * PROPERTY_SELECTION conformance enabled by configuration or default.
+     *
+     * @param serviceInfo WFSService configuration used to determine default
+     * @return <code>true</code> if PROPERTY_SELECTION conformance enabled
+     */
+    public boolean propertySelection(WFSInfo serviceInfo) {
+        return isEnabled(serviceInfo, propertySelection, PROPERTY_SELECTION);
+    }
+
+    /**
+     * PROPERTY_SELECTION conformance enablement.
+     *
+     * @param enabled PROPERTY_SELECTION conformance enabled, or <code>null</code> for default.
+     */
+    public void setPropertySelection(Boolean enabled) {
+        propertySelection = enabled;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("FeatureConformance");
@@ -507,6 +542,7 @@ public class FeatureConformance extends ConformanceInfo<WFSInfo> {
         sb.append(", queryables=").append(queryables);
         sb.append(", search=").append(search);
         sb.append(", sortBy=").append(sortBy);
+        sb.append(", propertySelection=").append(propertySelection);
         sb.append('}');
         return sb.toString();
     }

--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureService.java
@@ -58,6 +58,7 @@ import org.geoserver.wfs.request.FeatureCollectionResponse;
 import org.geoserver.wfs.request.GetFeatureRequest;
 import org.geoserver.wfs.request.Query;
 import org.geotools.api.feature.type.FeatureType;
+import org.geotools.api.feature.type.PropertyDescriptor;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.filter.Id;
@@ -344,7 +345,9 @@ public class FeatureService {
             @RequestParam(name = "bbox-crs", required = false) String bboxCRS,
             @RequestParam(name = "time", required = false) String time,
             @PathVariable(name = "itemId") String itemId,
-            @RequestParam(name = "crs", required = false) String crs)
+            @RequestParam(name = "crs", required = false) String crs,
+            @RequestParam(name = "properties", required = false) List<String> properties,
+            @RequestParam(name = "exclude-properties", required = false) List<String> excludeProperties)
             throws Exception {
         return items(
                 collectionId,
@@ -359,6 +362,8 @@ public class FeatureService {
                 null, /* sortby */
                 crs,
                 null, /* ids */
+                properties,
+                excludeProperties,
                 itemId);
     }
 
@@ -378,6 +383,8 @@ public class FeatureService {
             @RequestParam(name = "sortby", required = false) SortBy[] sortBy,
             @RequestParam(name = "crs", required = false) String crs,
             @RequestParam(name = "ids", required = false) List<String> ids,
+            @RequestParam(name = "properties", required = false) List<String> properties,
+            @RequestParam(name = "exclude-properties", required = false) List<String> excludeProperties,
             String itemId)
             throws Exception {
 
@@ -443,6 +450,32 @@ public class FeatureService {
                 LOGGER.warning(() -> "The sortby parameter is not supported by the service, requires "
                         + FeatureConformance.SORTBY.getId()
                         + " conformance to be enabled.");
+            }
+        }
+
+        if (properties != null || excludeProperties != null) {
+            if (!features.propertySelection(wfs)) {
+                LOGGER.warning(
+                        () -> "The properties / exclude-properties parameter is not supported by the service, requires "
+                                + FeatureConformance.PROPERTY_SELECTION.getId()
+                                + " conformance to be enabled.");
+            } else if (properties != null && excludeProperties != null) {
+                throw new APIException(
+                        APIException.INVALID_PARAMETER_VALUE,
+                        "You cannot use both properties and exclude-properties in the same request",
+                        HttpStatus.BAD_REQUEST);
+            } else {
+                if (properties != null && !properties.isEmpty()) {
+                    query.setPropertyNames(properties);
+                } else if (excludeProperties != null && !excludeProperties.isEmpty()) {
+                    List<String> props = new ArrayList<>();
+                    for (PropertyDescriptor pd : ft.getFeatureType().getDescriptors()) {
+                        if (!excludeProperties.contains(pd.getName().getLocalPart())) {
+                            props.add(pd.getName().getLocalPart());
+                        }
+                    }
+                    query.setPropertyNames(props);
+                }
             }
         }
 
@@ -521,6 +554,8 @@ public class FeatureService {
                 query.getSortBy(),
                 query.getCrs(),
                 query.getIds(),
+                null,
+                null,
                 null);
     }
 

--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeaturesAPIBuilder.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeaturesAPIBuilder.java
@@ -77,7 +77,11 @@ public class FeaturesAPIBuilder extends org.geoserver.ogcapi.OpenAPIBuilder<WFSI
             itemsParameters.removeIf(p -> p.get$ref().equals("#/components/parameters/ids"));
         }
         if (!features.sortBy(wfs)) {
-            itemsParameters.removeIf(p -> p.get$ref().equals("#/components/parameters/filter-sortby"));
+            itemsParameters.removeIf(p -> p.get$ref().equals("#/components/parameters/sortby"));
+        }
+        if (!features.propertySelection(wfs)) {
+            itemsParameters.removeIf(p -> p.get$ref().equals("#/components/parameters/properties"));
+            itemsParameters.removeIf(p -> p.get$ref().equals("#/components/parameters/exclude-properties"));
         }
 
         declareGetResponseFormats(api, "/collections/{collectionId}/items/{featureId}", FeaturesResponse.class);

--- a/src/extension/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/openapi.yaml
+++ b/src/extension/ogcapi/ogcapi-features/src/main/resources/org/geoserver/ogcapi/v1/features/openapi.yaml
@@ -168,6 +168,8 @@ paths:
         - $ref: '#/components/parameters/ids'
         - $ref: '#/components/parameters/crs'
         - $ref: '#/components/parameters/bbox-crs'
+        - $ref: '#/components/parameters/properties'
+        - $ref: '#/components/parameters/exclude-properties'
         - $ref: '#/components/parameters/otherParameters'
       responses:
         '200':
@@ -221,6 +223,8 @@ paths:
         - $ref: '#/components/parameters/collectionId'
         - $ref: '#/components/parameters/featureId'
         - $ref: '#/components/parameters/crs'
+        - $ref: '#/components/parameters/properties'
+        - $ref: '#/components/parameters/exclude-properties'
         - $ref: '#/components/parameters/otherParameters'
       responses:
         '200':
@@ -410,6 +414,26 @@ components:
         format: uri
       style: form
       explode: false
+    properties:
+      name: properties
+      in: query
+      required: false
+      style: form
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
+    exclude-properties:
+      name: exclude-properties
+      in: query
+      required: false
+      style: form
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
   schemas:
     queryables:
       type: object

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/FeatureTest.java
@@ -6,6 +6,7 @@ package org.geoserver.ogcapi.v1.features;
 
 import static org.geoserver.ogcapi.JSONSchemaMessageConverter.SCHEMA_TYPE_VALUE;
 import static org.geoserver.ogcapi.v1.features.JSONFGFeaturesResponse.COORD_REF_SYS;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -1285,5 +1286,92 @@ public class FeatureTest extends FeaturesTestSupport {
                 "ogc/features/v1/collections/" + roadSegments + "/items", StandardCharsets.UTF_8.name());
         assertEquals(200, response.getStatus());
         assertEquals("UTF-8", response.getCharacterEncoding());
+    }
+
+    @Test
+    public void testPropertySelectionItems() throws Exception {
+        WFSInfo wfs = getGeoServer().getService(WFSInfo.class);
+        FeatureConformance features = FeatureConformance.configuration(wfs);
+        features.setPropertySelection(true);
+        getGeoServer().save(wfs);
+        try {
+            // positive selection
+            String roadSegments = ResponseUtils.urlEncode(getLayerId(MockData.ROAD_SEGMENTS));
+            String basePath = "ogc/features/v1/collections/" + roadSegments + "/items";
+            DocumentContext fc = getAsJSONPath(basePath + "?properties=the_geom,FID", 200);
+            assertEquals("FeatureCollection", fc.read("type", String.class));
+            assertEquals(5, (int) fc.read("features.length()", Integer.class));
+            // check only the_geom and ID are present
+            DocumentContext feature = readContext(fc, "features[0]");
+            assertNotNull(feature.read("geometry"));
+            Map props = feature.read("properties", Map.class);
+            assertEquals(1, props.size());
+            assertNotNull(props.get("FID"));
+
+            // negative selection
+            fc = getAsJSONPath(
+                    "ogc/features/v1/collections/" + roadSegments + "/items?exclude-properties=the_geom,FID", 200);
+            assertEquals("FeatureCollection", fc.read("type", String.class));
+            assertEquals(5, (int) fc.read("features.length()", Integer.class));
+            // the_geom and ID are gone, NAME is available
+            feature = readContext(fc, "features[0]");
+            assertNull(feature.read("geometry"));
+            props = feature.read("properties", Map.class);
+            assertEquals(1, props.size());
+            assertNotNull(props.get("NAME"));
+
+            // both positive and negative (not allowed, bad request)
+            DocumentContext error = getAsJSONPath(
+                    "ogc/features/v1/collections/" + roadSegments
+                            + "/items?properties=the_geom,FID&exclude-properties=FID",
+                    400);
+            assertEquals("InvalidParameterValue", error.read("code"));
+            assertThat(
+                    error.read("description"),
+                    allOf(containsString("properties"), containsString("exclude-properties")));
+        } finally {
+            // restore defaults
+            features.setPropertySelection(null);
+            getGeoServer().save(wfs);
+        }
+    }
+
+    @Test
+    public void testPropertySelectionItem() throws Exception {
+        WFSInfo wfs = getGeoServer().getService(WFSInfo.class);
+        FeatureConformance features = FeatureConformance.configuration(wfs);
+        features.setPropertySelection(true);
+        getGeoServer().save(wfs);
+        try {
+            // positive selection
+            String roadSegments = ResponseUtils.urlEncode(getLayerId(MockData.ROAD_SEGMENTS));
+            String basePath = "ogc/features/v1/collections/" + roadSegments + "/items/RoadSegments.1107532045088";
+            DocumentContext feature = getAsJSONPath(basePath + "?properties=the_geom,FID", 200);
+            assertEquals("Feature", feature.read("type", String.class));
+            assertNotNull(feature.read("geometry"));
+            Map props = feature.read("properties", Map.class);
+            assertEquals(1, props.size());
+            assertNotNull(props.get("FID"));
+
+            // negative selection
+            feature = getAsJSONPath(basePath + "?exclude-properties=the_geom,FID", 200);
+            assertEquals("Feature", feature.read("type", String.class));
+            // the_geom and ID are gone, NAME is available
+            assertNull(feature.read("geometry"));
+            props = feature.read("properties", Map.class);
+            assertEquals(1, props.size());
+            assertNotNull(props.get("NAME"));
+
+            // both positive and negative (not allowed, bad request)
+            DocumentContext error = getAsJSONPath(basePath + "?properties=the_geom,FID&exclude-properties=FID", 400);
+            assertEquals("InvalidParameterValue", error.read("code"));
+            assertThat(
+                    error.read("description"),
+                    allOf(containsString("properties"), containsString("exclude-properties")));
+        } finally {
+            // restore defaults
+            features.setPropertySelection(null);
+            getGeoServer().save(wfs);
+        }
     }
 }

--- a/src/extension/ogcapi/web-features/src/main/resources/GeoServerApplication.properties
+++ b/src/extension/ogcapi/web-features/src/main/resources/GeoServerApplication.properties
@@ -15,6 +15,12 @@ FeatureServiceAdminPanel.feature.queryables=Queryables
 FeatureServiceAdminPanel.feature.ids=Identifiers
 FeatureServiceAdminPanel.feature.search=Search
 FeatureServiceAdminPanel.feature.sortBy=Sort By
+FeatureServiceAdminPanel.feature.propertySelection=Property Selection
+FeatureServiceAdminPanel.th.enabled=Enabled
+FeatureServiceAdminPanel.th.name=Name
+FeatureServiceAdminPanel.th.id=Identifier
+FeatureServiceAdminPanel.th.level=Level
+FeatureServiceAdminPanel.th.type=Type
 
 FeatureServiceAdminPanel.cql2.title=Common Query Language (CQL2)
 FeatureServiceAdminPanel.cql2.text=CQL2 Text


### PR DESCRIPTION
[![GEOS-11938](https://badgen.net/badge/JIRA/GEOS-11938/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11938) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

See jira ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.