### PR TITLE
CascadeDeleteVisitor: remove workspace styles before namespace

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/CascadeDeleteVisitor.java
+++ b/src/main/src/main/java/org/geoserver/catalog/CascadeDeleteVisitor.java
@@ -52,15 +52,15 @@ public class CascadeDeleteVisitor implements CatalogVisitor {
             s.accept(this);
         }
 
+        // remove styles contained in this workspace
+        for (StyleInfo style : catalog.getStylesByWorkspace(workspace)) {
+            style.accept(this);
+        }
+
         // remove any linked namespaces
         NamespaceInfo ns = catalog.getNamespaceByPrefix(workspace.getName());
         if (ns != null) {
             ns.accept(this);
-        }
-
-        // remove styles contained in this workspace
-        for (StyleInfo style : catalog.getStylesByWorkspace(workspace)) {
-            style.accept(this);
         }
 
         catalog.remove(workspace);

--- a/src/main/src/test/java/org/geoserver/catalog/impl/CascadeDeleteVisitorTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/CascadeDeleteVisitorTest.java
@@ -14,21 +14,30 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import org.geoserver.catalog.CascadeDeleteVisitor;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.Info;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.NamespaceWorkspaceConsistencyListener;
 import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.event.AbstractCatalogListener;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
 import org.geotools.api.filter.Filter;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class CascadeDeleteVisitorTest extends CascadeVisitorAbstractTest {
@@ -120,6 +129,48 @@ public class CascadeDeleteVisitorTest extends CascadeVisitorAbstractTest {
         assertEquals(0, catalog.count(ResourceInfo.class, Filter.INCLUDE));
         assertEquals(0, catalog.count(StoreInfo.class, Filter.INCLUDE));
         assertEquals(0, catalog.count(LayerGroupInfo.class, Filter.INCLUDE));
+    }
+
+    /**
+     * Regression test for the ordering constraint in {@link CascadeDeleteVisitor#visit(WorkspaceInfo)}: styles owned by
+     * the workspace must be removed before the workspace's namespace, because
+     * {@link NamespaceWorkspaceConsistencyListener} removes the workspace as soon as its namespace is removed (1:1
+     * relationship). If the namespace goes first, the workspace is gone before the visitor iterates its styles, which
+     * breaks catalog backends with referential integrity.
+     */
+    @Test
+    public void testCascadeWorkspaceRemovesStylesBeforeNamespace() {
+        Catalog catalog = getCatalog();
+        Assume.assumeTrue(
+                catalog.getListeners().stream().anyMatch(NamespaceWorkspaceConsistencyListener.class::isInstance));
+
+        assertTrue(catalog.getListeners().stream().anyMatch(NamespaceWorkspaceConsistencyListener.class::isInstance));
+        List<Class<?>> removalOrder = new ArrayList<>();
+        CatalogListener recorder = new AbstractCatalogListener() {
+            @Override
+            public void handleRemoveEvent(CatalogRemoveEvent event) {
+                Info src = event.getSource();
+                if (src instanceof StyleInfo) {
+                    removalOrder.add(StyleInfo.class);
+                } else if (src instanceof NamespaceInfo) {
+                    removalOrder.add(NamespaceInfo.class);
+                }
+            }
+        };
+        catalog.addListener(recorder);
+        try {
+            WorkspaceInfo ws = catalog.getWorkspaceByName(CITE_PREFIX);
+            assertNotNull(catalog.getStyleByName(WS_STYLE));
+            ws.accept(new CascadeDeleteVisitor(catalog));
+        } finally {
+            catalog.removeListener(recorder);
+        }
+
+        int firstNs = removalOrder.indexOf(NamespaceInfo.class);
+        int lastStyle = removalOrder.lastIndexOf(StyleInfo.class);
+        assertTrue("expected a NamespaceInfo removal, got " + removalOrder, firstNs >= 0);
+        assertTrue("expected at least one StyleInfo removal, got " + removalOrder, lastStyle >= 0);
+        assertTrue("workspace styles must be removed before the namespace, got " + removalOrder, lastStyle < firstNs);
     }
 
     @Test


### PR DESCRIPTION
CascadeDeleteVisitor.visit(WorkspaceInfo) used to remove the workspace's namespace before its styles.

In the object graph, workspace and namespace are siblings, styles(with workspace) are children.

Removing the namespace before the workspace causes NamespaceWorkspaceConsistencyListener to remove the workspace before the CascadeDeleteVisitor does it, making catalogs that maintain referential integrity fail (e.g. jdbcconfig, pgconfig).

on-behalf-of: @multiversio <info@multivers.io>


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.