### PR TITLE
Fix/validate layers properties after catalog load

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
@@ -54,7 +54,7 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
     String filesystemSandbox;
 
     // set to true once rules have been validated against a populated catalog
-    private volatile boolean rulesValidated = false;
+    private volatile boolean rulesValidated = false; 
 
     /** Returns the instanced contained in the Spring context for the UI to use */
     public static DataAccessRuleDAO get() {
@@ -123,7 +123,7 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
         this.catalogMode = catalogMode;
         this.rules = result;
         // rules changed, validation needs to be re-run against the catalog
-        this.rulesValidated = false;
+        this.rulesValidated = false; 
     }
 
     /** Parses a single layer.properties line into a {@link DataAccessRule}, returns false if the rule is not valid */
@@ -279,36 +279,39 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
         this.filesystemSandbox = filesystemSandbox;
     }
 
-    /** Registers a catalog listener to trigger rule validation once the catalog is (re)loaded. */
+    /**
+     * Registers a catalog listener to trigger rule validation once the catalog is (re)loaded.
+     */
     private void registerCatalogListener() {
         if (rawCatalog == null) return;
-        rawCatalog.addListener(new org.geoserver.catalog.event.CatalogListener() {
-            @Override
-            public void handleAddEvent(org.geoserver.catalog.event.CatalogAddEvent event)
-                    throws org.geoserver.catalog.CatalogException {}
+        rawCatalog.addListener(
+                new org.geoserver.catalog.event.CatalogListener() {
+                    @Override
+                    public void handleAddEvent(org.geoserver.catalog.event.CatalogAddEvent event)
+                            throws org.geoserver.catalog.CatalogException {}
 
-            @Override
-            public void handleRemoveEvent(org.geoserver.catalog.event.CatalogRemoveEvent event)
-                    throws org.geoserver.catalog.CatalogException {}
+                    @Override
+                    public void handleRemoveEvent(org.geoserver.catalog.event.CatalogRemoveEvent event)
+                            throws org.geoserver.catalog.CatalogException {}
 
-            @Override
-            public void handleModifyEvent(org.geoserver.catalog.event.CatalogModifyEvent event)
-                    throws org.geoserver.catalog.CatalogException {}
+                    @Override
+                    public void handleModifyEvent(org.geoserver.catalog.event.CatalogModifyEvent event)
+                            throws org.geoserver.catalog.CatalogException {}
 
-            @Override
-            public void handlePostModifyEvent(org.geoserver.catalog.event.CatalogPostModifyEvent event)
-                    throws org.geoserver.catalog.CatalogException {}
+                    @Override
+                    public void handlePostModifyEvent(
+                            org.geoserver.catalog.event.CatalogPostModifyEvent event)
+                            throws org.geoserver.catalog.CatalogException {}
 
-            @Override
-            public void reloaded() {
-                validateRulesAgainstCatalog();
-            }
-        });
+                    @Override
+                    public void reloaded() {
+                        validateRulesAgainstCatalog();
+                    }
+                });
 
         // if the catalog already appears populated, run validation immediately
         try {
-            if (rawCatalog.getWorkspaces() != null
-                    && !rawCatalog.getWorkspaces().isEmpty()) {
+            if (rawCatalog.getWorkspaces() != null && !rawCatalog.getWorkspaces().isEmpty()) {
                 validateRulesAgainstCatalog();
             }
         } catch (Exception e) {
@@ -330,7 +333,14 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
 
             String ruleText;
             if (layerName != null) {
-                ruleText = root + "." + layerName + "." + rule.getAccessMode().getAlias() + "=" + rule.getValue();
+                ruleText =
+                        root
+                                + "."
+                                + layerName
+                                + "."
+                                + rule.getAccessMode().getAlias()
+                                + "="
+                                + rule.getValue();
                 if (!ANY.equals(root) && rawCatalog.getWorkspaceByName(root) == null) {
                     LOGGER.warning("Namespace/Workspace " + root + " is unknown in rule " + ruleText);
                 }

--- a/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/DataAccessRuleDAO.java
@@ -54,7 +54,7 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
     String filesystemSandbox;
 
     // set to true once rules have been validated against a populated catalog
-    private volatile boolean rulesValidated = false; 
+    private volatile boolean rulesValidated = false;
 
     /** Returns the instanced contained in the Spring context for the UI to use */
     public static DataAccessRuleDAO get() {
@@ -123,7 +123,7 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
         this.catalogMode = catalogMode;
         this.rules = result;
         // rules changed, validation needs to be re-run against the catalog
-        this.rulesValidated = false; 
+        this.rulesValidated = false;
     }
 
     /** Parses a single layer.properties line into a {@link DataAccessRule}, returns false if the rule is not valid */
@@ -279,39 +279,36 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
         this.filesystemSandbox = filesystemSandbox;
     }
 
-    /**
-     * Registers a catalog listener to trigger rule validation once the catalog is (re)loaded.
-     */
+    /** Registers a catalog listener to trigger rule validation once the catalog is (re)loaded. */
     private void registerCatalogListener() {
         if (rawCatalog == null) return;
-        rawCatalog.addListener(
-                new org.geoserver.catalog.event.CatalogListener() {
-                    @Override
-                    public void handleAddEvent(org.geoserver.catalog.event.CatalogAddEvent event)
-                            throws org.geoserver.catalog.CatalogException {}
+        rawCatalog.addListener(new org.geoserver.catalog.event.CatalogListener() {
+            @Override
+            public void handleAddEvent(org.geoserver.catalog.event.CatalogAddEvent event)
+                    throws org.geoserver.catalog.CatalogException {}
 
-                    @Override
-                    public void handleRemoveEvent(org.geoserver.catalog.event.CatalogRemoveEvent event)
-                            throws org.geoserver.catalog.CatalogException {}
+            @Override
+            public void handleRemoveEvent(org.geoserver.catalog.event.CatalogRemoveEvent event)
+                    throws org.geoserver.catalog.CatalogException {}
 
-                    @Override
-                    public void handleModifyEvent(org.geoserver.catalog.event.CatalogModifyEvent event)
-                            throws org.geoserver.catalog.CatalogException {}
+            @Override
+            public void handleModifyEvent(org.geoserver.catalog.event.CatalogModifyEvent event)
+                    throws org.geoserver.catalog.CatalogException {}
 
-                    @Override
-                    public void handlePostModifyEvent(
-                            org.geoserver.catalog.event.CatalogPostModifyEvent event)
-                            throws org.geoserver.catalog.CatalogException {}
+            @Override
+            public void handlePostModifyEvent(org.geoserver.catalog.event.CatalogPostModifyEvent event)
+                    throws org.geoserver.catalog.CatalogException {}
 
-                    @Override
-                    public void reloaded() {
-                        validateRulesAgainstCatalog();
-                    }
-                });
+            @Override
+            public void reloaded() {
+                validateRulesAgainstCatalog();
+            }
+        });
 
         // if the catalog already appears populated, run validation immediately
         try {
-            if (rawCatalog.getWorkspaces() != null && !rawCatalog.getWorkspaces().isEmpty()) {
+            if (rawCatalog.getWorkspaces() != null
+                    && !rawCatalog.getWorkspaces().isEmpty()) {
                 validateRulesAgainstCatalog();
             }
         } catch (Exception e) {
@@ -333,14 +330,7 @@ public class DataAccessRuleDAO extends AbstractAccessRuleDAO<DataAccessRule> {
 
             String ruleText;
             if (layerName != null) {
-                ruleText =
-                        root
-                                + "."
-                                + layerName
-                                + "."
-                                + rule.getAccessMode().getAlias()
-                                + "="
-                                + rule.getValue();
+                ruleText = root + "." + layerName + "." + rule.getAccessMode().getAlias() + "=" + rule.getValue();
                 if (!ANY.equals(root) && rawCatalog.getWorkspaceByName(root) == null) {
                     LOGGER.warning("Namespace/Workspace " + root + " is unknown in rule " + ruleText);
                 }

--- a/src/security/security-tests/pom.xml
+++ b/src/security/security-tests/pom.xml
@@ -53,6 +53,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Mockito used in integration tests -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+/* (c) 2014 - 2026 Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
@@ -18,16 +18,17 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.util.LoggerRule;
 import org.geotools.util.logging.Logging;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 
 /** Integration test that demonstrates rule validation is deferred until the catalog is reloaded. */
 public class ValidateRulesAfterCatalogLoadTest {
 
-    @Rule public LoggerRule log = new LoggerRule(Logging.getLogger(DataAccessRuleDAO.class), Level.ALL);
+    @Rule
+    public LoggerRule log = new LoggerRule(Logging.getLogger(DataAccessRuleDAO.class), Level.ALL);
 
     @Test
     public void testValidationDeferredUntilCatalogReloaded() throws Exception {
@@ -40,10 +41,10 @@ public class ValidateRulesAfterCatalogLoadTest {
         // capture the registered CatalogListener
         AtomicReference<CatalogListener> listenerRef = new AtomicReference<>();
         doAnswer(invocation -> {
-            CatalogListener l = (CatalogListener) invocation.getArguments()[0];
-            listenerRef.set(l);
-            return null;
-        })
+                    CatalogListener l = (CatalogListener) invocation.getArguments()[0];
+                    listenerRef.set(l);
+                    return null;
+                })
                 .when(rawCatalog)
                 .addListener(any(CatalogListener.class));
 
@@ -72,19 +73,18 @@ public class ValidateRulesAfterCatalogLoadTest {
         l.reloaded();
 
         // now a WARNING should be logged for at least one of the rules
-        log.assertLogged(
-                new BaseMatcher<LogRecord>() {
-                    @Override
-                    public boolean matches(Object item) {
-                        if (!(item instanceof LogRecord)) return false;
-                        LogRecord r = (LogRecord) item;
-                        return r.getLevel().intValue() >= Level.WARNING.intValue()
-                                && r.getMessage().contains("Namespace/Workspace");
-                    }
+        log.assertLogged(new BaseMatcher<LogRecord>() {
+            @Override
+            public boolean matches(Object item) {
+                if (!(item instanceof LogRecord)) return false;
+                LogRecord r = (LogRecord) item;
+                return r.getLevel().intValue() >= Level.WARNING.intValue()
+                        && r.getMessage().contains("Namespace/Workspace");
+            }
 
-                    @Override
-                    public void describeTo(Description description) {}
-                });
+            @Override
+            public void describeTo(Description description) {}
+        });
     }
 
     @Test
@@ -98,10 +98,10 @@ public class ValidateRulesAfterCatalogLoadTest {
         // capture the registered CatalogListener
         AtomicReference<CatalogListener> listenerRef = new AtomicReference<>();
         doAnswer(invocation -> {
-            CatalogListener l = (CatalogListener) invocation.getArguments()[0];
-            listenerRef.set(l);
-            return null;
-        })
+                    CatalogListener l = (CatalogListener) invocation.getArguments()[0];
+                    listenerRef.set(l);
+                    return null;
+                })
                 .when(rawCatalog)
                 .addListener(any(CatalogListener.class));
 
@@ -120,8 +120,10 @@ public class ValidateRulesAfterCatalogLoadTest {
         Assert.assertFalse("No WARNING should be logged during parse (validation deferred)", sawWarningAtParse);
 
         // now simulate that workspaces were added before the catalog reload
-        when(rawCatalog.getWorkspaceByName(any(String.class))).thenReturn(mock(org.geoserver.catalog.WorkspaceInfo.class));
-        when(rawCatalog.getWorkspaces()).thenReturn(Collections.singletonList(mock(org.geoserver.catalog.WorkspaceInfo.class)));
+        when(rawCatalog.getWorkspaceByName(any(String.class)))
+                .thenReturn(mock(org.geoserver.catalog.WorkspaceInfo.class));
+        when(rawCatalog.getWorkspaces())
+                .thenReturn(Collections.singletonList(mock(org.geoserver.catalog.WorkspaceInfo.class)));
 
         // trigger reload and ensure NO WARNINGs are logged as the workspaces exist
         CatalogListener l = listenerRef.get();
@@ -132,6 +134,7 @@ public class ValidateRulesAfterCatalogLoadTest {
         boolean sawWarningAfterReload = log.records().stream()
                 .anyMatch(r -> r.getLevel().intValue() >= Level.WARNING.intValue()
                         && r.getMessage().contains("Namespace/Workspace"));
-        Assert.assertFalse("No WARNING should be logged after reload when workspaces are present", sawWarningAfterReload);
+        Assert.assertFalse(
+                "No WARNING should be logged after reload when workspaces are present", sawWarningAfterReload);
     }
 }

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
@@ -1,0 +1,137 @@
+/* (c) 2014 - 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.util.LoggerRule;
+import org.geotools.util.logging.Logging;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/** Integration test that demonstrates rule validation is deferred until the catalog is reloaded. */
+public class ValidateRulesAfterCatalogLoadTest {
+
+    @Rule public LoggerRule log = new LoggerRule(Logging.getLogger(DataAccessRuleDAO.class), Level.ALL);
+
+    @Test
+    public void testValidationDeferredUntilCatalogReloaded() throws Exception {
+        Catalog rawCatalog = mock(Catalog.class);
+
+        // ensure the catalog looks empty at first
+        when(rawCatalog.getWorkspaces()).thenReturn(Collections.emptyList());
+        when(rawCatalog.getWorkspaceByName(any(String.class))).thenReturn(null);
+
+        // capture the registered CatalogListener
+        AtomicReference<CatalogListener> listenerRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            CatalogListener l = (CatalogListener) invocation.getArguments()[0];
+            listenerRef.set(l);
+            return null;
+        })
+                .when(rawCatalog)
+                .addListener(any(CatalogListener.class));
+
+        // build large properties set simulating thousands of layers
+        Properties props = new Properties();
+        final int RULES = 2000; // large number to stress the parsing path
+        for (int i = 0; i < RULES; i++) {
+            props.put("ws" + i + ".layer" + i + ".r", "ROLE_X");
+        }
+
+        // construct the DAO (this will parse rules but should not emit WARNINGs yet)
+        MemoryDataAccessRuleDAO dao = new MemoryDataAccessRuleDAO(rawCatalog, props);
+
+        // ensure no WARNING logged during parsing (spurious startup warnings suppressed)
+        boolean sawWarningAtParse = log.records().stream()
+                .anyMatch(r -> r.getLevel().intValue() >= Level.WARNING.intValue()
+                        && r.getMessage().contains("Namespace/Workspace"));
+        Assert.assertFalse("No WARNING should be logged during parse (validation deferred)", sawWarningAtParse);
+
+        // now ensure the catalog still reports missing workspaces (simulate missing resources scenario)
+        when(rawCatalog.getWorkspaceByName(any(String.class))).thenReturn(null);
+
+        // trigger the catalog reload event which should cause validation to run and warnings to be emitted
+        CatalogListener l = listenerRef.get();
+        Assert.assertNotNull("CatalogListener should have been registered", l);
+        l.reloaded();
+
+        // now a WARNING should be logged for at least one of the rules
+        log.assertLogged(
+                new BaseMatcher<LogRecord>() {
+                    @Override
+                    public boolean matches(Object item) {
+                        if (!(item instanceof LogRecord)) return false;
+                        LogRecord r = (LogRecord) item;
+                        return r.getLevel().intValue() >= Level.WARNING.intValue()
+                                && r.getMessage().contains("Namespace/Workspace");
+                    }
+
+                    @Override
+                    public void describeTo(Description description) {}
+                });
+    }
+
+    @Test
+    public void testNoWarningWhenWorkspaceAddedBeforeReload() throws Exception {
+        Catalog rawCatalog = mock(Catalog.class);
+
+        // catalog appears empty at parse time
+        when(rawCatalog.getWorkspaces()).thenReturn(Collections.emptyList());
+        when(rawCatalog.getWorkspaceByName(any(String.class))).thenReturn(null);
+
+        // capture the registered CatalogListener
+        AtomicReference<CatalogListener> listenerRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            CatalogListener l = (CatalogListener) invocation.getArguments()[0];
+            listenerRef.set(l);
+            return null;
+        })
+                .when(rawCatalog)
+                .addListener(any(CatalogListener.class));
+
+        // large properties set
+        Properties props = new Properties();
+        final int RULES = 2000;
+        for (int i = 0; i < RULES; i++) {
+            props.put("ws" + i + ".layer" + i + ".r", "ROLE_X");
+        }
+
+        // construct DAO (parsing occurs, no warnings expected)
+        MemoryDataAccessRuleDAO dao = new MemoryDataAccessRuleDAO(rawCatalog, props);
+        boolean sawWarningAtParse = log.records().stream()
+                .anyMatch(r -> r.getLevel().intValue() >= Level.WARNING.intValue()
+                        && r.getMessage().contains("Namespace/Workspace"));
+        Assert.assertFalse("No WARNING should be logged during parse (validation deferred)", sawWarningAtParse);
+
+        // now simulate that workspaces were added before the catalog reload
+        when(rawCatalog.getWorkspaceByName(any(String.class))).thenReturn(mock(org.geoserver.catalog.WorkspaceInfo.class));
+        when(rawCatalog.getWorkspaces()).thenReturn(Collections.singletonList(mock(org.geoserver.catalog.WorkspaceInfo.class)));
+
+        // trigger reload and ensure NO WARNINGs are logged as the workspaces exist
+        CatalogListener l = listenerRef.get();
+        Assert.assertNotNull("CatalogListener should have been registered", l);
+        l.reloaded();
+
+        // assert no Namespace/Workspace WARNING was emitted after validation
+        boolean sawWarningAfterReload = log.records().stream()
+                .anyMatch(r -> r.getLevel().intValue() >= Level.WARNING.intValue()
+                        && r.getMessage().contains("Namespace/Workspace"));
+        Assert.assertFalse("No WARNING should be logged after reload when workspaces are present", sawWarningAfterReload);
+    }
+}

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
@@ -76,10 +76,11 @@ public class ValidateRulesAfterCatalogLoadTest {
         log.assertLogged(new BaseMatcher<>() {
             @Override
             public boolean matches(Object item) {
-                if (!(item instanceof LogRecord)) return false;
-                LogRecord r = (LogRecord) item;
-                return r.getLevel().intValue() >= Level.WARNING.intValue()
-                        && r.getMessage().contains("Namespace/Workspace");
+                if (item instanceof LogRecord r) {
+                    return r.getLevel().intValue() >= Level.WARNING.intValue()
+                            && r.getMessage().contains("Namespace/Workspace");
+                }
+                return false;
             }
 
             @Override

--- a/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/impl/ValidateRulesAfterCatalogLoadTest.java
@@ -56,7 +56,7 @@ public class ValidateRulesAfterCatalogLoadTest {
         }
 
         // construct the DAO (this will parse rules but should not emit WARNINGs yet)
-        MemoryDataAccessRuleDAO dao = new MemoryDataAccessRuleDAO(rawCatalog, props);
+        new MemoryDataAccessRuleDAO(rawCatalog, props);
 
         // ensure no WARNING logged during parsing (spurious startup warnings suppressed)
         boolean sawWarningAtParse = log.records().stream()
@@ -73,7 +73,7 @@ public class ValidateRulesAfterCatalogLoadTest {
         l.reloaded();
 
         // now a WARNING should be logged for at least one of the rules
-        log.assertLogged(new BaseMatcher<LogRecord>() {
+        log.assertLogged(new BaseMatcher<>() {
             @Override
             public boolean matches(Object item) {
                 if (!(item instanceof LogRecord)) return false;
@@ -113,7 +113,7 @@ public class ValidateRulesAfterCatalogLoadTest {
         }
 
         // construct DAO (parsing occurs, no warnings expected)
-        MemoryDataAccessRuleDAO dao = new MemoryDataAccessRuleDAO(rawCatalog, props);
+        new MemoryDataAccessRuleDAO(rawCatalog, props);
         boolean sawWarningAtParse = log.records().stream()
                 .anyMatch(r -> r.getLevel().intValue() >= Level.WARNING.intValue()
                         && r.getMessage().contains("Namespace/Workspace"));


### PR DESCRIPTION
[GEOS-12032] Spurious "Namespace/Workspace ... is unknown in rule ..." warnings during startup

See [above issue](https://osgeo-org.atlassian.net/browse/GEOS-12032) for the background to the fix below.

**Fix implemented**

I implemented the safer/less-invasive option: defer validation warnings until the Catalog is known to be populated while keeping early parsing available for access control.
**Changes (file and behavior):**
  - **File edited:** `DataAccessRuleDAO.java`
  - **Key changes:**
    - Downgraded immediate startup "namespace/group unknown" logs in `parseDataAccessRule(...)` from WARNING to FINE and append "(validation deferred)".
    - Introduced `rulesValidated` flag, reset when rules are reloaded so validation runs again on change.
    - Added `registerCatalogListener()` that registers a CatalogListener on `rawCatalog`. On `reloaded()` the listener calls `validateRulesAgainstCatalog()`.
    - Added `validateRulesAgainstCatalog()` that iterates current rules and emits WARNING only when the catalog is actually missing referenced workspace / layer group.
    - Call `registerCatalogListener()` from the DAO constructors.
**Rationale:**
    Keeps early parsing (so ResourceAccessManager can be created and used), avoids spurious WARNINGs, and performs authoritative validation once the Catalog is ready.

**Code snippets / pointers**
  - *Original (conceptual):*
	  parse time: if workspace missing → `LOGGER.warning(...)`
- *New approach:*
	parse time: if workspace missing → `LOGGER.fine(... + " (validation deferred)")`
	later on catalog `reloaded()` → `validateRulesAgainstCatalog()`:
		if workspace missing → `LOGGER.warning(...)`

**Tests added**
- *Integration test:* simulate `rawCatalog.reloaded()` event while a referenced workspace is absent
Assert that the WARNING is emitted by `validateRulesAgainstCatalog()`.
- *Regression test:* ensure the ResourceAccessManager still builds a rule tree and enforces rules the same as before.

**Alternatives considered (and reasons rejected)**
- *Delay parsing entirely until Catalog is loaded:*
  Pros: eliminate any chance of startup spurious logs.
  Cons: ResourceAccessManager (and other services) may require parsed rules early — changing initialization order is invasive and may break components that expect security rules to be available during startup.
- *Build authorization tree lazily on first use:*
  Pros: avoids startup ordering issues.
  Cons: may delay security decisions or cause subtle differences in behavior; requires more changes and tests.
- *Rely on Spring bean ordering or lifecycle events:*
  Pros: could coordinate initialization.
  Cons: brittle, hard to guarantee consistent across environments and tests.

I chose the validation-defer approach because it's minimal, safe, preserves current behaviour, removes the noise, and keeps a clear validation step when catalog data is known to be available.



# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.