### PR TITLE
[GEOS-12084] TemplateController REST endpoints accept non-existent workspace, store, and resource names

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/catalog/TemplateController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/catalog/TemplateController.java
@@ -13,6 +13,9 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.Paths;
 import org.geoserver.platform.resource.Resource;
@@ -25,6 +28,7 @@ import org.geoserver.rest.util.MediaTypeExtensions;
 import org.geoserver.rest.util.RESTUtils;
 import org.geoserver.rest.wrapper.RestWrapper;
 import org.geotools.util.logging.Logging;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
@@ -89,6 +93,7 @@ public class TemplateController extends AbstractCatalogController {
             @PathVariable(required = false) String featureTypeName,
             @PathVariable String templateName) {
 
+        validate(workspaceName, storeName, featureTypeName);
         String filename = templateName + "." + MediaTypeExtensions.FTL_EXTENSION;
         String path = Paths.path(path(workspaceName, storeName, featureTypeName), filename);
         Resource resource = resources.get(path);
@@ -113,6 +118,7 @@ public class TemplateController extends AbstractCatalogController {
             @PathVariable String templateName,
             HttpServletResponse response) {
 
+        validate(workspaceName, storeName, featureTypeName);
         String filename = templateName + "." + MediaTypeExtensions.FTL_EXTENSION;
         String path = Paths.path(path(workspaceName, storeName, featureTypeName), filename);
         Resource resource = resources.get(path);
@@ -148,6 +154,7 @@ public class TemplateController extends AbstractCatalogController {
             @PathVariable String templateName,
             HttpServletRequest request) {
 
+        validate(workspaceName, storeName, featureTypeName);
         String filename = templateName + "." + MediaTypeExtensions.FTL_EXTENSION;
         String path = path(workspaceName, storeName, featureTypeName);
         Resource directory = resources.get(path);
@@ -180,6 +187,7 @@ public class TemplateController extends AbstractCatalogController {
             @PathVariable(required = false) String storeName,
             @PathVariable(required = false) String featureTypeName) {
 
+        validate(workspaceName, storeName, featureTypeName);
         String path = path(workspaceName, storeName, featureTypeName);
         Resource directory = resources.get(path);
         switch (directory.getType()) {
@@ -229,5 +237,53 @@ public class TemplateController extends AbstractCatalogController {
             }
         }
         return Paths.path(path.toArray(new String[] {}));
+    }
+
+    private void validate(
+            @Nullable String workspaceName, @Nullable String storeName, @Nullable String resourceTypeName) {
+        WorkspaceInfo workspace = validateWorkspace(workspaceName);
+        if (workspace != null) {
+            StoreInfo store = validateStore(workspace, storeName);
+            if (store != null) {
+                validateResource(store, resourceTypeName);
+            }
+        }
+    }
+
+    private WorkspaceInfo validateWorkspace(@Nullable String workspaceName) {
+        if (workspaceName == null) {
+            return null;
+        }
+        WorkspaceInfo workspace = catalog.getWorkspaceByName(workspaceName);
+        if (workspace == null) {
+            throw new RestException("Workspace " + workspaceName + " does not exist", HttpStatus.NOT_FOUND);
+        }
+        return workspace;
+    }
+
+    private StoreInfo validateStore(WorkspaceInfo workspace, @Nullable String storeName) {
+        if (storeName == null) {
+            return null;
+        }
+        StoreInfo store = catalog.getStoreByName(workspace, storeName, StoreInfo.class);
+        if (store == null) {
+            throw new RestException(
+                    "Store %s:%s does not exist".formatted(workspace.getName(), storeName), HttpStatus.NOT_FOUND);
+        }
+        return store;
+    }
+
+    private void validateResource(StoreInfo store, @Nullable String resourceName) {
+        if (resourceName == null) {
+            return;
+        }
+
+        ResourceInfo resource = catalog.getResourceByStore(store, resourceName, ResourceInfo.class);
+        if (resource == null) {
+            throw new RestException(
+                    "Resouce %s:%s does not exist"
+                            .formatted(store.getWorkspace().getName(), resourceName),
+                    HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/restconfig/src/test/java/org/geoserver/rest/catalog/TemplateControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/catalog/TemplateControllerTest.java
@@ -85,25 +85,29 @@ public class TemplateControllerTest extends CatalogRESTTestSupport {
     private List<String> getAllPaths() {
         List<String> paths = new ArrayList<>();
 
+        // global templates
         paths.add(ROOT_PATH + "/templates/aTemplate.ftl");
         paths.add(ROOT_PATH + "/templates/anotherTemplate.ftl");
 
-        paths.add(ROOT_PATH + "/workspaces/topp/templates/aTemplate.ftl");
-        paths.add(ROOT_PATH + "/workspaces/topp/templates/anotherTemplate.ftl");
+        // workspace templates (cite workspace exists from default test data)
+        paths.add(ROOT_PATH + "/workspaces/cite/templates/aTemplate.ftl");
+        paths.add(ROOT_PATH + "/workspaces/cite/templates/anotherTemplate.ftl");
 
-        paths.add(ROOT_PATH + "/workspaces/topp/datastores/states_shapefile/templates/aTemplate.ftl");
-        paths.add(ROOT_PATH + "/workspaces/topp/datastores/states_shapefile/templates/anotherTemplate.ftl");
+        // datastore templates (cite datastore exists in cite workspace)
+        paths.add(ROOT_PATH + "/workspaces/cite/datastores/cite/templates/aTemplate.ftl");
+        paths.add(ROOT_PATH + "/workspaces/cite/datastores/cite/templates/anotherTemplate.ftl");
 
-        paths.add(
-                ROOT_PATH + "/workspaces/topp/datastores/states_shapefile/featuretypes/states/templates/aTemplate.ftl");
-        paths.add(ROOT_PATH
-                + "/workspaces/topp/datastores/states_shapefile/featuretypes/states/templates/anotherTemplate.ftl");
+        // feature type templates (Buildings exists in cite datastore)
+        paths.add(ROOT_PATH + "/workspaces/cite/datastores/cite/featuretypes/Buildings/templates/aTemplate.ftl");
+        paths.add(ROOT_PATH + "/workspaces/cite/datastores/cite/featuretypes/Buildings/templates/anotherTemplate.ftl");
 
+        // coveragestore templates (DEM exists in wcs workspace from setUpDefaultRasterLayers)
         paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/templates/aTemplate.ftl");
         paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/templates/anotherTemplate.ftl");
 
-        paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/coverages/tazdem.tiff/templates/aTemplate.ftl");
-        paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/coverages/tazdem.tiff/templates/anotherTemplate.ftl");
+        // coverage templates
+        paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/coverages/DEM/templates/aTemplate.ftl");
+        paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/coverages/DEM/templates/anotherTemplate.ftl");
 
         return paths;
     }
@@ -174,6 +178,97 @@ public class TemplateControllerTest extends CatalogRESTTestSupport {
         assertEquals(barContent, getAsString(barTemplate).trim());
     }
 
+    // -- Non-existent workspace --
+
+    @Test
+    public void testPutNonExistentWorkspace() throws Exception {
+        String path = ROOT_PATH + "/workspaces/nonexistent/templates/test.ftl";
+        assertEquals(404, putAsServletResponse(path, "content", "text/plain").getStatus());
+    }
+
+    @Test
+    public void testGetNonExistentWorkspace() throws Exception {
+        assertNotFound(ROOT_PATH + "/workspaces/nonexistent/templates/test.ftl");
+    }
+
+    @Test
+    public void testDeleteNonExistentWorkspace() throws Exception {
+        assertEquals(
+                404,
+                deleteAsServletResponse(ROOT_PATH + "/workspaces/nonexistent/templates/test.ftl")
+                        .getStatus());
+    }
+
+    @Test
+    public void testListNonExistentWorkspace() throws Exception {
+        assertNotFound(ROOT_PATH + "/workspaces/nonexistent/templates");
+    }
+
+    // -- Non-existent datastore --
+
+    @Test
+    public void testPutNonExistentDatastore() throws Exception {
+        String path = ROOT_PATH + "/workspaces/cite/datastores/nonexistent/templates/test.ftl";
+        assertEquals(404, putAsServletResponse(path, "content", "text/plain").getStatus());
+    }
+
+    @Test
+    public void testGetNonExistentDatastore() throws Exception {
+        assertNotFound(ROOT_PATH + "/workspaces/cite/datastores/nonexistent/templates/test.ftl");
+    }
+
+    @Test
+    public void testDeleteNonExistentDatastore() throws Exception {
+        assertEquals(
+                404,
+                deleteAsServletResponse(ROOT_PATH + "/workspaces/cite/datastores/nonexistent/templates/test.ftl")
+                        .getStatus());
+    }
+
+    @Test
+    public void testListNonExistentDatastore() throws Exception {
+        assertNotFound(ROOT_PATH + "/workspaces/cite/datastores/nonexistent/templates");
+    }
+
+    // -- Non-existent coveragestore --
+
+    @Test
+    public void testPutNonExistentCoveragestore() throws Exception {
+        String path = ROOT_PATH + "/workspaces/wcs/coveragestores/nonexistent/templates/test.ftl";
+        assertEquals(404, putAsServletResponse(path, "content", "text/plain").getStatus());
+    }
+
+    @Test
+    public void testListNonExistentCoveragestore() throws Exception {
+        assertNotFound(ROOT_PATH + "/workspaces/wcs/coveragestores/nonexistent/templates");
+    }
+
+    // -- Non-existent feature type --
+
+    @Test
+    public void testPutNonExistentFeatureType() throws Exception {
+        String path = ROOT_PATH + "/workspaces/cite/datastores/cite/featuretypes/nonexistent/templates/test.ftl";
+        assertEquals(404, putAsServletResponse(path, "content", "text/plain").getStatus());
+    }
+
+    @Test
+    public void testListNonExistentFeatureType() throws Exception {
+        assertNotFound(ROOT_PATH + "/workspaces/cite/datastores/cite/featuretypes/nonexistent/templates");
+    }
+
+    // -- Non-existent coverage --
+
+    @Test
+    public void testPutNonExistentCoverage() throws Exception {
+        String path = ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/coverages/nonexistent/templates/test.ftl";
+        assertEquals(404, putAsServletResponse(path, "content", "text/plain").getStatus());
+    }
+
+    @Test
+    public void testListNonExistentCoverage() throws Exception {
+        assertNotFound(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/coverages/nonexistent/templates");
+    }
+
     @Test
     public void testAllPathsSequentiallyForJson() throws Exception {
         Random random = new Random();
@@ -188,24 +283,21 @@ public class TemplateControllerTest extends CatalogRESTTestSupport {
         paths.add(ROOT_PATH + "/templates/aTemplate_json.ftl");
         paths.add(ROOT_PATH + "/templates/anotherTemplate_json.ftl");
 
-        paths.add(ROOT_PATH + "/workspaces/topp/templates/aTemplate_json.ftl");
-        paths.add(ROOT_PATH + "/workspaces/topp/templates/anotherTemplate_json.ftl");
+        paths.add(ROOT_PATH + "/workspaces/cite/templates/aTemplate_json.ftl");
+        paths.add(ROOT_PATH + "/workspaces/cite/templates/anotherTemplate_json.ftl");
 
-        paths.add(ROOT_PATH + "/workspaces/topp/datastores/states_shapefile/templates/aTemplate_json.ftl");
-        paths.add(ROOT_PATH + "/workspaces/topp/datastores/states_shapefile/templates/anotherTemplate_json.ftl");
+        paths.add(ROOT_PATH + "/workspaces/cite/datastores/cite/templates/aTemplate_json.ftl");
+        paths.add(ROOT_PATH + "/workspaces/cite/datastores/cite/templates/anotherTemplate_json.ftl");
 
+        paths.add(ROOT_PATH + "/workspaces/cite/datastores/cite/featuretypes/Buildings/templates/aTemplate_json.ftl");
         paths.add(ROOT_PATH
-                + "/workspaces/topp/datastores/states_shapefile/featuretypes/states/templates/aTemplate_json.ftl");
-        paths.add(
-                ROOT_PATH
-                        + "/workspaces/topp/datastores/states_shapefile/featuretypes/states/templates/anotherTemplate_json.ftl");
+                + "/workspaces/cite/datastores/cite/featuretypes/Buildings/templates/anotherTemplate_json.ftl");
 
         paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/templates/aTemplate_json.ftl");
         paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/templates/anotherTemplate_json.ftl");
 
-        paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/coverages/tazdem.tiff/templates/aTemplate_json.ftl");
-        paths.add(ROOT_PATH
-                + "/workspaces/wcs/coveragestores/DEM/coverages/tazdem.tiff/templates/anotherTemplate_json.ftl");
+        paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/coverages/DEM/templates/aTemplate_json.ftl");
+        paths.add(ROOT_PATH + "/workspaces/wcs/coveragestores/DEM/coverages/DEM/templates/anotherTemplate_json.ftl");
 
         return paths;
     }


### PR DESCRIPTION
[![GEOS-12084](https://badgen.net/badge/JIRA/GEOS-12084/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12084) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Validate workspace, store, and resource in TemplateController REST endpoints

TemplateController accepted any path variable values without checking they correspond to existing catalog objects. This allowed creating templates in non-existent workspace directories and bypassed SecureCatalog workspace visibility checks.

Add validation in TemplateController for all path variables:

- Workspace: check catalog.getWorkspaceByName() returns non-null
- Store: check catalog.getStoreByName() returns non-null
- Resource (feature type/coverage): check catalog.getResourceByStore()

Return 404 when any referenced catalog object does not exist, applied consistently to GET, PUT, DELETE, and list operations.

Also fix TemplateControllerTest to use valid paths from the default test data (cite workspace, cite datastore, Buildings feature type) instead of non-existent topp/states_shapefile/states paths, and add tests for non-existent workspace, datastore, coveragestore, feature type, and coverage.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 