### PR TITLE
Fix aboutcontroller advice v2

### DIFF
--- a/src/community/gsr/pom.xml
+++ b/src/community/gsr/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3.1</version>
+      <version>2.13.2</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/src/extension/importer/rest/pom.xml
+++ b/src/extension/importer/rest/pom.xml
@@ -26,10 +26,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.restlet</groupId>
-      <artifactId>org.restlet.ext.fileupload</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
     </dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -468,7 +468,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.3.1</version>
+        <version>2.13.2</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.genericdao</groupId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -126,6 +126,7 @@
     <postgis.jdbc.version>1.3.3</postgis.jdbc.version>
     <servlet-api.version>6.1.0</servlet-api.version>
     <xalan.version>2.7.3</xalan.version>
+    <protobuf.version>4.33.2</protobuf.version>
 
     <!-- ================================ -->
     <!-- Maven plugin configuration      -->
@@ -606,6 +607,11 @@
         <version>5.13.4</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
       </dependency>
 
       <!-- logging dependencies managed by platform-dependencies BOM -->

--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/AboutController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/AboutController.java
@@ -40,7 +40,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(
         path = RestBaseController.ROOT_PATH + "/about",
         produces = {MediaType.TEXT_HTML_VALUE, MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
-@ControllerAdvice
 public class AboutController extends RestBaseController {
 
     @GetMapping(value = "/manifest")

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/AboutControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/AboutControllerTest.java
@@ -80,6 +80,7 @@ public class AboutControllerTest extends GeoServerSystemTestSupport {
         JSONObject json = (JSONObject) getAsJSON(BASEPATH + "/about/version.json");
         // print(json);
         checkJSONModel(json);
+        assertTrue(json.has("about"));
     }
 
     @Test


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.

# Description

This PR fixes an issue in the REST /about/version.json endpoint where JSON output could be duplicated due to AboutController applying @ControllerAdvice to itself.

The self-applied advice caused XStream serialization to run twice, resulting in two consecutive JSON objects being written to the response stream during REST JSON serialization.