### PR TITLE
[GEOS-12099] Fix: GWC backup deadlock caused by DefaultTileLayerCatalog FileSystem…

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/CatalogBackupRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/CatalogBackupRestoreTasklet.java
@@ -8,6 +8,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Maps;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
@@ -234,22 +235,11 @@ public class CatalogBackupRestoreTasklet extends AbstractCatalogBackupRestoreTas
 
             Assert.notNull(gwcConfig, "gwcConfig is NULL");
 
-            // Store GWC Layers Configurations
-            final TileLayerCatalog gwcCatalog = (TileLayerCatalog) GeoServerExtensions.bean("GeoSeverTileLayerCatalog");
-
-            if (gwcCatalog != null) {
-                final XMLConfiguration gwcXmlPersisterFactory =
-                        (XMLConfiguration) GeoServerExtensions.bean("gwcXmlConfig");
-                final GeoServerResourceLoader resourceLoader = new GeoServerResourceLoader(targetBackupFolder.dir());
-
-                final DefaultTileLayerCatalog gwcBackupCatalog =
-                        new DefaultTileLayerCatalog(resourceLoader, gwcXmlPersisterFactory);
-                gwcBackupCatalog.initialize();
-
-                for (String layerName : gwcCatalog.getLayerNames()) {
-                    backupGwcLayer(gwcCatalog, gwcBackupCatalog, layerName);
-                }
-            }
+            // Store GWC Layers Configurations by copying files directly.
+            // This avoids creating a DefaultTileLayerCatalog which registers a
+            // FileSystemWatcher that causes lock contention and deadlocks on
+            // subsequent backup operations.
+            backupGwcLayersDirect(targetBackupFolder, true);
 
         } catch (Exception e) {
             logValidationExceptions(null, e);
@@ -1014,68 +1004,68 @@ public class CatalogBackupRestoreTasklet extends AbstractCatalogBackupRestoreTas
                 }
             }
 
