### PR TITLE
Re-enable acl community module in the assembly smoke test

### DIFF
--- a/build/assembly_test/src/test/java/org/geoserver/AbstractPluginTester.java
+++ b/build/assembly_test/src/test/java/org/geoserver/AbstractPluginTester.java
@@ -13,6 +13,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Map;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.w3c.dom.Document;
@@ -40,6 +42,25 @@ abstract class AbstractPluginTester {
      */
     protected void prepareTestDirectory(Path testWorkDir) throws Exception {
         // Default no-op.
+    }
+
+    /**
+     * Extra {@code -D} system properties to pass to the spawned GeoServer JVM via {@code JAVA_OPTS}. Subclasses
+     * override to configure plugins that require system properties to reach a healthy startup state (e.g. remote
+     * service URLs, credentials, feature toggles). Returned values are not shell-quoted — keep them simple.
+     */
+    protected Map<String, String> systemProperties() {
+        return Map.of();
+    }
+
+    /**
+     * Basic-auth credentials ({@code "user:password"}) for all HTTP requests the tester makes — the readiness probe and
+     * any helper {@code GET} calls. Subclasses override when the plugin requires an authenticated caller (e.g. the ACL
+     * plugin, which invokes its access manager even for GetCapabilities and refuses anonymous callers when its remote
+     * API is unreachable). Returning {@code null} (the default) sends no {@code Authorization} header.
+     */
+    protected String basicAuthCredentials() {
+        return null;
     }
 
     /** Polls the startup check path until it returns HTTP 200 or the process exits/times out. */
@@ -100,6 +121,11 @@ abstract class AbstractPluginTester {
         HttpURLConnection connection = (HttpURLConnection) new URL(context.baseUrl() + path).openConnection();
         connection.setConnectTimeout(2000);
         connection.setReadTimeout(5000);
+        String credentials = basicAuthCredentials();
+        if (credentials != null) {
+            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+            connection.setRequestProperty("Authorization", "Basic " + encoded);
+        }
         return connection;
     }
 

--- a/build/assembly_test/src/test/java/org/geoserver/AssemblyTest.java
+++ b/build/assembly_test/src/test/java/org/geoserver/AssemblyTest.java
@@ -393,10 +393,15 @@ public class AssemblyTest {
                 ProcessBuilder pb = new ProcessBuilder("./bin/startup.sh");
                 pb.directory(testWorkDir.toFile());
                 pb.environment().put("JETTY_OPTS", "-Djetty.http.port=" + httpPort);
-                pb.environment()
-                        .put(
-                                "JAVA_OPTS",
-                                TEST_JAVA_OPTS + " -DSTOP.PORT=" + stopPort + " -DSTOP.KEY=stopkey-" + httpPort);
+                StringBuilder javaOpts = new StringBuilder(TEST_JAVA_OPTS)
+                        .append(" -DSTOP.PORT=")
+                        .append(stopPort)
+                        .append(" -DSTOP.KEY=stopkey-")
+                        .append(httpPort);
+                tester.systemProperties()
+                        .forEach((k, v) ->
+                                javaOpts.append(" -D").append(k).append('=').append(v));
+                pb.environment().put("JAVA_OPTS", javaOpts.toString());
 
                 pb.redirectErrorStream(true);
                 File stdoutLogFile =

--- a/build/assembly_test/src/test/java/org/geoserver/GeoServerAclTester.java
+++ b/build/assembly_test/src/test/java/org/geoserver/GeoServerAclTester.java
@@ -1,0 +1,34 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver;
+
+import java.util.Map;
+
+/**
+ * Smoke tester for the ACL plugin. The ACL client normally probes the remote ACL API during startup and fails fast if
+ * it can't reach it; setting {@code geoserver.acl.client.startupCheck=false} lets the Spring beans load and the WMS
+ * capabilities endpoint respond without a running ACL server. basePath/username/password still have to be set because
+ * they're read eagerly, even though they're never used once the probe is disabled.
+ */
+public class GeoServerAclTester extends DefaultPluginTester {
+
+    @Override
+    protected Map<String, String> systemProperties() {
+        return Map.of(
+                "geoserver.acl.client.startupCheck", "false",
+                "geoserver.acl.client.basePath", "http://localhost:0/acl/api",
+                "geoserver.acl.client.username", "geoserver",
+                "geoserver.acl.client.password", "pwd");
+    }
+
+    /**
+     * Authenticate as the default admin so GetCapabilities bypasses the ACL access manager — an anonymous call would
+     * trigger a remote authorization lookup and fail on the unreachable ACL API.
+     */
+    @Override
+    protected String basicAuthCredentials() {
+        return "admin:geoserver";
+    }
+}

--- a/build/assembly_test/src/test/java/org/geoserver/PluginRegistry.java
+++ b/build/assembly_test/src/test/java/org/geoserver/PluginRegistry.java
@@ -45,6 +45,7 @@ final class PluginRegistry {
 
         // custom testers
         TESTERS.put("wps-jdbc", new WPSJDBCTester());
+        TESTERS.put("acl", new GeoServerAclTester());
     }
 
     private PluginRegistry() {}

--- a/src/community/acl/README.md
+++ b/src/community/acl/README.md
@@ -66,6 +66,32 @@ In order to completely disabling the plugin, set it to `false`:
 -Dgeoserver.acl.client.enabled=false
 ```
 
+#### Startup API probe
+
+At startup the plugin verifies it can reach the ACL API server before letting GeoServer come up. The probe can be
+tuned or disabled through two additional properties:
+
+- `geoserver.acl.client.startupCheck` — whether to perform the server API check during startup. Defaults to `true`.
+  Set to `false` to let GeoServer start even when the ACL server is unreachable at boot time; the client will
+  keep retrying on demand. Useful for offline smoke tests or environments where the ACL server starts after
+  GeoServer.
+
+- `geoserver.acl.client.initTimeout` — timeout, in seconds, to wait for the API server to become available during
+  the startup probe. Defaults to a short grace period; raise it when the ACL server has a slower cold start than
+  GeoServer, lower it to fail fast in CI.
+
+```
+-Dgeoserver.acl.client.startupCheck=false
+-Dgeoserver.acl.client.initTimeout=60
+```
+
+Or via environment variables:
+
+```
+export GEOSERVER_ACL_CLIENT_STARTUPCHECK=false
+export GEOSERVER_ACL_CLIENT_INITTIMEOUT=60
+```
+
 ### Environment variables
 
 In production environments it's usually more convenient to control configuration options through

--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -162,8 +162,7 @@
         <module>graticule</module>
         <module>wfs-freemarker</module>
         <module>stac-datastore</module>
-        <!-- This module won't start properly from geoserver + zip -->
-        <!--module>acl</module-->
+        <module>acl</module>
         <module>geoparquet</module>
         <module>duckdb</module>
         <module>wps-download-netcdf</module>


### PR DESCRIPTION
The acl plugin was excluded from communityRelease in d05aa2756c because it refused to start under `build/assembly_test`: its client probes the remote ACL API at boot and its access manager intercepts even anonymous GetCapabilities calls, both of which fail without a reachable ACL server. Fixing it needed two small generic hooks on the smoke tester that other plugins can reuse.

- `AbstractPluginTester.systemProperties()` — returns extra `-D` flags that get appended to `JAVA_OPTS` before the GeoServer process is spawned. Default empty.
- `AbstractPluginTester.basicAuthCredentials()` — returns `"user:password"` for an `Authorization: Basic` header on every HTTP call the tester makes (readiness probe + `getAsDom`/`getAsString`/`get`). Default `null`, no header sent.
- `GeoServerAclTester` uses both: `startupCheck=false` plus placeholder basePath/username/password to let the Spring beans load, and admin:geoserver credentials so GetCapabilities bypasses the ACL access manager instead of hitting the unreachable API.
- src/community/pom.xml: re-add <module>acl</module> to communityRelease.
- src/community/acl/README.md: document `geoserver.acl.client.startupCheck` and `geoserver.acl.client.initTimeout`, the knobs that make offline smoke testing (and slow-cold-start deployments) possible.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.