### PR TITLE
[GEOS-12083] Skip brute force login delays when checking for default administrator password

### DIFF
--- a/src/main/src/main/java/org/geoserver/security/BruteForceListener.java
+++ b/src/main/src/main/java/org/geoserver/security/BruteForceListener.java
@@ -6,6 +6,7 @@ package org.geoserver.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,6 +31,8 @@ public class BruteForceListener implements ApplicationListener<AbstractAuthentic
 
     static final Logger LOGGER = Logging.getLogger(BruteForceListener.class);
 
+    private static final ThreadLocal<Boolean> THROTTLING_DISABLED = new ThreadLocal<>();
+
     /**
      * Simple single node delayed login tracker. Should be made pluggable to allow by some sort of network service for a
      * clustered installation
@@ -40,6 +43,42 @@ public class BruteForceListener implements ApplicationListener<AbstractAuthentic
 
     public BruteForceListener(GeoServerSecurityManager securityManager) {
         this.securityManager = securityManager;
+    }
+
+    /**
+     * Executes a task with authentication throttling disabled for the current thread.
+     *
+     * @param task the task to execute
+     * @param <V> the return type of the task
+     * @return the result of the task
+     * @throws Exception if the task fails
+     */
+    public static <V> V withThrottlingDisabled(Callable<V> task) throws Exception {
+        Boolean previous = THROTTLING_DISABLED.get();
+        try {
+            setThrottlingDisabled(true);
+            return task.call();
+        } finally {
+            if (Boolean.TRUE.equals(previous)) {
+                THROTTLING_DISABLED.set(Boolean.TRUE);
+            } else {
+                THROTTLING_DISABLED.remove();
+            }
+        }
+    }
+
+    /**
+     * Disables the authentication delay for the current thread. This is useful for internal geoserver checks that don't
+     * want to wait for the brute force delay
+     *
+     * @param disabled true to disable, false to enable
+     */
+    private static void setThrottlingDisabled(boolean disabled) {
+        if (disabled) {
+            THROTTLING_DISABLED.set(Boolean.TRUE);
+        } else {
+            THROTTLING_DISABLED.remove();
+        }
     }
 
     private BruteForcePreventionConfig getConfig() {
@@ -53,6 +92,10 @@ public class BruteForceListener implements ApplicationListener<AbstractAuthentic
 
     @Override
     public void onApplicationEvent(AbstractAuthenticationEvent event) {
+        if (Boolean.TRUE.equals(THROTTLING_DISABLED.get())) {
+            return;
+        }
+
         // is it enabled?
         BruteForcePreventionConfig config = getConfig();
         if (!config.isEnabled()) {
@@ -72,6 +115,7 @@ public class BruteForceListener implements ApplicationListener<AbstractAuthentic
             LOGGER.warning("Brute force attack prevention enabled, but Spring Authentication "
                     + "does not provide a user name, skipping: "
                     + authentication);
+            return;
         }
 
         // do we have a delayed login in flight already? If so, kill this login attempt
@@ -118,7 +162,8 @@ public class BruteForceListener implements ApplicationListener<AbstractAuthentic
         return config.getWhitelistAddressMatchers().stream().anyMatch(matcher -> matcher.matches(request));
     }
 
-    private long computeDelay(BruteForcePreventionConfig config) {
+    @com.google.common.annotations.VisibleForTesting
+    long computeDelay(BruteForcePreventionConfig config) {
         long min = config.getMinDelaySeconds() * 1000;
         long max = config.getMaxDelaySeconds() * 1000;
         return min + (long) ((max - min) * ThreadLocalRandom.current().nextDouble());

--- a/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
+++ b/src/main/src/main/java/org/geoserver/security/GeoServerSecurityManager.java
@@ -1047,9 +1047,7 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
         } catch (InvalidKeyException e) {
             strongEncryptionAvaialble = false;
             LOGGER.warning(
-                    """
-                    Strong cryptography is NOT available
-                    Download and installation the of unlimted length policy files is recommended""");
+                    "Strong cryptography is NOT available. Downloading and installing of the unlimited strength policy files is recommended");
         } catch (Exception ex) {
             LOGGER.log(Level.WARNING, "Strong cryptography is NOT available, unexpected error", ex);
             strongEncryptionAvaialble = false; // should not happen
@@ -1359,12 +1357,12 @@ public class GeoServerSecurityManager implements ApplicationContextAware, Applic
                 GeoServerUser.ADMIN_USERNAME, GeoServerUser.DEFAULT_ADMIN_PASSWD);
 
         try {
-            token = providerMgr.authenticate(token);
+            Authentication result = BruteForceListener.withThrottlingDisabled(() -> providerMgr.authenticate(token));
+            return result.isAuthenticated();
         } catch (Exception e) {
-            // ok
+            // authentication failed
+            return false;
         }
-
-        return token.isAuthenticated();
     }
 
     /** Lists all available filter configurations. */

--- a/src/main/src/test/java/org/geoserver/security/BruteForceListenerTest.java
+++ b/src/main/src/test/java/org/geoserver/security/BruteForceListenerTest.java
@@ -1,0 +1,78 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.geoserver.security.config.BruteForcePreventionConfig;
+import org.geoserver.security.config.SecurityManagerConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+public class BruteForceListenerTest {
+
+    @Before
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // just a test, not a real IP
+    public void setup() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("128.0.0.1");
+        GeoServerSecurityFilterChainProxy.REQUEST.set(request);
+    }
+
+    @After
+    public void tearDown() {
+        GeoServerSecurityFilterChainProxy.REQUEST.remove();
+    }
+
+    @Test
+    public void testThrottlingDisabled() throws Exception {
+        // Setup mock security manager and config
+        GeoServerSecurityManager sm = mock(GeoServerSecurityManager.class);
+        SecurityManagerConfig smConfig = mock(SecurityManagerConfig.class);
+        BruteForcePreventionConfig bfConfig = new BruteForcePreventionConfig();
+        bfConfig.setEnabled(true);
+        bfConfig.setMinDelaySeconds(1);
+        bfConfig.setMaxDelaySeconds(1);
+
+        when(sm.getSecurityConfig()).thenReturn(smConfig);
+        when(smConfig.getBruteForcePrevention()).thenReturn(bfConfig);
+
+        // We use a spy to avoid actual waits while allowing call count verification
+        BruteForceListener listener = spy(new BruteForceListener(sm));
+        doReturn(0L).when(listener).computeDelay(any());
+
+        // prepare the authentication failed event
+        Authentication auth = new UsernamePasswordAuthenticationToken("admin", "wrong-password");
+        AuthenticationFailureBadCredentialsEvent event =
+                new AuthenticationFailureBadCredentialsEvent(auth, new AuthenticationException("bad") {});
+
+        // 1. Verify it actually tries to delay when NOT disabled, computeDelay is called once
+        listener.onApplicationEvent(event);
+        verify(listener, times(1)).computeDelay(any());
+
+        // 2. Verify it does NOT try to delay when disabled (computeDelay not called, count remains 1)
+        BruteForceListener.withThrottlingDisabled(() -> {
+            listener.onApplicationEvent(event);
+            return null;
+        });
+        verify(listener, times(1)).computeDelay(any());
+
+        // 3. Verify it's re-enabled after cleanup, causing a second call to computeDelay
+        listener.onApplicationEvent(event);
+        verify(listener, times(2)).computeDelay(any());
+    }
+}


### PR DESCRIPTION
[![GEOS-12083](https://badgen.net/badge/JIRA/GEOS-12083/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12083) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

As per title, a little "perk" for the GeoServer 3 release, which will make the GS3 GUI feel snappier.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 