### PR TITLE
Fix for parallel extension assemblies

### DIFF
--- a/src/extension/pom.xml
+++ b/src/extension/pom.xml
@@ -728,6 +728,53 @@
                   <inputFileExtensions>md</inputFileExtensions>
                 </configuration>
               </execution>
+              <!--
+                Render the shared LICENSE.md / README.md from src/release/extensions/ into the
+                same path the per-module assembly descriptors expect.  The release module builds
+                AFTER extensions in the reactor, so extensions cannot rely on it having run first.
+                The first extension to build will generate these files; subsequent ones find them
+                already in place (the markdown plugin is a no-op when outputs are up-to-date).
+              -->
+              <execution>
+                <id>shared-extension-docs</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <inputDirectory>${geoserverBaseDir}/release/extensions</inputDirectory>
+                  <outputDirectory>${geoserverBaseDir}/release/target/html/extensions</outputDirectory>
+                  <recursiveInput>false</recursiveInput>
+                  <transformRelativeMarkdownLinks>true</transformRelativeMarkdownLinks>
+                  <headerHtmlFile>${project.build.directory}/html-template/header.html</headerHtmlFile>
+                  <footerHtmlFile>${project.build.directory}/html-template/footer.html</footerHtmlFile>
+                  <pegdownExtensions>TABLES,FENCED_CODE_BLOCKS,AUTOLINKS,FORCELISTITEMPARA</pegdownExtensions>
+                  <defaultTitle>true</defaultTitle>
+                  <inputFileExtensions>md</inputFileExtensions>
+                </configuration>
+              </execution>
+              <!--
+                Render the top-level license files (GPL, LGPL, NOTICE, etc.) into the path
+                referenced by the assembly descriptors' licenses fileSet.
+              -->
+              <execution>
+                <id>shared-licenses</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <inputDirectory>${geoserverBaseDir}/../licenses</inputDirectory>
+                  <outputDirectory>${geoserverBaseDir}/release/target/html/licenses</outputDirectory>
+                  <recursiveInput>false</recursiveInput>
+                  <transformRelativeMarkdownLinks>true</transformRelativeMarkdownLinks>
+                  <headerHtmlFile>${project.build.directory}/html-template/header.html</headerHtmlFile>
+                  <footerHtmlFile>${project.build.directory}/html-template/footer.html</footerHtmlFile>
+                  <pegdownExtensions>TABLES,FENCED_CODE_BLOCKS,AUTOLINKS,FORCELISTITEMPARA</pegdownExtensions>
+                  <defaultTitle>true</defaultTitle>
+                  <inputFileExtensions>md,txt</inputFileExtensions>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
         </plugins>


### PR DESCRIPTION
**Problem**: PR #8910 refactored extension assemblies from a centralized run (at the root pom level, after all modules including `release` were built) to per-module runs. But the assembly descriptors still reference HTML files generated by the `release` module at `${geoserverBaseDir}/release/target/html/extensions/LICENSE.html` and `${geoserverBaseDir}/release/target/html/licenses/*.html`. Since the `release` module builds last in the reactor (step 141/141) and extensions build much earlier (e.g., KML at step 44/141), those files don't exist yet when the assembly plugin runs.

**Fix**: Added two new `markdown-page-generator-plugin` executions to the `assembly-docs` profile in `src/extension/pom.xml`:

1. `shared-extension-docs` — renders the shared `LICENSE.md`, `LICENSE_GS.md`, `LICENSE_GT.md`, and `README.md` from `src/release/extensions/` into `src/release/target/html/extensions/`, the exact path all assembly descriptors reference.

2. `shared-licenses` — renders the top-level license files (`GPL.md`, `LGPL.md`, `NOTICE.md`, `GEOTOOLS_NOTICE.txt`, etc.) from the `licenses/` directory into `src/release/target/html/licenses/`, the path referenced by the assembly descriptors' `licenses` fileSet.

The first extension module to build generates these shared files; subsequent extensions find them already in place. No changes to any assembly descriptors are needed, keeping the diff minimal and the fix safe.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.