### PR TITLE
Use if always on worfklow step to clear cache

### DIFF
--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -102,5 +102,6 @@ jobs:
         sleep 5
         echo "🎉 Binary package smoke test completed successfully"
     - name: Remove SNAPSHOT jars from repository
+      if: always()
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -48,6 +48,7 @@ jobs:
       run: |
         mvn -B -ntp -fae -f src/pom.xml javadoc:aggregate
     - name: Remove SNAPSHOT jars from repository
+      if: always()
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,6 +52,7 @@ jobs:
       run: |
         mvn -B -ntp -nsu -U -T1C -fae -DskipTests -PcommunityRelease -f src/community/pom.xml clean install
     - name: Remove SNAPSHOT jars from repository
+      if: always()
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
 

--- a/.github/workflows/linux_locales.yml
+++ b/.github/workflows/linux_locales.yml
@@ -63,6 +63,7 @@ jobs:
         mvn --version
         mvn -B -ntp -U -T1C -fae -Prelease -f src/pom.xml clean install
     - name: Remove SNAPSHOT jars from repository
+      if: always()
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,5 +40,6 @@ jobs:
       run: |
         mvn -B -ntp -U -T2 -Prelease,macos-github-build -f src/pom.xml clean install
     - name: Remove SNAPSHOT jars from repository
+      if: always()
       run: |
         find .m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.github/workflows/postgis_appschema_online.yml
+++ b/.github/workflows/postgis_appschema_online.yml
@@ -56,5 +56,6 @@ jobs:
           EOT
           mvn -B clean install -nsu --file src/pom.xml -Prelease,app-schema-online-test -pl :gs-app-schema-postgis-test -Dspotless.apply.skip=true
       - name: Remove SNAPSHOT jars from repository
+        if: always()
         run: |
           find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {} 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,5 +40,6 @@ jobs:
       run: |
         mvn --% -B -ntp -U -T2 -Dall -Prelease,windows-github-build -f src/pom.xml clean install
     - name: Remove SNAPSHOT jars from repository
+      if: always()
       run: |
         cmd --% /c for /f %i in ('dir /a:d /s /b %userprofile%\*SNAPSHOT*') do rd /s /q %i


### PR DESCRIPTION
The choice of if always is correct as we want this to run if job succeeds, fails, or is cancled.

This is a GitHub maintenance activity and does not have a Jira.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.