### PR TITLE
Fix sporadic timeout failures in control-flow tests

### DIFF
--- a/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/AbstractFlowControllerTest.java
+++ b/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/AbstractFlowControllerTest.java
@@ -38,6 +38,20 @@ public abstract class AbstractFlowControllerTest {
     }
 
     /**
+     * Like {@link #waitBlocked}, but also accepts the thread having already timed out.
+     *
+     * <p>Use this for threads with short flow-controller timeouts, where the timeout may expire before polling can
+     * detect the WAITING state.
+     */
+    void waitBlockedOrTimedOut(FlowControllerTestingThread fct, long maxWait) {
+        await().atMost(maxWait, MILLISECONDS)
+                .pollDelay(10, MILLISECONDS)
+                .until(() -> fct.getState() == State.WAITING
+                        || fct.getState() == State.TIMED_WAITING
+                        || fct.state == ThreadState.TIMED_OUT);
+    }
+
+    /**
      * Waits until the thread is terminated
      *
      * @param t the thread

--- a/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/FlowControllerTestingThread.java
+++ b/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/FlowControllerTestingThread.java
@@ -22,7 +22,9 @@ public class FlowControllerTestingThread extends Thread {
     Request request;
     long timeout;
     long processingDelay;
-    ThreadState state;
+    /** volatile because it is written by the worker thread and read by the test's main thread. */
+    volatile ThreadState state;
+
     Throwable error;
     CountDownLatch waitLatch;
 

--- a/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/GlobalFlowControllerTest.java
+++ b/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/GlobalFlowControllerTest.java
@@ -88,7 +88,7 @@ public class GlobalFlowControllerTest extends AbstractFlowControllerTest {
             t1.start();
             waitBlocked(t1, MAX_WAIT); // wait until it blocks on latch
             t2.start();
-            waitBlocked(t2, MAX_WAIT); // wait until it blocks on control-flow
+            waitBlockedOrTimedOut(t2, MAX_WAIT);
             latch.countDown(); // release t1 and make it do it's 400ms wait
 
             // wait until both terminate

--- a/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/PriorityFlowControllerTest.java
+++ b/src/extension/control-flow/src/test/java/org/geoserver/flow/controller/PriorityFlowControllerTest.java
@@ -145,7 +145,7 @@ public class PriorityFlowControllerTest extends AbstractFlowControllerTest {
             t1.start();
             waitBlocked(t1, MAX_WAIT); // wait until it blocks on latch
             t2.start();
-            waitBlocked(t2, MAX_WAIT); // wait until it blocks on control-flow
+            waitBlockedOrTimedOut(t2, MAX_WAIT);
             latch.countDown(); // release t1 and make it do it's 400ms wait
 
             // wait until both terminate


### PR DESCRIPTION
We're getting sporadic failures in github actions like the following:

```
Error: 2,946 [ERROR] org.geoserver.flow.controller.PriorityFlowControllerTest.testTimeout -- Time elapsed: 120.1 s <<< ERROR!
org.awaitility.core.ConditionTimeoutException: Condition with Lambda expression in org.geoserver.flow.controller.AbstractFlowControllerTest was not fulfilled within 1 minutes.
  at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
  at org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
  at org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
  at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1160)
  at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1129)
  at org.geoserver.flow.controller.AbstractFlowControllerTest.waitBlocked(AbstractFlowControllerTest.java:37)
  at org.geoserver.flow.controller.PriorityFlowControllerTest.testTimeout(PriorityFlowControllerTest.java:148)
```

The `testTimeout()` methods in `GlobalFlowControllerTest` and `PriorityFlowControllerTest` use a `100ms` flow-controller timeout. On loaded CI machines, the main thread may not poll the worker's thread state within that narrow window. By the time `waitBlocked()` checks, the thread has already timed out and terminated, so the `WAITING`/`TIMED_WAITING` condition is never met and the test fails after `60` seconds, evidenced by the time taken on a failed run:

```
01:43:44,226 [INFO] OWS request flow controller ........................ FAILURE [02:07 min]
```
vs. a successful run:
```
22:45:44,669 [INFO] OWS request flow controller ........................ SUCCESS [  7.718 s]
```

Add `waitBlockedOrTimedOut()` to `AbstractFlowControllerTest`, that also accepts the thread having already reached `TIMED_OUT` state, and use it in both `testTimeout()` methods.

Also make `FlowControllerTestingThread.state` **`volatile`** to guarantee cross-thread visibility.

---
Hopefully this PR in tandem with #9413 will make the PR checks more stable.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.