### PR TITLE
Run docs only when docs are touched, other builds only when code is touched

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -3,6 +3,10 @@ name: Run Acceptance Tests
 on:
   pull_request:
     paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
       - '**/src/main/resources/GeoServerApplication_*.properties'
       - '!**/src/main/resources/GeoServerApplication_fr.properties'
 

--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -1,7 +1,12 @@
 name: Assembly GitHub CI
 
 on:
-  pull_request
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/cite.yml
+++ b/.github/workflows/cite.yml
@@ -3,6 +3,10 @@ name: Run CITE Tests
 on:
   pull_request:
     paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
       - '**/src/main/resources/GeoServerApplication_*.properties'
       - '!**/src/main/resources/GeoServerApplication_fr.properties'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,15 @@ on:
     branches: [main, 3.0.x, 3.1.x, afrigis-new-screenshots]
     paths:
       - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
       - '.github/workflows/docs.yml'
   pull_request:
     branches: [main, 3.0.x, 3.1.x]
     paths:
       - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
       - '.github/workflows/docs.yml'
 
 concurrency:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -3,6 +3,10 @@ name: Javadocs GitHub CI
 on:
   pull_request:
     paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
       - '**/src/main/resources/GeoServerApplication_*.properties'
       - '!**/src/main/resources/GeoServerApplication_fr.properties'
 
@@ -51,4 +55,3 @@ jobs:
       if: always()
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
-

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,6 +3,10 @@ name: Linux JDK GitHub CI
 on:
   pull_request:
     paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
       - '**/src/main/resources/GeoServerApplication_*.properties'
       - '!**/src/main/resources/GeoServerApplication_fr.properties'
 
@@ -55,4 +59,3 @@ jobs:
       if: always()
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
-

--- a/.github/workflows/linux_locales.yml
+++ b/.github/workflows/linux_locales.yml
@@ -3,6 +3,10 @@ name: Linux Locale Build
 on:
   pull_request:
     paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
       - '**/src/main/resources/GeoServerApplication_*.properties'
       - '!**/src/main/resources/GeoServerApplication_fr.properties'
 
@@ -66,4 +70,3 @@ jobs:
       if: always()
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
-

--- a/.github/workflows/linux_timezone.yml
+++ b/.github/workflows/linux_timezone.yml
@@ -3,6 +3,10 @@ name: Linux Timezone Build
 on:
   pull_request:
     paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
       - '**/src/main/resources/GeoServerApplication_*.properties'
       - '!**/src/main/resources/GeoServerApplication_fr.properties'
 
@@ -57,4 +61,3 @@ jobs:
       if: always()
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
-

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,6 +3,10 @@ name: Mac OS GitHub CI
 on:
   pull_request:
     paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
       - '**/src/main/resources/GeoServerApplication_*.properties'
       - '!**/src/main/resources/GeoServerApplication_fr.properties'
 

--- a/.github/workflows/postgis_appschema_online.yml
+++ b/.github/workflows/postgis_appschema_online.yml
@@ -1,6 +1,12 @@
 name: PostGIS app-schema online tests
 
-on: [ pull_request ]
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,6 +1,12 @@
 name: QA GitHub CI
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,6 +3,10 @@ name: Windows GitHub CI
 on:
   pull_request:
     paths-ignore:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - 'requirements.txt'
+      - '.github/workflows/docs.yml'
       - '**/src/main/resources/GeoServerApplication_*.properties'
       - '!**/src/main/resources/GeoServerApplication_fr.properties'
 


### PR DESCRIPTION
Hi @peter-afrigis I saw your comment on the PR about docs triggering too many builds, the contents of this PR migth help. Mind I did not have time to doube check it, but it should be legit.
Better separation should be possible, don't run code builds when the CITE data dirs are touched, but only the CITE tests, but it's a start that should help with the problem at hand.

For now marking it as a draft, do with it what you see fit (try, change, merge). 

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.