### PR TITLE
[GEOS-12092] Fixed JSON representation of featuretype restricted with a single option.

### DIFF
--- a/src/wfs-core/src/main/java/org/geoserver/wfs/json/JSONDescribeFeatureTypeResponse.java
+++ b/src/wfs-core/src/main/java/org/geoserver/wfs/json/JSONDescribeFeatureTypeResponse.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.List;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.config.GeoServer;
@@ -165,17 +166,26 @@ public class JSONDescribeFeatureTypeResponse extends WFSDescribeFeatureTypeOutpu
                 String upperBoundary = ((IsBetweenImpl) f).getUpperBoundary().toString();
                 jw.key("minInclusive").value(renderExpression(isExpressionNumeric, lowerBoundary));
                 jw.key("maxInclusive").value(renderExpression(isExpressionNumeric, upperBoundary));
-            } else if (filterClass == OrImpl.class) {
+            } else if (filterClass == OrImpl.class || filterClass == IsEqualsToImpl.class) {
                 jw.key("enumeration");
                 jw.array();
-                for (Filter eq : ((OrImpl) f).getChildren()) {
-                    String expression = ((IsEqualsToImpl) eq).getExpression2().toString();
+                for (Filter filter : extractEnumerationFilters(f, filterClass)) {
+                    String expression =
+                            ((IsEqualsToImpl) filter).getExpression2().toString();
                     jw.value(renderExpression(isExpressionNumeric, expression));
                 }
                 jw.endArray();
             }
         }
         jw.endObject(); // end restriction object
+    }
+
+    private static List<Filter> extractEnumerationFilters(Filter f, Class<? extends Filter> filterClass) {
+        if (filterClass == OrImpl.class) {
+            return ((OrImpl) f).getChildren();
+        } else {
+            return List.of(f);
+        }
     }
 
     private static Object renderExpression(boolean isExpressionNumeric, String expression) {

--- a/src/wfs2_x/src/test/java/org/geoserver/wfs/v2_0/DescribeFeatureTypeTest.java
+++ b/src/wfs2_x/src/test/java/org/geoserver/wfs/v2_0/DescribeFeatureTypeTest.java
@@ -24,6 +24,7 @@ import java.sql.Connection;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorCompletionService;
@@ -577,6 +578,11 @@ public class DescribeFeatureTypeTest extends WFS20TestSupport {
         attributes.get(1).setBinding(String.class);
         attributes.get(1).setOptions(new ArrayList<>(Arrays.asList(1, "TWO", 3, "Five", "eight")));
 
+        attributes.get(2).setName("single_option");
+        attributes.get(2).setSource("description");
+        attributes.get(2).setBinding(String.class);
+        attributes.get(2).setOptions(Collections.singletonList("single"));
+
         fti.getAttributes().addAll(attributes);
         getCatalog().save(fti);
 
@@ -600,6 +606,12 @@ public class DescribeFeatureTypeTest extends WFS20TestSupport {
         assertXpathEvaluatesTo("3", "//xsd:element[@name='optioned']//xsd:enumeration[3]/@value", doc);
         assertXpathEvaluatesTo("Five", "//xsd:element[@name='optioned']//xsd:enumeration[4]/@value", doc);
         assertXpathEvaluatesTo("eight", "//xsd:element[@name='optioned']//xsd:enumeration[5]/@value", doc);
+
+        // check single option restriction
+        assertXpathNotExists("//xsd:element[@name='single_option']/@type", doc);
+        assertXpathExists("//xsd:element[@name='single_option']/xsd:simpleType/xsd:restriction", doc);
+        assertXpathEvaluatesTo("xsd:string", "//xsd:element[@name='single_option']//xsd:restriction/@base", doc);
+        assertXpathEvaluatesTo("single", "//xsd:element[@name='single_option']//xsd:enumeration[1]/@value", doc);
     }
 
     @Test
@@ -626,6 +638,11 @@ public class DescribeFeatureTypeTest extends WFS20TestSupport {
         attributes.get(2).setBinding(Integer.class);
         attributes.get(2).setOptions(new ArrayList<>(Arrays.asList(1, 2, 3, 5, 8)));
 
+        attributes.get(3).setName("single_option");
+        attributes.get(3).setSource("description");
+        attributes.get(3).setBinding(String.class);
+        attributes.get(3).setOptions(Collections.singletonList("single"));
+
         fti.getAttributes().addAll(attributes);
         getCatalog().save(fti);
 
@@ -645,7 +662,7 @@ public class DescribeFeatureTypeTest extends WFS20TestSupport {
         assertEquals(Math.E, rangedJsonRestriction.getDouble("minInclusive"), 1e-6);
         assertEquals(Math.PI, rangedJsonRestriction.getDouble("maxInclusive"), 1e-6);
 
-        // check int options restriction
+        // check options restriction
         JSONObject optionedJson = properties.getJSONObject(1);
         JSONObject optionedJsonRestriction = optionedJson.getJSONObject("restriction");
         JSONArray optionedJsonRestrictionEnumeration = optionedJsonRestriction.getJSONArray("enumeration");
@@ -657,6 +674,12 @@ public class DescribeFeatureTypeTest extends WFS20TestSupport {
         JSONObject optionedIntJsonRestriction = optionedIntJson.getJSONObject("restriction");
         JSONArray optionedIntJsonRestrictionEnumeration = optionedIntJsonRestriction.getJSONArray("enumeration");
         assertArrayEquals(new Integer[] {1, 2, 3, 5, 8}, optionedIntJsonRestrictionEnumeration.toArray());
+
+        // check single option restriction
+        JSONObject singleOptionedJson = properties.getJSONObject(3);
+        JSONObject singleOptionedJsonRestriction = singleOptionedJson.getJSONObject("restriction");
+        JSONArray singleOptionedJsonRestrictionEnumeration = singleOptionedJsonRestriction.getJSONArray("enumeration");
+        assertArrayEquals(new String[] {"single"}, singleOptionedJsonRestrictionEnumeration.toArray());
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-12092](https://badgen.net/badge/JIRA/GEOS-12092/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12092) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

When a featuretype attribute has a single “option” restriction, the JSON representation of the feature type was not containing the restriction.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 