### PR TITLE
Make constructors public for bean classes and avoid Spring using reflection

### DIFF
--- a/src/extension/css/src/main/java/org/geoserver/community/css/web/CssHandler.java
+++ b/src/extension/css/src/main/java/org/geoserver/community/css/web/CssHandler.java
@@ -73,7 +73,7 @@ public class CssHandler extends StyleHandler implements ModuleStatus {
 
     private SLDHandler sldHandler;
 
-    protected CssHandler(GeoServerExtensions extensions, SLDHandler sldHandler) {
+    public CssHandler(GeoServerExtensions extensions, SLDHandler sldHandler) {
         super("CSS", FORMAT);
         this.sldHandler = sldHandler;
         this.zoomContextFinders = extensions.extensions(ZoomContextFinder.class);

--- a/src/extension/dxf/wps/src/main/java/org/geoserver/wps/ppio/DXFPPIO.java
+++ b/src/extension/dxf/wps/src/main/java/org/geoserver/wps/ppio/DXFPPIO.java
@@ -24,7 +24,7 @@ import org.geotools.feature.FeatureCollection;
  * @author Andrea Aime - OpenGeo, Peter Hopfgartner - R3 GIS
  */
 public class DXFPPIO extends CDataPPIO {
-    protected DXFPPIO() {
+    public DXFPPIO() {
         super(FeatureCollection.class, FeatureCollection.class, "application/dxf");
     }
 

--- a/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportTaskController.java
+++ b/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportTaskController.java
@@ -78,7 +78,7 @@ public class ImportTaskController extends ImportBaseController {
     static final Logger LOGGER = Logging.getLogger(ImportTaskController.class);
 
     @Autowired
-    protected ImportTaskController(Importer importer) {
+    public ImportTaskController(Importer importer) {
         super(importer);
     }
 

--- a/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportTransformController.java
+++ b/src/extension/importer/rest/src/main/java/org/geoserver/importer/rest/ImportTransformController.java
@@ -44,7 +44,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class ImportTransformController extends ImportBaseController {
 
     @Autowired
-    protected ImportTransformController(Importer importer) {
+    public ImportTransformController(Importer importer) {
         super(importer);
     }
 

--- a/src/extension/mbstyle/src/main/java/org/geoserver/community/mbstyle/MBStyleHandler.java
+++ b/src/extension/mbstyle/src/main/java/org/geoserver/community/mbstyle/MBStyleHandler.java
@@ -61,7 +61,7 @@ public class MBStyleHandler extends StyleHandler {
 
     private SLDHandler sldHandler;
 
-    protected MBStyleHandler(SLDHandler sldHandler) {
+    public MBStyleHandler(SLDHandler sldHandler) {
         super("MBStyle", FORMAT);
         this.sldHandler = sldHandler;
     }

--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeaturesSampleDataProvider.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeaturesSampleDataProvider.java
@@ -19,7 +19,7 @@ public class FeaturesSampleDataProvider implements SampleDataProvider {
 
     private final FeatureService service;
 
-    FeaturesSampleDataProvider(FeatureService service) {
+    public FeaturesSampleDataProvider(FeatureService service) {
         this.service = service;
     }
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/WPSFactoryExtension.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/WPSFactoryExtension.java
@@ -9,7 +9,7 @@ import org.geoserver.config.ServiceFactoryExtension;
 
 public class WPSFactoryExtension extends ServiceFactoryExtension<WPSInfo> {
 
-    protected WPSFactoryExtension() {
+    public WPSFactoryExtension() {
         super(WPSInfo.class);
     }
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/AggregateProcessJSONPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/AggregateProcessJSONPPIO.java
@@ -54,7 +54,7 @@ import org.kordamp.json.JSONObject;
  */
 public class AggregateProcessJSONPPIO extends CDataPPIO {
 
-    protected AggregateProcessJSONPPIO() {
+    public AggregateProcessJSONPPIO() {
         super(AggregateProcess.Results.class, AggregateProcess.Results.class, "application/json");
     }
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/AggregateProcessPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/AggregateProcessPPIO.java
@@ -20,7 +20,7 @@ public class AggregateProcessPPIO extends XStreamPPIO {
 
     static final QName AggregationResults = new QName("AggregationResults");
 
-    protected AggregateProcessPPIO() {
+    public AggregateProcessPPIO() {
         super(AggregateProcess.Results.class, AggregationResults);
     }
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ClassificationStatsPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/ClassificationStatsPPIO.java
@@ -20,7 +20,7 @@ import org.xml.sax.helpers.AttributesImpl;
  */
 public class ClassificationStatsPPIO extends XMLPPIO {
 
-    protected ClassificationStatsPPIO() {
+    public ClassificationStatsPPIO() {
         super(ClassificationStats.class, ClassificationStats.class, new QName("Results"));
     }
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/PagedUniqueProcessPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/gs/PagedUniqueProcessPPIO.java
@@ -20,7 +20,7 @@ public class PagedUniqueProcessPPIO extends CDataPPIO {
 
     static final ObjectMapper MAPPER = new ObjectMapper();
 
-    protected PagedUniqueProcessPPIO() {
+    public PagedUniqueProcessPPIO() {
         super(PagedUniqueProcess.Results.class, PagedUniqueProcess.Results.class, "application/json");
     }
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/CSVPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/CSVPPIO.java
@@ -28,7 +28,7 @@ public class CSVPPIO extends CDataPPIO {
     WPSResourceManager resourceManager;
     private static final Logger LOGGER = Logging.getLogger("org.geoserver.wps.ppio.CSVPPIO");
 
-    protected CSVPPIO(WPSResourceManager resourceManager) {
+    public CSVPPIO(WPSResourceManager resourceManager) {
         super(SimpleFeatureCollection.class, SimpleFeatureCollection.class, "text/csv");
         this.resourceManager = resourceManager;
     }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/GeoJSONPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/GeoJSONPPIO.java
@@ -63,7 +63,7 @@ public abstract class GeoJSONPPIO extends CDataPPIO {
             super(FeatureCollection.class);
         }
 
-        protected FeatureCollections(GeoServer gs) {
+        public FeatureCollections(GeoServer gs) {
             super(FeatureCollection.class, gs);
         }
 
@@ -96,7 +96,7 @@ public abstract class GeoJSONPPIO extends CDataPPIO {
             super(Geometry.class);
         }
 
-        protected Geometries(GeoServer gs) {
+        public Geometries(GeoServer gs) {
             super(Geometry.class, gs);
         }
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/GeoTiffPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/GeoTiffPPIO.java
@@ -75,7 +75,7 @@ public class GeoTiffPPIO extends BinaryPPIO implements ExtensionPriority {
 
     private final WPSResourceManager resources;
 
-    protected GeoTiffPPIO(WPSResourceManager resources) {
+    public GeoTiffPPIO(WPSResourceManager resources) {
         super(GridCoverage2D.class, GridCoverage2D.class, "image/tiff");
         this.resources = resources;
     }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/InterpolationPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/InterpolationPPIO.java
@@ -14,7 +14,7 @@ import org.eclipse.imagen.Interpolation;
  */
 public class InterpolationPPIO extends LiteralPPIO {
 
-    protected InterpolationPPIO() {
+    public InterpolationPPIO() {
         super(Interpolation.class);
     }
 

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/RawDataPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/RawDataPPIO.java
@@ -23,7 +23,7 @@ public class RawDataPPIO extends ComplexPPIO {
 
     WPSResourceManager resourceManager;
 
-    protected RawDataPPIO(WPSResourceManager resourceManager) {
+    public RawDataPPIO(WPSResourceManager resourceManager) {
         super(RawData.class, RawData.class, AbstractRawData.BINARY_MIME);
         this.resourceManager = resourceManager;
     }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/SLDStylePPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/SLDStylePPIO.java
@@ -28,7 +28,7 @@ public class SLDStylePPIO extends XMLPPIO {
 
     Configuration sldConfiguration;
 
-    protected SLDStylePPIO() {
+    public SLDStylePPIO() {
         super(Style.class, Style.class, "text/xml; subtype=sld/1.0.0", SLD.STYLEDLAYERDESCRIPTOR);
         sldConfiguration = new SLDConfiguration();
     }

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/ShapeZipPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/ShapeZipPPIO.java
@@ -45,7 +45,7 @@ public class ShapeZipPPIO extends BinaryPPIO {
     private final GeoServerResourceLoader resourceLoader;
     WPSResourceManager resources;
 
-    protected ShapeZipPPIO(
+    public ShapeZipPPIO(
             WPSResourceManager resources, GeoServer gs, Catalog catalog, GeoServerResourceLoader resourceLoader) {
         super(FeatureCollection.class, FeatureCollection.class, "application/zip");
         this.resources = resources;

--- a/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/URLPPIO.java
+++ b/src/extension/wps/wps-core/src/main/java/org/geoserver/wps/ppio/URLPPIO.java
@@ -14,7 +14,7 @@ import java.net.URL;
  */
 public class URLPPIO extends LiteralPPIO {
 
-    protected URLPPIO() {
+    public URLPPIO() {
         super(URL.class);
     }
 

--- a/src/main/src/main/java/org/geoserver/catalog/SLDPackageHandler.java
+++ b/src/main/src/main/java/org/geoserver/catalog/SLDPackageHandler.java
@@ -34,7 +34,7 @@ public class SLDPackageHandler extends StyleHandler {
 
     private SLDHandler sldHandler;
 
-    protected SLDPackageHandler(SLDHandler sldHandler) {
+    public SLDPackageHandler(SLDHandler sldHandler) {
         super("ZIP", FORMAT);
         this.sldHandler = sldHandler;
     }

--- a/src/main/src/main/java/org/geoserver/security/impl/RESTAccessRuleDAO.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/RESTAccessRuleDAO.java
@@ -34,7 +34,7 @@ public class RESTAccessRuleDAO extends AbstractAccessRuleDAO<String> {
     static final Pattern PATTERN = Pattern.compile(
             "\\S+;(GET|POST|PUT|DELETE|HEAD|OPTIONS)(,(GET|POST|PUT|DELETE|HEAD|OPTIONS))*=\\S+(, ?\\S+)*");
 
-    protected RESTAccessRuleDAO(GeoServerDataDirectory dd) throws IOException {
+    public RESTAccessRuleDAO(GeoServerDataDirectory dd) throws IOException {
         super(dd, "rest.properties");
     }
 

--- a/src/restconfig/src/main/java/org/geoserver/rest/security/DataAccessController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/security/DataAccessController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(path = RestBaseController.ROOT_PATH + "/security/acl/layers")
 public class DataAccessController extends AbstractAclController<DataAccessRule, DataAccessRuleDAO> {
 
-    DataAccessController() {
+    public DataAccessController() {
         super(DataAccessRuleDAO.get());
     }
 

--- a/src/wcs/src/main/java/org/geoserver/wcs/responses/CoverageResponseDelegateFinder.java
+++ b/src/wcs/src/main/java/org/geoserver/wcs/responses/CoverageResponseDelegateFinder.java
@@ -25,8 +25,6 @@ public class CoverageResponseDelegateFinder implements ApplicationContextAware {
 
     private ApplicationContext applicationContext;
 
-    private CoverageResponseDelegateFinder() {}
-
     /** Locates an encoder for a specific GetCoverage results output format */
     public CoverageResponseDelegate encoderFor(String outputFormat) {
 

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/MIMETypeMapper.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/response/MIMETypeMapper.java
@@ -52,7 +52,7 @@ public class MIMETypeMapper implements ApplicationContextAware {
     private List<CoverageMimeTypeMapper> mappers;
 
     /** Constructor. */
-    private MIMETypeMapper(CoverageResponseDelegateFinder finder, Catalog catalog) {
+    public MIMETypeMapper(CoverageResponseDelegateFinder finder, Catalog catalog) {
         // collect all of the output mime types
         for (String of : finder.getOutputFormats()) {
             CoverageResponseDelegate delegate = finder.encoderFor(of);

--- a/src/wfs-core/src/main/java/org/geoserver/wfs/WFSFactoryExtension.java
+++ b/src/wfs-core/src/main/java/org/geoserver/wfs/WFSFactoryExtension.java
@@ -9,7 +9,7 @@ import org.geoserver.config.ServiceFactoryExtension;
 
 public class WFSFactoryExtension extends ServiceFactoryExtension<WFSInfo> {
 
-    protected WFSFactoryExtension() {
+    public WFSFactoryExtension() {
         super(WFSInfo.class);
     }
 


### PR DESCRIPTION
Spring beans that are declared in applicationContext.xml and have non-public constructors can't be instantiated with Java Configuraion classes and in both cases (java and xml) force the constructors to be made accessible through reflection.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.