### PR TITLE
Fix race condition in gs-metadata causing CI failures

### DIFF
--- a/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/ConfigurationServiceImpl.java
+++ b/src/extension/metadata/src/main/java/org/geoserver/metadata/data/service/impl/ConfigurationServiceImpl.java
@@ -120,7 +120,13 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         return customNativeMappingsConfig;
     }
 
-    private void readConfiguration() {
+    /**
+     * Reads and merges all {@code *.yaml} configuration files from the metadata directory.
+     *
+     * <p>Synchronized because it's called from bodh {@link #reload()} and the {@link ResourceListener} callback from
+     * {@link #init()}, which may fire concurrently.
+     */
+    private synchronized void readConfiguration() {
         Resource folder = getFolder();
         ObjectMapper mapper = new YAMLMapper();
         List<Resource> files = Resources.list(folder, new Resources.ExtensionFilter("YAML"));


### PR DESCRIPTION
A race condition in ConfigurationServiceImpl causes TabsTest to break at least one build job in github actions for every pull request.

We get either:
```
Error: 4,301 [ERROR] org.geoserver.metadata.web.TabsTest.testTabs -- Time elapsed: 0.365 s <<< FAILURE!
java.lang.AssertionError: expected:<7> but was:<14>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at org.geoserver.metadata.web.TabsTest.testTabs(TabsTest.java:58)
....
Error: 3,977 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.4:test (default-test) on project gs-metadata: There are test failures.
```

or:

```
Error: 3,307 [ERROR] org.geoserver.metadata.web.TabsTest.testSave -- Time elapsed: 0.183 s <<< FAILURE!
org.opentest4j.AssertionFailedError: component 'org.geoserver.metadata.web.panel.MetadataPanel' is not of type: org.apache.wicket.extensions.markup.html.tabs.TabbedPanel
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:138)
	at org.apache.wicket.util.tester.WicketTester.assertResult(WicketTester.java:804)
	at org.apache.wicket.util.tester.WicketTester.assertComponent(WicketTester.java:312)
	at org.geoserver.metadata.web.TabsTest.testSave(TabsTest.java:88)
...
Error: 5,027 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.4:test (default-test) on project gs-metadata: There are test failures.
```

**Root cause analysis**:

- `testSave` failure (`MetadataPanel is not of type `TabbedPanel`): One thread finishes building the config (including tabs from `metadata-tabs.yaml`), then the other thread overwrites configuration with a new `MetadataConfigurationImpl` (at line 135) and hasn't processed `metadata-tabs.yaml` yet, hence the test sees a config with no tabs and the panel renders as a plain `MetadataPanel` instead of a `TabbedPanel`. 
- `testTabs` failure (`expected:<7> but was:<14>`): Both threads add attributes to the same config object doubling attributes count.

**Summing up**: 

`readConfiguration()` is called concurrently from the `ResourceListener` callback (triggered when test `@BeforeClass` copies `metadata-tabs.yaml`) and from `reload()` (called in the `@Before` method). Without synchronization, both threads can add attributes to the same `MetadataConfigurationImpl`, doubling the count (14 instead of 7) and causing intermittent test failures in GitHub Actions.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.