### PR TITLE
[GEOS-12085] LocalSettingsController does not validate workspace existence

### DIFF
--- a/src/restconfig/src/main/java/org/geoserver/rest/LocalSettingsController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/LocalSettingsController.java
@@ -7,7 +7,6 @@ package org.geoserver.rest;
 import freemarker.template.ObjectWrapper;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.ContactInfo;
 import org.geoserver.config.GeoServer;
@@ -54,7 +53,7 @@ public class LocalSettingsController extends AbstractGeoServerController {
             produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_HTML_VALUE})
     public RestWrapper<SettingsInfo> localSettingsGet(@PathVariable String workspaceName) {
 
-        WorkspaceInfo workspaceInfo = geoServer.getCatalog().getWorkspaceByName(workspaceName);
+        WorkspaceInfo workspaceInfo = findWorkspace(workspaceName);
         SettingsInfo settingsInfo = geoServer.getSettings(workspaceInfo);
         if (settingsInfo == null) {
             settingsInfo = new SettingsInfoImpl();
@@ -73,16 +72,11 @@ public class LocalSettingsController extends AbstractGeoServerController {
             produces = MediaType.TEXT_PLAIN_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public String localSettingsCreate(@PathVariable String workspaceName, @RequestBody SettingsInfo settingsInfo) {
-        String name = "";
-        if (workspaceName != null) {
-            Catalog catalog = geoServer.getCatalog();
-            WorkspaceInfo workspaceInfo = catalog.getWorkspaceByName(workspaceName);
-            settingsInfo.setWorkspace(workspaceInfo);
-            geoServer.add(settingsInfo);
-            geoServer.save(geoServer.getSettings(workspaceInfo));
-            name = settingsInfo.getWorkspace().getName();
-        }
-        return name;
+        WorkspaceInfo workspaceInfo = findWorkspace(workspaceName);
+        settingsInfo.setWorkspace(workspaceInfo);
+        geoServer.add(settingsInfo);
+        geoServer.save(geoServer.getSettings(workspaceInfo));
+        return workspaceInfo.getName();
     }
 
     @PutMapping(
@@ -93,28 +87,35 @@ public class LocalSettingsController extends AbstractGeoServerController {
                 MediaType.TEXT_XML_VALUE
             })
     public void localSettingsPut(@PathVariable String workspaceName, @RequestBody SettingsInfo settingsInfo) {
-        if (workspaceName != null) {
-            WorkspaceInfo workspaceInfo = geoServer.getCatalog().getWorkspaceByName(workspaceName);
-            SettingsInfo original = geoServer.getSettings(workspaceInfo);
-            if (original == null) {
-                settingsInfo.setWorkspace(workspaceInfo);
-                geoServer.add(settingsInfo);
-                geoServer.save(geoServer.getSettings(workspaceInfo));
-            } else {
-                OwsUtils.copy(settingsInfo, original, SettingsInfo.class);
-                original.setWorkspace(workspaceInfo);
-                geoServer.save(original);
-            }
+        WorkspaceInfo workspaceInfo = findWorkspace(workspaceName);
+        SettingsInfo original = geoServer.getSettings(workspaceInfo);
+        if (original == null) {
+            settingsInfo.setWorkspace(workspaceInfo);
+            geoServer.add(settingsInfo);
+            geoServer.save(geoServer.getSettings(workspaceInfo));
+        } else {
+            OwsUtils.copy(settingsInfo, original, SettingsInfo.class);
+            original.setWorkspace(workspaceInfo);
+            geoServer.save(original);
         }
     }
 
     @DeleteMapping
-    public void localSetingsDelete(@PathVariable String workspaceName) {
-        if (workspaceName != null) {
-            WorkspaceInfo workspaceInfo = geoServer.getCatalog().getWorkspaceByName(workspaceName);
-            SettingsInfo settingsInfo = geoServer.getSettings(workspaceInfo);
-            geoServer.remove(settingsInfo);
+    public void localSettingsDelete(@PathVariable String workspaceName) {
+        WorkspaceInfo workspaceInfo = findWorkspace(workspaceName);
+        SettingsInfo settingsInfo = geoServer.getSettings(workspaceInfo);
+        if (settingsInfo == null) {
+            throw new RestException("Settings for workspace " + workspaceName + " do not exist", HttpStatus.NOT_FOUND);
         }
+        geoServer.remove(settingsInfo);
+    }
+
+    private WorkspaceInfo findWorkspace(String workspaceName) {
+        WorkspaceInfo ws = geoServer.getCatalog().getWorkspaceByName(workspaceName);
+        if (ws == null) {
+            throw new RestException("Workspace " + workspaceName + " does not exist", HttpStatus.NOT_FOUND);
+        }
+        return ws;
     }
 
     @Override

--- a/src/restconfig/src/test/java/org/geoserver/rest/LocalSettingsControllerTest.java
+++ b/src/restconfig/src/test/java/org/geoserver/rest/LocalSettingsControllerTest.java
@@ -1,0 +1,135 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.rest;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.SettingsInfo;
+import org.geoserver.config.impl.SettingsInfoImpl;
+import org.geoserver.rest.catalog.CatalogRESTTestSupport;
+import org.junit.After;
+import org.junit.Test;
+import org.kordamp.json.JSON;
+import org.kordamp.json.JSONObject;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
+
+/**
+ * Tests for {@link LocalSettingsController}, focusing on workspace validation and CRUD operations for
+ * workspace-specific settings.
+ */
+public class LocalSettingsControllerTest extends CatalogRESTTestSupport {
+
+    private static final String WS = "sf";
+    private static final String ENDPOINT = RestBaseController.ROOT_PATH + "/workspaces/%s/settings";
+
+    @After
+    public void revert() {
+        GeoServer gs = getGeoServer();
+        WorkspaceInfo ws = gs.getCatalog().getWorkspaceByName(WS);
+        if (ws != null && gs.getSettings(ws) == null) {
+            SettingsInfo settings = new SettingsInfoImpl();
+            settings.setWorkspace(ws);
+            gs.add(settings);
+        }
+    }
+
+    // -- Non-existent workspace returns 404 --
+
+    @Test
+    public void testGetNonExistentWorkspace() throws Exception {
+        MockHttpServletResponse response = getAsServletResponse(ENDPOINT.formatted("nonexistent") + ".json");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testPostNonExistentWorkspace() throws Exception {
+        String json = "{'settings':{'charset':'UTF-8'}}";
+        MockHttpServletResponse response = postAsServletResponse(ENDPOINT.formatted("nonexistent"), json, "text/json");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testPutNonExistentWorkspace() throws Exception {
+        String json = "{'settings':{'charset':'UTF-8'}}";
+        MockHttpServletResponse response = putAsServletResponse(ENDPOINT.formatted("nonexistent"), json, "text/json");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteNonExistentWorkspace() throws Exception {
+        MockHttpServletResponse response = deleteAsServletResponse(ENDPOINT.formatted("nonexistent"));
+        assertEquals(404, response.getStatus());
+    }
+
+    // -- CRUD on valid workspace --
+
+    @Test
+    public void testGetAsJSON() throws Exception {
+        JSON json = getAsJSON(ENDPOINT.formatted(WS) + ".json");
+        JSONObject settings = ((JSONObject) json).getJSONObject("settings");
+        assertNotNull(settings);
+        assertEquals(WS, settings.getJSONObject("workspace").get("name"));
+    }
+
+    @Test
+    public void testGetAsXML() throws Exception {
+        Document dom = getAsDOM(ENDPOINT.formatted(WS) + ".xml");
+        assertEquals("settings", dom.getDocumentElement().getLocalName());
+        assertXpathEvaluatesTo(WS, "/settings/workspace/name", dom);
+    }
+
+    @Test
+    public void testPutAsJSON() throws Exception {
+        String json = "{'settings':{'workspace':{'name':'%s'},'charset':'ISO-8859-1','numDecimals':5}}".formatted(WS);
+        MockHttpServletResponse response = putAsServletResponse(ENDPOINT.formatted(WS), json, "text/json");
+        assertEquals(200, response.getStatus());
+
+        JSONObject updated = ((JSONObject) getAsJSON(ENDPOINT.formatted(WS) + ".json")).getJSONObject("settings");
+        assertEquals("ISO-8859-1", updated.get("charset"));
+        assertEquals("5", updated.get("numDecimals").toString().trim());
+    }
+
+    @Test
+    public void testPutAsXML() throws Exception {
+        String xml = "<settings><workspace><name>%s</name></workspace><charset>ISO-8859-1</charset></settings>"
+                .formatted(WS);
+        MockHttpServletResponse response = putAsServletResponse(ENDPOINT.formatted(WS), xml, MediaType.TEXT_XML_VALUE);
+        assertEquals(200, response.getStatus());
+
+        Document dom = getAsDOM(ENDPOINT.formatted(WS) + ".xml");
+        assertXpathEvaluatesTo("ISO-8859-1", "/settings/charset", dom);
+    }
+
+    @Test
+    public void testDeleteAndRecreate() throws Exception {
+        // delete
+        assertEquals(200, deleteAsServletResponse(ENDPOINT.formatted(WS)).getStatus());
+
+        // recreate via POST
+        String json = "{'settings':{'workspace':{'name':'%s'},'charset':'UTF-8','numDecimals':8}}".formatted(WS);
+        MockHttpServletResponse response = postAsServletResponse(ENDPOINT.formatted(WS), json, "text/json");
+        assertEquals(201, response.getStatus());
+
+        // verify
+        JSONObject settings = ((JSONObject) getAsJSON(ENDPOINT.formatted(WS) + ".json")).getJSONObject("settings");
+        assertEquals(WS, settings.getJSONObject("workspace").get("name"));
+    }
+
+    @Test
+    public void testDeleteNonExistentSettings() throws Exception {
+        // delete settings first
+        deleteAsServletResponse(ENDPOINT.formatted(WS));
+
+        // deleting again should return 404
+        MockHttpServletResponse response = deleteAsServletResponse(ENDPOINT.formatted(WS));
+        assertEquals(404, response.getStatus());
+    }
+}


### PR DESCRIPTION
[![GEOS-12085](https://badgen.net/badge/JIRA/GEOS-12085/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12085) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Validate workspace existence in LocalSettingsController and avoid NPE.

`LocalSettingsController` passed the workspace name to the catalog without null-checking the result, causing `NullPointerException` when the workspace doesn't exist or is hidden by `SecureCatalog`.

Add `findWorkspace()` that throws `RestException(404)` when the workspace is not found, called from all four endpoints (GET, POST, PUT, DELETE). Also check for null settings on DELETE to return 404 instead of NPE.

Add `LocalSettingsControllerTest` covering non-existent workspace (404 for all operations), CRUD on valid workspace, and delete of non-existent settings.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 