### PR TITLE
bug: describing feature type when the layer does not yet have data AND outputFormat is specified

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/json/JSONDescribeFeatureTypeResponse.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/json/JSONDescribeFeatureTypeResponse.java
@@ -45,6 +45,17 @@ public class JSONDescribeFeatureTypeResponse extends WFSDescribeFeatureTypeOutpu
         if (featureTypeInfos.length == 0) {
             throw new IOException("Unable to write an empty feature info array.");
         }
+        
+        // BUG FIX: Validate all feature types exist before writing any JSON to prevent malformed output
+        // This prevents the bug where partial JSON is written before ft.getFeatureType() throws IOException
+        // for (FeatureTypeInfo ft : featureTypeInfos) {
+        //     try {
+        //         ft.getFeatureType(); // This will throw if schema doesn't exist
+        //     } catch (IOException e) {
+        //         throw new ServiceException("Schema '" + ft.getName() + "' does not exist.", e);
+        //     }
+        // }
+        
         // prepare to write out
         try (OutputStreamWriter osw =
                         new OutputStreamWriter(output, gs.getSettings().getCharset());
@@ -71,6 +82,9 @@ public class JSONDescribeFeatureTypeResponse extends WFSDescribeFeatureTypeOutpu
             for (FeatureTypeInfo ft : featureTypeInfos) {
                 jw.object();
                 jw.key("typeName").value(ft.getName());
+                // BUG LOCATION: This line throws IOException after partial JSON is written to stream
+                // PROBLEM: ft.getFeatureType() can throw IOException for non-existent schemas
+                // RESULT: Exception handlers write XML/JSON exceptions to stream already containing partial JSON
                 SimpleFeatureType schema = (SimpleFeatureType) ft.getFeatureType();
                 jw.key("properties");
                 jw.array();


### PR DESCRIPTION
if you describe a feature type (when the layer does not resolve to data yet) AND you specify an outputFormat you can get a malformed payload.

version 2.28.0

here are the cases:

- describing a feature type and requesting application/json output
  - notice that xml is embedded in the json (malforming the json)

```
$ curl -s "http://host:port/geoserver/wfs?service=WFS&version=2.0.0&request=DescribeFeatureType&typeNames=rdp:mock_ais&outputFormat=application/json" -u admin:password
{"elementFormDefault":"qualified","targetNamespace":"rdp","targetPrefix":"rdp","featureTypes":[{"typeName":"mock_ais"<?xml version="1.0" encoding="UTF-8"?><ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.0" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://rdp.local:8081/geoserver/schemas/ows/1.1.0/owsAll.xsd">
  <ows:Exception exceptionCode="NoApplicableCode">
    <ows:ExceptionText>java.io.IOException: Schema &amp;apos;mock_ais&amp;apos; does not exist.
Schema &amp;apos;mock_ais&amp;apos; does not exist.</ows:ExceptionText>
  </ows:Exception>
</ows:ExceptionReport>
```

- describing a feature type and requesting application/json output and exceptions output as json as well
  - notice that is almost correct but the json is malformed at `... {"typeName":"mock_ais"{"version" ...`

```
$ curl -s "http://host.port/geoserver/wfs?service=WFS&version=2.0.0&request=DescribeFeatureType&typeNames=rdp:mock_ais&outputFormat=application/json&exceptions=application/json" -u admin:password
{"elementFormDefault":"qualified","targetNamespace":"rdp","targetPrefix":"rdp","featureTypes":[{"typeName":"mock_ais"{"version":"2.0.0","exceptions":[{"code":"NoApplicableCode","locator":"noLocator","text":"java.io.IOException: Schema 'mock_ais' does not exist.\nSchema 'mock_ais' does not exist."}]}%
```

- and here's the call with no specific format request for reference
  - this is the case that works as expected

```
$ curl -s "http://host:port/geoserver/wfs?service=WFS&version=2.0.0&request=DescribeFeatureType&typeNames=rdp:mock_ais" -u admin:password
<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:rdp="rdp" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="rdp">
  <xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://rdp.local:8081/geoserver/schemas/gml/3.2.1/gml.xsd"/>
</xsd:schema>
```

---

just a note:
i tried to create a JIRA bug but after i registered an account when i would try to create a bug report i'd get 
```
Something went wrong on our end

If this keeps happening, share this information with your admin, who should [contact support](https://support.atlassian.com/contact).
```