### PR TITLE
[GEOS-12101] Fix: Workspace styles not persisted to disk after restore

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/CatalogBackupRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/CatalogBackupRestoreTasklet.java
@@ -9,6 +9,7 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
@@ -24,6 +25,7 @@ import org.geoserver.config.GeoServerPropertyConfigurer;
 import org.geoserver.config.LoggingInfo;
 import org.geoserver.config.ServiceInfo;
 import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.config.GWCConfigPersister;
 import org.geoserver.gwc.config.GWCInitializer;
@@ -171,8 +173,13 @@ public class CatalogBackupRestoreTasklet extends AbstractCatalogBackupRestoreTas
                             dd.get(Paths.path("workspaces", ws.getName())).dir());
                     backupRestoreAdditionalResources(wsDd.getResourceStore(), targetWorkspacesFolder.get(ws.getName()));
 
-                    // Backup Style SLDs
+                    // Backup Workspace Style XMLs and SLDs
                     for (StyleInfo sty : getCatalog().getStylesByWorkspace(ws)) {
+                        // Write the style.xml metadata file
+                        Resource wsStyleFolder = BackupUtils.dir(targetWorkspacesFolder.get(ws.getName()), "styles");
+                        doWrite(sty, wsStyleFolder, sty.getName() + ".xml");
+
+                        // Copy the SLD file
                         Resource styResource = wsDd.get(Paths.path("styles", sty.getFilename()));
                         if (Resources.exists(styResource)) {
                             Resources.copy(
@@ -687,7 +694,8 @@ public class CatalogBackupRestoreTasklet extends AbstractCatalogBackupRestoreTas
                     sty.setWorkspace(ws);
                     Resource wsLocalStyleFolder =
                             BackupUtils.dir(dd.get(Paths.path("workspaces", ws.getName())), "styles");
-                    doWrite(sty, wsLocalStyleFolder, sty.getName() + ".xml");
+                    // Use referenceByName=false so GeoServer can load the style from disk
+                    doWriteStyleForRestore(sty, wsLocalStyleFolder, sty.getName() + ".xml");
 
                     Resource styResource = sourceRestoreFolder.get(
                             Paths.path("workspaces", ws.getName(), "styles", sty.getFilename()));
@@ -1213,6 +1221,27 @@ public class CatalogBackupRestoreTasklet extends AbstractCatalogBackupRestoreTas
                 throw new IllegalArgumentException(
                         "TileLayer with same name already exists: " + layerName + ": <" + layerID + ">");
             }
+        }
+    }
+
+    /**
+     * Write a StyleInfo to disk with referenceByName=false.
+     *
+     * <p>This is needed because GeoServer's catalog loader expects workspace references to be written as
+     * <workspace><id>...</id></workspace> rather than <workspace><name>...</name></workspace>.
+     *
+     * <p>The standard doWrite() method uses referenceByName=true (set in BackupRestoreItem) which is correct for
+     * portable backups, but not for writing styles that need to be loaded by GeoServer's catalog.
+     */
+    private void doWriteStyleForRestore(StyleInfo style, Resource directory, String fileName) throws Exception {
+        try (OutputStream out = Resources.fromPath(fileName, directory).out()) {
+            XStreamPersister xp = getxStreamPersisterFactory().createXMLPersister();
+            xp.setCatalog(getCatalog());
+            xp.setReferenceByName(false); // Use ID references, not name references
+            Object item = xp.unwrapProxies(style);
+            xp.getXStream().toXML(item, out);
+        } catch (Exception e) {
+            logValidationExceptions(style, e);
         }
     }
 }

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/writer/CatalogItemWriter.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/writer/CatalogItemWriter.java
@@ -21,6 +21,9 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.catalog.WMTSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.catalog.impl.ResolvingProxy;
+import org.geoserver.catalog.impl.StyleInfoImpl;
 import org.geotools.util.logging.Logging;
 import org.jspecify.annotations.NonNull;
 import org.springframework.batch.core.StepExecution;
