### PR TITLE
Skip setting catalog on remote styles in JDBCConfig resolveTransient

### DIFF
--- a/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
+++ b/src/community/jdbcconfig/src/main/java/org/geoserver/jdbcconfig/internal/ConfigDatabase.java
@@ -1162,7 +1162,12 @@ public class ConfigDatabase implements ApplicationContextAware {
             return;
         }
         real = ModificationProxy.unwrap(real);
-        if (real instanceof StyleInfoImpl || real instanceof StoreInfoImpl || real instanceof ResourceInfoImpl) {
+        boolean isRemoteStyle = real instanceof StyleInfoImpl
+                && ((StyleInfoImpl) real).getMetadata().containsKey(StyleInfoImpl.IS_REMOTE);
+        if (!isRemoteStyle
+                && (real instanceof StyleInfoImpl
+                        || real instanceof StoreInfoImpl
+                        || real instanceof ResourceInfoImpl)) {
             OwsUtils.set(real, "catalog", catalog);
         }
         if (real instanceof ResourceInfoImpl impl) {

--- a/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/ConfigDatabaseTest.java
+++ b/src/community/jdbcconfig/src/test/java/org/geoserver/jdbcconfig/internal/ConfigDatabaseTest.java
@@ -475,6 +475,45 @@ public class ConfigDatabaseTest {
     }
 
     @Test
+    public void testWMSCascadingRemoteStylesAfterCacheReload() throws Exception {
+        WorkspaceInfo ws = addWorkspace();
+
+        WMSStoreInfoImpl wmsStore = new WMSStoreInfoImpl(database.getCatalog());
+        wmsStore.setCapabilitiesURL(
+                ConfigDatabaseTest.class.getResource("/wms_capabilities.xml").toString());
+        wmsStore.setId("theWmsStore");
+        wmsStore.setName("fakeGeoServer");
+        wmsStore.setWorkspace(ws);
+        wmsStore.setUseConnectionPooling(false);
+        database.add(wmsStore);
+
+        CatalogBuilder cb = new CatalogBuilder(database.getCatalog());
+        cb.setStore(wmsStore);
+        WMSLayerInfoImpl wmsLayer = (WMSLayerInfoImpl) cb.buildWMSLayer("states");
+        wmsLayer.reset();
+        wmsLayer.setId("theWmsLayer");
+        wmsLayer.setForcedRemoteStyle("population");
+        wmsLayer.setSelectedRemoteStyles(new ArrayList<>(Arrays.asList("pophatch", "polygon")));
+        database.add(wmsLayer);
+        LayerInfoImpl layer = (LayerInfoImpl) cb.buildLayer(wmsLayer);
+        layer.setId("theLayer");
+        database.add(layer);
+
+        // clear cache to force re-fetch, triggering resolveTransient()
+        database.clearCache(layer);
+
+        LayerInfo reloaded = database.getById(layer.getId(), LayerInfo.class);
+        assertNotNull(reloaded);
+
+        StyleInfo defaultStyle = reloaded.getDefaultStyle();
+        assertRemoteStyle(defaultStyle);
+
+        // remote styles must not have catalog set by resolveTransient()
+        StyleInfoImpl unwrapped = (StyleInfoImpl) ModificationProxy.unwrap(defaultStyle);
+        assertNull("Remote style should not have catalog set by resolveTransient()", unwrapped.getCatalog());
+    }
+
+    @Test
     public void testWMTSStore() throws Exception {
         final WMTSStoreInfo store = addWMTSStore();
 


### PR DESCRIPTION
The`jdbcconfig` plugin causes WMTS GetCapabilities to fail for cascaded WMS layers with:
```
Error searching max and min scale denominators for style ''
```

This is the same issue described in #8775 (closed by stale bot), implementing the fix suggested by NielsCharlier.

## Reproduce

1. Enable the `jdbcconfig` plugin
2. Create a WMS store pointing to an external WMS server
3. Add a layer from this WMS store (with Tile-Caching enabled, which is the default)
4. Request WMTS GetCapabilities

**Result:** `400: Error searching max and min scale denominators for style ''`

## Root cause

`ConfigDatabase.resolveTransient()` unconditionally sets the `catalog` property on all `StyleInfoImpl` objects. Remote styles (generated on-the-fly from WMS/WMTS capabilities) are not part of the local catalog and should not have a catalog reference. When they do, other code paths (such as WMTS GetCapabilities building legend info) see a style with a non-null catalog and attempt to resolve it by name against the catalog. Since remote default styles have an empty name, this lookup fails.

## Fix

Check for the existing `StyleInfoImpl.IS_REMOTE` metadata flag before setting catalog in `resolveTransient()` and skip it if the style is remote.

Tested on 2.28.2
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).