-            // Store GWC Layers Configurations
-            // TODO: This should be done using the spring-batch item reader/writer, since it is not
-            // safe to save tons of single XML files.
-            //       Nonetheless, given the default implementation of GWC Catalog does not have much
-            // sense to refactor this code now.
-            final TileLayerCatalog gwcCatalog = (TileLayerCatalog) GeoServerExtensions.bean("GeoSeverTileLayerCatalog");
-
-            if (gwcCatalog != null) {
-                final XMLConfiguration gwcXmlPersisterFactory =
-                        (XMLConfiguration) GeoServerExtensions.bean("gwcXmlConfig");
-                final GeoServerResourceLoader resourceLoader = new GeoServerResourceLoader(targetBackupFolder.dir());
-
-                final DefaultTileLayerCatalog gwcBackupCatalog =
-                        new DefaultTileLayerCatalog(resourceLoader, gwcXmlPersisterFactory);
-                gwcBackupCatalog.initialize();
-
-                for (String layerName : gwcCatalog.getLayerNames()) {
-                    backupGwcLayer(gwcCatalog, gwcBackupCatalog, layerName);
-                }
-            }
+            // Store GWC Layers Configurations by copying files directly
+            backupGwcLayersDirect(targetBackupFolder, true);
 
         } catch (Exception e) {
             logValidationExceptions(null, e);
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private void backupGwcLayer(
-            final TileLayerCatalog gwcCatalog, final DefaultTileLayerCatalog gwcBackupCatalog, String layerName) {
-        GeoServerTileLayerInfo gwcLayerInfo = gwcCatalog.getLayerByName(layerName);
+    /**
+     * Copy GWC layer XML files directly to the target backup folder. This avoids creating a DefaultTileLayerCatalog
+     * which registers a FileSystemWatcher that causes lock contention and deadlocks on subsequent backup operations.
+     *
+     * @param targetBackupFolder the target folder for the backup
+     * @param applyFilter whether to apply workspace/layer filters
+     */
+    private void backupGwcLayersDirect(Resource targetBackupFolder, boolean applyFilter) throws Exception {
+        final TileLayerCatalog gwcCatalog = (TileLayerCatalog) GeoServerExtensions.bean("GeoSeverTileLayerCatalog");
+        if (gwcCatalog == null) return;
 
-        // Persist the GWC Layer Info into the backup folder
-        boolean persistResource = false;
+        GeoServerDataDirectory dd = (GeoServerDataDirectory) GeoServerExtensions.bean("dataDirectory");
+        Resource gwcLayersDir = dd.get("gwc-layers");
+        Resource targetGwcLayersDir = BackupUtils.dir(targetBackupFolder, "gwc-layers");
 
+        for (String layerName : gwcCatalog.getLayerNames()) {
+            GeoServerTileLayerInfo layerInfo = gwcCatalog.getLayerByName(layerName);
+            if (layerInfo == null) continue;
+
+            if (applyFilter && !shouldBackupGwcLayer(layerName)) {
+                continue;
+            }
+
+            String layerId = layerInfo.getId();
+            if (layerId == null) continue;
+            Resource sourceFile = gwcLayersDir.get(layerId + ".xml");
+            if (Resources.exists(sourceFile)) {
+                try (FileInputStream fis = new FileInputStream(sourceFile.file())) {
+                    Resources.copy(fis, targetGwcLayersDir, layerId + ".xml");
+                }
+            }
+        }
+    }
+
+    /** Determines if a GWC layer should be backed up based on filter settings. */
+    private boolean shouldBackupGwcLayer(String layerName) {
         LayerInfo layerInfo = getCatalog().getLayerByName(layerName);
-
         if (layerInfo != null) {
             WorkspaceInfo ws = getLayerWorkspace(layerInfo);
-
-            if (!filteredResource(layerInfo, ws, true, LayerInfo.class)) {
-                persistResource = true;
-            }
-        } else {
-            try {
-                LayerGroupInfo layerGroupInfo = getCatalog().getLayerGroupByName(layerName);
-                if (layerGroupInfo != null) {
-                    WorkspaceInfo ws = getLayerGroupWorkspace(layerGroupInfo);
-
-                    if (!filteredResource(ws, false)) {
-                        persistResource = true;
-                    }
-                }
-            } catch (NullPointerException e) {
-                if (getCurrentJobExecution() != null) {
-                    getCurrentJobExecution().addWarningExceptions(List.of(e));
-                }
-            }
+            return !filteredResource(layerInfo, ws, true, LayerInfo.class);
         }
 
-        if (persistResource) {
-            gwcBackupCatalog.save(gwcLayerInfo);
+        try {
+            LayerGroupInfo layerGroupInfo = getCatalog().getLayerGroupByName(layerName);
+            if (layerGroupInfo != null) {
+                WorkspaceInfo ws = getLayerGroupWorkspace(layerGroupInfo);
+                return !filteredResource(ws, false);
+            }
+        } catch (NullPointerException e) {
+            if (getCurrentJobExecution() != null) {
+                getCurrentJobExecution().addWarningExceptions(List.of(e));
+            }
         }
+        return false;
     }
 
     private WorkspaceInfo getLayerGroupWorkspace(LayerGroupInfo layerGroupInfo) {

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/GwcRepeatedBackupTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/GwcRepeatedBackupTest.java
@@ -1,0 +1,126 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.logging.Level;
+import org.geoserver.backuprestore.utils.BackupUtils;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.platform.resource.Files;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resources;
+import org.geotools.util.factory.Hints;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.batch.core.BatchStatus;
+
+/**
+ * Tests that repeated backup operations with GWC enabled complete without deadlock.
+ *
+ * <p>Prior to the fix, the backup code created DefaultTileLayerCatalog instances which register FileSystemWatcher
+ * listeners that are never cleaned up. On subsequent backup operations, this caused lock contention in
+ * MemoryLockProvider leading to deadlocks. The fix replaces DefaultTileLayerCatalog usage with direct file copy.
+ */
+public class GwcRepeatedBackupTest extends BackupRestoreTestSupport {
+
+    @Override
+    @Before
+    public void beforeTest() throws InterruptedException {
+        ensureCleanedQueues();
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+    }
+
+    @Test
+    public void testRepeatedBackupsWithGwcDoNotDeadlock() throws Exception {
+        // Run 3 consecutive backups with GWC enabled.
+        // Previously, each backup leaked FileSystemWatcher listeners from
+        // DefaultTileLayerCatalog, causing deadlocks on subsequent operations.
+        for (int i = 0; i < 3; i++) {
+            Hints hints = new Hints(new HashMap<>(2));
+            hints.add(new Hints(new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE), Backup.PARAM_BEST_EFFORT_MODE));
+
+            File backupFile = File.createTempFile("testGwcBackup_" + i, ".zip");
+            backupFile.deleteOnExit();
+            BackupExecutionAdapter backupExecution =
+                    backupFacade.runBackupAsync(Files.asResource(backupFile), true, null, null, null, hints);
+
+            Thread.sleep(100);
+
+            assertNotNull(backupFacade.getBackupExecutions());
+            assertFalse(backupFacade.getBackupExecutions().isEmpty());
+            assertNotNull(backupExecution);
+
+            int cnt = 0;
+            while (cnt < 100 && (backupExecution.getStatus() != BatchStatus.COMPLETED || backupExecution.isRunning())) {
+                Thread.sleep(100);
+                cnt++;
+
+                if (backupExecution.getStatus() == BatchStatus.ABANDONED
+                        || backupExecution.getStatus() == BatchStatus.FAILED
+                        || backupExecution.getStatus() == BatchStatus.UNKNOWN) {
+                    for (Throwable exception : backupExecution.getAllFailureExceptions()) {
+                        LOGGER.log(Level.WARNING, "ERROR: " + exception.getLocalizedMessage(), exception);
+                    }
+                    break;
+                }
+            }
+
+            assertEquals(
+                    "Backup " + i + " should complete successfully",
+                    BatchStatus.COMPLETED,
+                    backupExecution.getStatus());
+        }
+    }
+
+    @Test
+    public void testGwcLayerFilesCopiedDirectly() throws Exception {
+        // Verify that GWC layer XML files are present in the backup output,
+        // confirming the direct file copy approach works correctly.
+        GeoServerDataDirectory dd = backupFacade.getGeoServerDataDirectory();
+
+        Hints hints = new Hints(new HashMap<>(2));
+        hints.add(new Hints(new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE), Backup.PARAM_BEST_EFFORT_MODE));
+
+        File backupFile = File.createTempFile("testGwcLayerFiles", ".zip");
+        backupFile.deleteOnExit();
+        BackupExecutionAdapter backupExecution =
+                backupFacade.runBackupAsync(Files.asResource(backupFile), true, null, null, null, hints);
+
+        Thread.sleep(100);
+
+        int cnt = 0;
+        while (cnt < 100 && (backupExecution.getStatus() != BatchStatus.COMPLETED || backupExecution.isRunning())) {
+            Thread.sleep(100);
+            cnt++;
+
+            if (backupExecution.getStatus() == BatchStatus.ABANDONED
+                    || backupExecution.getStatus() == BatchStatus.FAILED
+                    || backupExecution.getStatus() == BatchStatus.UNKNOWN) {
+                for (Throwable exception : backupExecution.getAllFailureExceptions()) {
+                    LOGGER.log(Level.WARNING, "ERROR: " + exception.getLocalizedMessage(), exception);
+                }
+                break;
+            }
+        }
+
+        assertEquals(BatchStatus.COMPLETED, backupExecution.getStatus());
+        assertTrue(Resources.exists(Files.asResource(backupFile)));
+
+        // Extract backup and verify gwc-layers directory exists with content
+        Resource targetFolder = BackupUtils.geoServerTmpDir(dd);
+        BackupUtils.extractTo(Files.asResource(backupFile), targetFolder);
+
+        if (Resources.exists(targetFolder)) {
+            Resource gwcLayers = targetFolder.get("gwc-layers");
+            assertTrue("gwc-layers directory should exist in backup", Resources.exists(gwcLayers));
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-12099](https://badgen.net/badge/JIRA/GEOS-12099/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12099) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Thebackup code was creating DefaultTileLayerCatalog instances which register FileSystemWatcher listeners that are never cleaned up. On subsequent backup operations, this caused lock contention in MemoryLockProvider leading to deadlocks.

Also fixed: gwcProvider.in() was acquiring resource locks unnecessarily during backup. Changed to use direct FileInputStream for read-only backup.

Changes:
- Replace DefaultTileLayerCatalog usage with direct file copy in backup
- Use FileInputStream instead of gwcProvider.in() to avoid lock acquisition
- Extract backupGwcLayersDirect() helper method for code reuse
- Add shouldBackupGwcLayer() for filter checking


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 