### PR TITLE
Fix fixed-timezone handling for WFS GeoJSON `timeStamp`

### DIFF
--- a/src/main/src/main/java/org/geoserver/json/GeoJSONFeatureWriter.java
+++ b/src/main/src/main/java/org/geoserver/json/GeoJSONFeatureWriter.java
@@ -30,7 +30,6 @@ import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.ServiceException;
-import org.geoserver.util.ISO8601Formatter;
 import org.geotools.api.feature.Feature;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
@@ -304,7 +303,13 @@ public abstract class GeoJSONFeatureWriter<T extends FeatureType, F extends Feat
 
     /** Writes a OGC API - Features compliant timeStamp collection attribute */
     protected void writeCollectionTimeStamp(GeoJSONBuilder jw) {
-        jw.key("timeStamp").value(new ISO8601Formatter().format(new Date()));
+        Date timestamp = new Date();
+        jw.key("timeStamp");
+        if (TemporalUtils.isDateTimeFormatEnabled()) {
+            jw.value(TemporalUtils.printDate(timestamp));
+        } else {
+            jw.value(timestamp);
+        }
     }
 
     /**

--- a/src/main/src/test/java/org/geoserver/json/GeoJSONFeatureWriterTest.java
+++ b/src/main/src/test/java/org/geoserver/json/GeoJSONFeatureWriterTest.java
@@ -1,0 +1,65 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.json;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringWriter;
+import java.util.TimeZone;
+import org.geotools.api.feature.Feature;
+import org.geotools.api.feature.type.FeatureType;
+import org.geotools.util.factory.Hints;
+import org.junit.Test;
+
+public class GeoJSONFeatureWriterTest {
+
+    @Test
+    public void testCollectionTimeStampUsesConfiguredLocalTimeZone() {
+        TimeZone previousTimeZone = TimeZone.getDefault();
+        Object previousDateTimeFormat = Hints.getSystemDefault(Hints.DATE_TIME_FORMAT_HANDLING);
+        Object previousLocalTime = Hints.getSystemDefault(Hints.LOCAL_DATE_TIME_HANDLING);
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("GMT+08:00"));
+            Hints.putSystemDefault(Hints.DATE_TIME_FORMAT_HANDLING, true);
+            Hints.putSystemDefault(Hints.LOCAL_DATE_TIME_HANDLING, true);
+
+            StringWriter writer = new StringWriter();
+            GeoJSONBuilder builder = new GeoJSONBuilder(writer);
+            new TestGeoJSONFeatureWriter().writeTimeStamp(builder);
+
+            assertTrue(writer.toString(), writer.toString().matches("\\{\"timeStamp\":\".*\\+08:00\"\\}"));
+        } finally {
+            TimeZone.setDefault(previousTimeZone);
+            restoreHint(Hints.DATE_TIME_FORMAT_HANDLING, previousDateTimeFormat);
+            restoreHint(Hints.LOCAL_DATE_TIME_HANDLING, previousLocalTime);
+        }
+    }
+
+    private static void restoreHint(Hints.Key key, Object value) {
+        if (value == null) {
+            Hints.removeSystemDefault(key);
+        } else {
+            Hints.putSystemDefault(key, value);
+        }
+    }
+
+    private static final class TestGeoJSONFeatureWriter extends GeoJSONFeatureWriter<FeatureType, Feature> {
+
+        private TestGeoJSONFeatureWriter() {
+            super(null);
+        }
+
+        @Override
+        protected boolean isFeatureBounding() {
+            return false;
+        }
+
+        private void writeTimeStamp(GeoJSONBuilder builder) {
+            builder.object();
+            writeCollectionTimeStamp(builder);
+            builder.endObject();
+        }
+    }
+}


### PR DESCRIPTION
## Background
  In the current WFS GeoJSON response, the top-level `timeStamp` and the time fields inside `properties` use different timezone handling strategies.

  Before this fix:
  - the top-level `timeStamp` was always serialized with a fixed UTC/GMT-based formatter;
  - time fields inside `properties` followed the existing date/time serialization path, which is affected by the `TemporalUtils` / `GeoJSONBuilder` handling
  strategy.

  As a result, different time fields in the same response were serialized differently. This is confusing for clients because `timeStamp` and the temporal
  fields in `properties` all represent time values, but they do not follow the same timezone rules.

  ## What is changed
  This change aligns the serialization strategy of the top-level `timeStamp` with the one already used for temporal fields in `properties`.

  Specifically:
  - the semantic meaning of `timeStamp` remains unchanged and still represents the response generation time;
  - `timeStamp` no longer uses the fixed-UTC `ISO8601Formatter` directly;
  - when date/time formatting is enabled, `timeStamp` is now serialized via `TemporalUtils.printDate(...)`;
  - when date/time formatting is disabled, `timeStamp` now goes through the default `GeoJSONBuilder` date serialization path.

  ## Result
  After this change, the top-level `timeStamp` and the temporal fields inside `properties` follow the same timezone handling strategy in WFS GeoJSON
  responses. This removes the inconsistency within the response and makes the behavior easier for clients to understand and use.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.