@@ -96,7 +99,26 @@ public class CatalogItemWriter<T> extends CatalogWriter<T> {
     }
 
     private void write(StyleInfo styleInfo) {
-        StyleInfo source = getCatalog().getStyleByName((styleInfo).getName());
+        // Use workspace-aware lookup for workspace-specific styles
+        WorkspaceInfo ws = styleInfo.getWorkspace();
+        // Resolve workspace proxy to actual workspace so the XML is written with ID reference
+        // instead of name reference. This is critical for GeoServer to load the style correctly
+        // on restart (CatalogLoaderSanitizer.validate() compares workspace IDs).
+        if (ws != null) {
+            WorkspaceInfo resolvedWs = ResolvingProxy.resolve(getCatalog(), ws);
+            if (resolvedWs != null) {
+                // Unwrap ModificationProxy to access StyleInfoImpl directly,
+                // since styleInfo may be wrapped in a proxy during restore.
+                StyleInfo unwrapped = ModificationProxy.unwrap(styleInfo);
+                if (unwrapped instanceof StyleInfoImpl) {
+                    ((StyleInfoImpl) unwrapped).setWorkspace(resolvedWs);
+                }
+                ws = resolvedWs;
+            }
+        }
+        StyleInfo source = (ws != null)
+                ? getCatalog().getStyleByName(ws, styleInfo.getName())
+                : getCatalog().getStyleByName(styleInfo.getName());
         if (source == null) {
             getCatalog().add(styleInfo);
             getCatalog().save(getCatalog().getStyle((styleInfo).getId()));

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/WorkspaceStyleBackupRestoreTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/WorkspaceStyleBackupRestoreTest.java
@@ -1,0 +1,155 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.logging.Level;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.platform.resource.Files;
+import org.geotools.util.factory.Hints;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.batch.core.BatchStatus;
+
+/**
+ * Tests that workspace-specific styles are correctly included in backup and restored with proper workspace context so
+ * they survive GeoServer restarts.
+ *
+ * <p>Prior to the fix:
+ *
+ * <ul>
+ *   <li>Backup only copied SLD files but not style XML metadata for workspace styles
+ *   <li>Restore used getStyleByName() without workspace context, failing to match workspace styles
+ *   <li>Style XML was written with name-based workspace references instead of ID-based, causing GeoServer's catalog
+ *       loader to fail on restart
+ * </ul>
+ */
+public class WorkspaceStyleBackupRestoreTest extends BackupRestoreTestSupport {
+
+    @Override
+    @Before
+    public void beforeTest() throws InterruptedException {
+        ensureCleanedQueues();
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+    }
+
+    /**
+     * Verifies that workspace style XML metadata files are included in the backup zip. Without the fix, only SLD files
+     * were backed up for workspace styles, not the style.xml metadata.
+     */
+    @Test
+    public void testWorkspaceStyleXmlIncludedInBackup() throws Exception {
+        File backupFile = File.createTempFile("testWorkspaceStyleBackup", ".zip");
+        backupFile.deleteOnExit();
+
+        BackupExecutionAdapter backupExecution =
+                backupFacade.runBackupAsync(Files.asResource(backupFile), true, null, null, null, createHints());
+
+        waitForCompletion(backupExecution);
+        assertEquals(BatchStatus.COMPLETED, backupExecution.getStatus());
+
+        // Verify the backup zip contains workspace style XML metadata files.
+        // The test setup (BackupRestoreTestSupport) creates sf_style in workspace sf
+        // and cite_style in workspace cite.
+        try (ZipFile zip = new ZipFile(backupFile)) {
+            ZipEntry sfStyleXml = zip.getEntry("workspaces/sf/styles/sf_style.xml");
+            assertNotNull("Backup should contain workspace style XML: workspaces/sf/styles/sf_style.xml", sfStyleXml);
+
+            // Verify XML content references the workspace
+            try (InputStream is = zip.getInputStream(sfStyleXml)) {
+                String content = new String(is.readAllBytes());
+                assertTrue("Style XML should contain workspace reference", content.contains("<workspace>"));
+                assertTrue("Style XML should contain style name", content.contains("<name>sf_style</name>"));
+            }
+
+            ZipEntry citeStyleXml = zip.getEntry("workspaces/cite/styles/cite_style.xml");
+            assertNotNull(
+                    "Backup should contain workspace style XML:" + " workspaces/cite/styles/cite_style.xml",
+                    citeStyleXml);
+        }
+    }
+
+    /**
+     * Verifies that workspace styles survive a backup-then-restore round trip and are correctly associated with their
+     * workspaces after restore. This uses a fresh backup (not pre-built test data) to ensure the backup includes the
+     * workspace style XML metadata added by the fix.
+     */
+    @Test
+    public void testWorkspaceStyleRoundTrip() throws Exception {
+        // Step 1: Create a backup (which now includes workspace style XMLs)
+        File backupFile = File.createTempFile("testWorkspaceStyleRoundTrip", ".zip");
+        backupFile.deleteOnExit();
+
+        BackupExecutionAdapter backupExecution =
+                backupFacade.runBackupAsync(Files.asResource(backupFile), true, null, null, null, createHints());
+
+        waitForCompletion(backupExecution);
+        assertEquals(BatchStatus.COMPLETED, backupExecution.getStatus());
+
+        // Step 2: Restore from that backup
+        RestoreExecutionAdapter restoreExecution =
+                backupFacade.runRestoreAsync(Files.asResource(backupFile), null, null, null, createHints());
+
+        Thread.sleep(100);
+
+        assertNotNull(backupFacade.getRestoreExecutions());
+        assertFalse(backupFacade.getRestoreExecutions().isEmpty());
+        assertNotNull(restoreExecution);
+
+        Thread.sleep(100);
+
+        final Catalog restoreCatalog = restoreExecution.getRestoreCatalog();
+        assertNotNull(restoreCatalog);
+
+        waitForCompletion(restoreExecution);
+        assertEquals(BatchStatus.COMPLETED, restoreExecution.getStatus());
+
+        // Step 3: Verify workspace styles are restored with correct workspace association.
+        // Without the fix, getStyleByName(workspace, name) would return null because
+        // the restore used the non-workspace-aware getStyleByName(name) lookup.
+        StyleInfo sfStyle = restoreCatalog.getStyleByName(restoreCatalog.getWorkspaceByName("sf"), "sf_style");
+        assertNotNull("sf_style should be found via workspace-aware lookup", sfStyle);
+        assertNotNull("sf_style should have workspace set", sfStyle.getWorkspace());
+        assertEquals("sf", sfStyle.getWorkspace().getName());
+
+        StyleInfo citeStyle = restoreCatalog.getStyleByName(restoreCatalog.getWorkspaceByName("cite"), "cite_style");
+        assertNotNull("cite_style should be found via workspace-aware lookup", citeStyle);
+        assertNotNull("cite_style should have workspace set", citeStyle.getWorkspace());
+        assertEquals("cite", citeStyle.getWorkspace().getName());
+    }
+
+    private Hints createHints() {
+        Hints hints = new Hints(new HashMap<>(2));
+        hints.add(new Hints(new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE), Backup.PARAM_BEST_EFFORT_MODE));
+        return hints;
+    }
+
+    private void waitForCompletion(AbstractExecutionAdapter execution) throws Exception {
+        int cnt = 0;
+        while (cnt < 100 && (execution.getStatus() != BatchStatus.COMPLETED || execution.isRunning())) {
+            Thread.sleep(100);
+            cnt++;
+
+            if (execution.getStatus() == BatchStatus.ABANDONED
+                    || execution.getStatus() == BatchStatus.FAILED
+                    || execution.getStatus() == BatchStatus.UNKNOWN) {
+                for (Throwable exception : execution.getAllFailureExceptions()) {
+                    LOGGER.log(Level.WARNING, "ERROR: " + exception.getLocalizedMessage(), exception);
+                }
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-12101](https://badgen.net/badge/JIRA/GEOS-12101/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12101) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

When restoring, workspace styles exist in the catalog, but their files are not written to workspaces/*/styles/ directory.

Root cause: Style XML files were written with name-based workspace references (<workspace><name>geonode</name></workspace>), but GeoServer's catalog loader expects ID-based references (<workspace><id>WorkspaceInfoImpl-xxx</id></workspace>).

This commit fixes the issue by:

1. Including workspace style XML metadata files in backup
   - Backup was only copying SLD files, but not the style.xml metadata

2. Using workspace-aware lookup when restoring styles
   - Restore was using getStyleByName() without workspace context
   - Also resolve workspace proxy to ensure correct ID reference in XML

3. Writing workspace styles with ID references during restore
   - Added doWriteStyleForRestore() method with referenceByName=false
   - Ensures GeoServer can load styles from disk after restart


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 