### PR TITLE
[GEOS-12119] Workspace-scoped OGC API Styles endpoint returns styles from other workspaces

### DIFF
--- a/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StylesDocument.java
+++ b/src/community/ogcapi/ogcapi-styles/src/main/java/org/geoserver/ogcapi/v1/styles/StylesDocument.java
@@ -7,10 +7,12 @@ package org.geoserver.ogcapi.v1.styles;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Iterator;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.Predicates;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.util.CloseableIterator;
 import org.geoserver.ogcapi.AbstractDocument;
 import org.geoserver.ogcapi.StyleDocument;
+import org.geoserver.ows.LocalWorkspace;
 import org.geoserver.platform.ServiceException;
 import org.geotools.api.filter.Filter;
 
@@ -27,8 +29,14 @@ public class StylesDocument extends AbstractDocument {
 
     @SuppressWarnings("PMD.CloseResource") // hopefully closed as it gets iterated
     public Iterator<StyleDocument> getStyles() {
-        // full scan (we might add paging/filtering later)
-        CloseableIterator<StyleInfo> styles = catalog.list(StyleInfo.class, Filter.INCLUDE);
+        // under a workspace-scoped virtual service, return only that workspace's styles
+        // plus global (workspace-less) ones; outside of a workspace scope, return everything
+        Filter filter = Filter.INCLUDE;
+        if (LocalWorkspace.get() != null) {
+            String wsName = LocalWorkspace.get().getName();
+            filter = Predicates.or(Predicates.equal("workspace.name", wsName), Predicates.isNull("workspace"));
+        }
+        CloseableIterator<StyleInfo> styles = catalog.list(StyleInfo.class, filter);
         return new Iterator<>() {
 
             StyleDocument next;

--- a/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/v1/styles/StylesTest.java
+++ b/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/v1/styles/StylesTest.java
@@ -7,6 +7,7 @@ package org.geoserver.ogcapi.v1.styles;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.jayway.jsonpath.DocumentContext;
 import java.util.List;
@@ -52,6 +53,7 @@ public class StylesTest extends StylesTestSupport {
                         "RoadSegments",
                         "Streams",
                         "ws:NamedPlacesWS",
+                        "ws2:NamedPlacesWS2",
                         "cssSample",
                         "generic",
                         "line",
@@ -72,5 +74,30 @@ public class StylesTest extends StylesTestSupport {
                 exists(
                         json,
                         "styles[?(@.id == 'Default')].links[?(@.rel == 'stylesheet' && @.type == 'application/vnd.geoserver.geocss+css')]"));
+    }
+
+    @Test
+    public void testStylesWorkspaceScoped() throws Exception {
+        DocumentContext json = getAsJSONPath("ws/ogc/styles/v1/styles", 200);
+        List<String> ids = json.read("styles[*].id");
+
+        // styles from the current workspace are visible (name is dequalified under a virtual service)
+        assertTrue("expected NamedPlacesWS in " + ids, ids.contains("NamedPlacesWS"));
+        // global styles remain accessible from the workspace-scoped listing
+        assertTrue("expected global 'Default' style in " + ids, ids.contains("Default"));
+        // styles belonging to another workspace must not leak in
+        assertFalse("ws2 style leaked into ws listing: " + ids, ids.contains("NamedPlacesWS2"));
+        assertFalse("qualified ws2 style leaked into ws listing: " + ids, ids.contains("ws2:NamedPlacesWS2"));
+    }
+
+    @Test
+    public void testStylesWorkspaceScopedOtherWorkspace() throws Exception {
+        DocumentContext json = getAsJSONPath("ws2/ogc/styles/v1/styles", 200);
+        List<String> ids = json.read("styles[*].id");
+
+        assertTrue("expected NamedPlacesWS2 in " + ids, ids.contains("NamedPlacesWS2"));
+        assertTrue("expected global 'Default' style in " + ids, ids.contains("Default"));
+        assertFalse("ws style leaked into ws2 listing: " + ids, ids.contains("NamedPlacesWS"));
+        assertFalse("qualified ws style leaked into ws2 listing: " + ids, ids.contains("ws:NamedPlacesWS"));
     }
 }

--- a/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/v1/styles/StylesTestSupport.java
+++ b/src/community/ogcapi/ogcapi-styles/src/test/java/org/geoserver/ogcapi/v1/styles/StylesTestSupport.java
@@ -37,6 +37,10 @@ public class StylesTestSupport extends OGCApiTestSupport {
         testData.addWorkspace("ws", "http://www.geoserver.org/ws", catalog);
         WorkspaceInfo ws = catalog.getWorkspaceByName("ws");
         testData.addStyle(ws, "NamedPlacesWS", "NamedPlaces.sld", SystemTestData.class, catalog);
+        // add a second workspace with its own style, to verify cross-workspace isolation
+        testData.addWorkspace("ws2", "http://www.geoserver.org/ws2", catalog);
+        WorkspaceInfo ws2 = catalog.getWorkspaceByName("ws2");
+        testData.addStyle(ws2, "NamedPlacesWS2", "NamedPlaces.sld", SystemTestData.class, catalog);
         // add a style with a comment that can be used for raw style return
         testData.addStyle(POLYGON_COMMENT, "polygonComment.sld", StylesTestSupport.class, catalog);
 


### PR DESCRIPTION
[![GEOS-12119](https://badgen.net/badge/JIRA/GEOS-12119/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12119) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->

When using the OGC API Styles extension to list styles via a workspace-scoped service like

```
myworkspace/ogc/styles/v1/styles
```

the endpoint currently returns all styles, even those present in other workspaces. Additionally, the URLs returned in the `href` field for styles from other workspaces return 404 as they are prefixed by the wrong workspace. This PR makes sure that workspace-scoped list requests only return styles in the respective workspace and global styles.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

Note: There is no JIRA ticket since I was not able to create one even after logging in (via Google SSO):
> You are not authorized to perform this operation. Please log in.

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 