### PR TITLE
control-flow: stuck-slot watchdog

### DIFF
--- a/src/extension/control-flow/README.md
+++ b/src/extension/control-flow/README.md
@@ -1,0 +1,256 @@
+# control-flow
+
+> **Note:** this document was prepared in April 2026 against the module behavior at that time. It is intended as
+> onboarding material and is not actively maintained alongside the code. Treat it as a starting point: the module may
+> have evolved since, and individual statements below may be out of sync with the current source. When in doubt,
+> trust the code.
+
+Throttles concurrent OWS requests and optionally rate-limits or prioritises them by user, IP or HTTP header.
+
+The extension also ships a small IP blacklist filter that rejects blacklisted addresses before the dispatcher runs.
+
+This README covers the internals - for configuration reference, see the GeoServer user manual.
+
+## How it works
+
+Every HTTP request that reaches GeoServer goes through a Spring-delegated servlet filter. For OWS requests the
+dispatcher also fires callbacks once the request has been parsed into a service+operation. `ControlFlowCallback` is
+registered as both a filter and a dispatcher callback, hooking both points from a single class. When the dispatcher
+callback fires it asks a `FlowControllerProvider` for the list of controllers that apply to the request, walks that list
+in priority order calling `requestIncoming(request, timeout)` on each, and only lets the operation run after every controller
+has granted a slot. When the operation finishes the list is walked in reverse and each slot is released. Everything
+else in this module is configuration surface around that core flow.
+
+Rules live in `$GEOSERVER_DATA_DIR/controlflow.properties`. Example:
+
+```properties
+timeout=10
+ows.global=16
+ows.wms.getmap=4
+user.ows.wms.getmap=6/s;2s
+ip=8
+ip.blacklist=192.168.1.8, 192.168.1.10
+ows.priority.http=gs-priority,0
+```
+
+## Where the code lives
+
+```
+org.geoserver.flow              ControlFlowCallback (filter + DispatcherCallback in one class),
+                                ControlFlowConfigurator, FlowController, FlowControllerProvider,
+                                DefaultFlowControllerProvider, ControllerPriorityComparator, ControlModuleStatus
+org.geoserver.flow.config       DefaultControlFlowConfigurator - the controlflow.properties parser
+org.geoserver.flow.controller   FlowController implementations + ThreadBlocker implementations +
+                                key/priority providers + IpBlacklistFilter + request matchers
+```
+
+Start with `ControlFlowCallback.java` - the rest of the module is easier to follow afterwards.
+
+## Spring wiring (`applicationContext.xml`)
+
+Three beans:
+
+| Bean                   | Class                 | Role |
+| ---------------------- | --------------------- | ---- |
+| `controlFlowCallback`  | `ControlFlowCallback` | Implements **both** `AbstractDispatcherCallback` **and** `GeoServerFilter`. Acquires/releases controllers per request. |
+| `ipBlacklistFilter`    | `IpBlacklistFilter`   | Rejects requests from blacklisted IPs with HTTP 403. Reads the same `controlflow.properties`. |
+| `controlExtension`     | `ControlModuleStatus` | Shows up in the module status panel on the admin UI. |
+
+Both `ControlFlowCallback` and `IpBlacklistFilter` are auto-discovered by GeoServer's `SpringDelegatingFilter`, which wraps every incoming
+request in all `GeoServerFilter` beans it finds in the context. No `web.xml` changes, no explicit filter mapping.
+
+If the data dir doesn't ship a custom `ControlFlowConfigurator` or `FlowControllerProvider`, `ControlFlowCallback.setApplicationContext` registers
+the defaults (`DefaultControlFlowConfigurator`, `DefaultFlowControllerProvider`) as singletons on first access. See `ControlFlowCallback.registDefaultBeansIfNeeded`.
+
+## High-level architecture
+
+```mermaid
+graph TD
+    A[HTTP request] --> B[GeoServer filter chain]
+    B --> C[IpBlacklistFilter]
+    C -->|403| Z1[rejected]
+    C --> D[ControlFlowCallback.doFilter]
+    D --> E[Spring Dispatcher]
+    E --> F[Dispatcher.operationDispatched]
+    F --> G[ControlFlowCallback.operationDispatched]
+    G --> H[FlowControllerProvider.getFlowControllers]
+    H --> I[FlowController list<br/>sorted by priority]
+    I --> J[for each controller:<br/>requestIncoming within remaining timeout]
+    J -->|timeout| Z2[HTTP 503<br/>Requested timeout out...]
+    J --> K[operation runs<br/>GetMap, GetCapabilities, ...]
+    K --> L[Dispatcher.finished]
+    L --> M[ControlFlowCallback.finished]
+    M --> N[releaseControllers reverse order]
+    N --> O[response]
+    D -.->|finally safety net| N
+```
+
+## Per-request lifecycle
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant F as ControlFlowCallback<br/>(as Filter)
+    participant D as GeoServer Dispatcher
+    participant CB as ControlFlowCallback<br/>(as DispatcherCallback)
+    participant P as FlowControllerProvider
+    participant FC as FlowController[]
+    participant OP as OWS operation
+
+    C->>F: HTTP request
+    F->>D: chain.doFilter
+    D->>CB: operationDispatched(req, op)
+    CB->>CB: REQUEST_CONTROLLERS.get() == null<br/>(not a nested dispatch)
+    CB->>P: getFlowControllers(req')
+    P-->>CB: List<FlowController> sorted by priority
+    CB->>CB: REQUEST_CONTROLLERS.set(context)<br/>blockedRequests++
+    loop each controller in priority order
+        CB->>FC: requestIncoming(req', remainingTimeout)
+        alt returned true
+            FC-->>CB: granted
+        else timeout (returned false)
+            FC-->>CB: false
+            CB-->>D: throw HttpErrorCodeException(503)
+        end
+    end
+    CB->>CB: blockedRequests--<br/>runningRequests++
+    CB-->>D: return
+    D->>OP: run operation (render, query, ...)
+    OP-->>D: result
+    D->>CB: finished(req)
+    CB->>CB: releaseControllers(false)<br/>nestingLevel--
+    loop each controller, reverse order
+        CB->>FC: requestComplete(req')
+    end
+    CB->>CB: runningRequests--<br/>REQUEST_CONTROLLERS.remove()
+    D-->>F: response
+    F->>F: finally releaseControllers(true)<br/>(precaution in case finished() is not called by any reason)
+    F-->>C: HTTP response + X-Control-flow-delay-ms header
+```
+
+## Per-request state
+
+Everything per-request lives in two `ThreadLocal`s on `ControlFlowCallback`:
+
+- `REQUEST_CONTROLLERS` holds a `CallbackContext`: the list of controllers acquired for this request, the timeout in
+force, the `Request` clone we used as the queue key, and a `nestingLevel` counter.
+- `FAILED_ON_FLOW_CONTROLLERS` is a single boolean: `true` if acquisition failed partway through, so that on release
+we know not to decrement `runningRequests` for a request that never actually started running.
+
+Two process-wide `AtomicLong` counters gives an overall view of the server's state: `blockedRequests` (requests currently
+sitting in some controller's queue) and `runningRequests` (requests that made it through all controllers and are now
+executing).
+
+### Re-entrance (integrated GWC, internal dispatches)
+
+When GWC is integrated into the WMS pipeline - as transparent integration or as a native tile service - a single HTTP request
+can re-enter `Dispatcher` on the same thread, which fires `operationDispatched` a second (and possibly third) time. Acquiring the same
+controller twice on one thread would deadlock immediately on the first BasicOWS slot, so nested calls are detected via
+`REQUEST_CONTROLLERS.get() != null` and only bump `nestingLevel`; actual release happens when `nestingLevel` hits zero. As a safety net, the
+servlet-filter `doFilter` also calls `releaseControllers(true)` in its `finally` block, so if anything swallowed `finished()` on the way out the slot
+is still released before the HTTP response returns.
+
+## Controllers and blockers
+
+Controllers live in `org.geoserver.flow.controller`. The `FlowController` contract is minimal:
+
+```java
+public interface FlowController {
+    boolean requestIncoming(Request request, long timeout); // true if entered, false on timeout
+    void    requestComplete(Request request);               // always called, matches every requestIncoming
+    int     getPriority();                                  // used to sort via ControllerPriorityComparator
+}
+```
+
+Controllers run in **priority order** on acquire and in **reverse** on release. The three base classes the rest build on:
+
+- `SingleQueueFlowController` - a controller whose matching is a single `Predicate<Request>` and whose blocking behaviour is delegated to a `ThreadBlocker`.
+The global and per-OWS controllers are instances of this.
+- `QueueController` - for controllers that maintain a dynamic set of queues, one per key (IP, user). Creates `SingleQueueFlowController`-like queues on demand.
+- `RateFlowController` - implements `FlowController` directly: no queue, only per-key counters over sliding time windows. Rate-limiter, not concurrency-limiter.
+
+### ThreadBlocker implementations
+
+A `ThreadBlocker` is the primitive that blocks a thread until a slot is available. Two exist:
+
+- `SimpleThreadBlocker(queueSize)` - wraps a fair `ArrayBlockingQueue<Request>` of capacity `queueSize`. `requestIncoming` calls
+`queue.offer(request, timeout, MS)` which returns `false` if the queue stayed full for the whole timeout; `requestComplete`
+calls `queue.remove(request)`, matching by object identity against the `Request` clone stored in `CallbackContext`. `toString()` returns
+`SimpleBlocker(N)`, which is the form that appears in the logs.
+- `PriorityThreadBlocker(queueSize, priorityProvider)` - used only when `ows.priority.http=...` is configured. Maintains a `Set<Request>`
+of currently-running requests and a `PriorityQueue<WaitToken>` of waiters, each waiter owning a `CountDownLatch`. When a slot frees,
+`releaseNext()` polls the highest-priority waiter and counts its latch down. All mutations are under `synchronized(this)`.
+
+### Controllers catalog
+
+| Config key  | Class | What it does |
+| ----------- | ----- | ------------ |
+| `ows.global=N` | `GlobalFlowController` | `N` concurrent OWS operations across the whole server (the matcher always returns true). |
+| `ows.<svc>[.<op>[.<fmt>]]=N` | `BasicOWSController` | `N` concurrent matches for the given `service[.request[.outputFormat]]` via `OWSRequestMatcher`. `toString()` is what produces `BasicOWSController(wms.getmap,SimpleBlocker(4))` in the logs. |
+| `ip=N` | `IpFlowController` | Per-IP limit of `N` concurrent requests. Dynamic `ConcurrentHashMap<ip, Queue>` with 10s idle cleanup. Honours `X-Forwarded-For`. |
+| `ip.<A.B.C.D>=N` | `SingleIpFlowController` | Hard-coded per-IP limit for a specific address. |
+| `user=N` | `UserConcurrentFlowController` | Per-user concurrent limit, keyed by a `CookieKeyGenerator` (sets a `gs-user-id` cookie when missing). |
+| `user.ows.<svc>[.<op>[.<fmt>]]=R/U[;Ds]` | `RateFlowController` | Sliding rate limit per cookie key - `R` requests per interval `U`, with an optional `Ds` delay before responding 429. |
+| `ip.ows.<svc>[.<op>[.<fmt>]]=R/U[;Ds]`      | `RateFlowController`           | Same shape, keyed by IP via `IpKeyGenerator`. |
+| `timeout=N`                                 | (not a controller)             | Seconds to wait in *any* queue before responding HTTP 503. Applied as a single shared deadline across all controllers for the request. |
+| `ows.priority.http=Header,default`          | (config only)                  | Flips the blocker factory in `DefaultControlFlowConfigurator.buildBlocker` from `SimpleThreadBlocker` to `PriorityThreadBlocker` and reads the priority from `Header` (integer; `default` when missing/invalid). |
+| `ip.blacklist=a,b,c` / `ip.whitelist=a,b,c` | `IpBlacklistFilter`            | Reject the listed IPs with HTTP 403 at the servlet-filter level before the dispatcher runs. Whitelist overrides blacklist. A `*` in a pattern becomes the regex `(.{0,1}[0-9]+.{0,1}){0,4}`. |
+
+Rate unit in `R/U[;Ds]` is one of `s`, `m`, `h`, `d` (see the `RATE_PATTERN` constant).
+
+### The parser
+
+`DefaultControlFlowConfigurator.buildFlowControllers()` walks `controlflow.properties` and maps each key to a controller per
+the table above. A `PropertyFileWatcher` detects on-disk changes; `DefaultFlowControllerProvider.checkConfiguration` rebuilds
+the sorted controller list under `synchronized(configurator)` when `configurator.isStale()` returns `true`. `timeout` is
+stored in milliseconds (key value × 1000) on a `volatile long`.
+
+## Response headers
+
+`ControlFlowCallback` sets the following response headers:
+
+- `X-Control-flow-delay-ms` - milliseconds spent between entering `operationDispatched` and either clearing flow-controller
+acquisition or throwing. Set in the `finally` block of `operationDispatched`, so every response carries it.
+- `X-Concurrent-Limit` / `X-Concurrent-Requests` - set by controllers enforcing concurrency limits; useful for clients that want to self-throttle.
+
+The 503 body reads `Requested timeout while waiting to be executed, please lower your request rate`.
+
+## Log format cheatsheet
+
+Messages emitted under the `geoserver.flow` logger:
+
+| Level | Message | Meaning |
+| ----- | ------- | ------- |
+| INFO  | `Request [...] starting, processing through flow controllers` | A non-nested dispatch has started acquiring controllers. |
+| FINE  | `Request [...] enter BasicOWSController(wms.getmap,SimpleBlocker(4))/4` | About to call `requestIncoming` on this controller. The trailing `/N` is the **live** queue size at log time, not a per-request counter. For a `SimpleThreadBlocker` of capacity 4, `/4` indicates the queue is full and the call will block until a slot frees or the timeout expires. |
+| FINE  | `Request [...] exit BasicOWSController(...)/N` | `requestIncoming` returned `true`; the request is now counted in the queue. `/N` is the queue size **after** entry. Not emitted on timeout - there is no `exit` line when the controller returned `false`. |
+| INFO  | `Request control-flow performed, running requests: X, blocked requests: Y` | Emitted in the `finally` of `operationDispatched`; controller acquisition has finished (successfully or by throwing). |
+| INFO  | `releasing flow controllers for [...]` | Release path has started (`finished()` or the `doFilter` `finally`). |
+| INFO  | `Request completed, running requests: X, blocked requests: Y` | End of release path. |
+| FINE  | `Nested request found, not locking on it` | Re-entrant `operationDispatched` on the same thread; only `nestingLevel` was incremented. |
+| WARN  | `Request [...] held flow-controller slot for <N>ms, over the configured <timeout>ms timeout; peer requests may have returned HTTP 503 while waiting for this one.` | Release-time stuck-slot warning. |
+
+Because `/N` is a shared counter read at log-emission time, values across different threads' `enter`/`exit` lines fluctuate freely. Do not read them as belonging to a single request.
+
+## Operational notes
+
+- **Only queue waits are bounded.** `timeout` caps time spent in a queue, not execution time.
+- **`timeout=0` or omitted disables the queue-wait deadline.** Waiters then block on `BlockingQueue.put` with no timeout. Not recommended
+for production: a slow operation can cause waiters to pile up indefinitely.
+- **`controlflow.properties` is hot-reloaded.** Changes are picked up on the next request through the `PropertyFileWatcher.isStale` check in
+`DefaultFlowControllerProvider.checkConfiguration`. No restart required.
+- **Ordering matters.** Lower-priority controllers are acquired first and released last. Reverse-order release drains the most specific
+limits (usually OWS-level) before more general ones (global), which reduces the chance of a low-priority request keeping a slot a higher-priority request needs.
+- **`ControlFlowCallback`'s constructor calls `REQUEST_CONTROLLERS.remove()`** to isolate unit tests from leftover thread-locals
+in the test runner. At runtime there is a single callback bean, so the call is effectively a no-op.
+
+## Developer tips
+
+- Start with `ControlFlowCallback.java`, specifically `operationDispatched` and `releaseControllers`. The rest of the module is easier to follow afterwards.
+- To add a new flow controller: implement `FlowController`, add a parser branch in `DefaultControlFlowConfigurator.buildFlowControllers`,
+and provide a `toString()` that includes the controller's parameters - the logs rely on it.
+- To add a new blocker: implement `ThreadBlocker` and wire it through `buildBlocker` in the configurator, or wrap it directly inside a controller.
+- For concurrency tests use `AbstractFlowControllerTest` and `FlowControllerTestingThread`. These were recently hardened (`state` is `volatile`,
+`waitBlockedOrTimedOut` accepts `TIMED_OUT`) to eliminate sporadic CI failures caused by ad-hoc thread-state polling. Reuse them rather than rolling your own.
+

--- a/src/extension/control-flow/README.md
+++ b/src/extension/control-flow/README.md
@@ -134,7 +134,7 @@ sequenceDiagram
 Everything per-request lives in two `ThreadLocal`s on `ControlFlowCallback`:
 
 - `REQUEST_CONTROLLERS` holds a `CallbackContext`: the list of controllers acquired for this request, the timeout in
-force, the `Request` clone we used as the queue key, and a `nestingLevel` counter.
+force, the `Request` clone we used as the queue key, a `nestingLevel` counter, plus a couple of fields the stuck-slot watchdog uses (start time, owning thread).
 - `FAILED_ON_FLOW_CONTROLLERS` is a single boolean: `true` if acquisition failed partway through, so that on release
 we know not to decrement `runningRequests` for a request that never actually started running.
 
@@ -216,6 +216,83 @@ acquisition or throwing. Set in the `finally` block of `operationDispatched`, so
 
 The 503 body reads `Requested timeout while waiting to be executed, please lower your request rate`.
 
+## Stuck-slot watchdog
+
+### The two time windows of a request
+
+A request spends its life in two consecutive states, and control-flow only bounds one of them:
+
+1. **Queue wait.** The thread is inside `operationDispatched`'s controller loop, parked in `SimpleThreadBlocker.offer(req, maxWait, MS)`
+because a peer holds the slot. It exits either when a slot frees (loop continues) or when the wait exceeds `timeout=N` (503 is thrown).
+This window is **strictly bounded** by `timeout`. The `blockedRequests` counter reflects it.
+2. **Running.** Every controller has granted; `operationDispatched` has returned; the thread is executing the actual OWS operation
+(rendering, querying, building the response). Control-flow holds no lock here — it just waits for `DispatcherCallback.finished(req)`
+to fire and release the slots. This window is **not bounded by anything in control-flow**; its natural length is however long
+the operation takes. The `runningRequests` counter reflects it.
+
+A **stuck slot** is a request that entered state (2) and never left it - typically because something downstream (a datastore,
+a renderer, a cache, a native call) is wedged and `finished` never fires. The slot stays held indefinitely. From control-flow's
+point of view, the slot *looks* occupied exactly like a normal running request — same counter, same callbacks not-yet-fired,
+no exception. Peer requests arriving behind it pile up in state (1), hit `timeout`, and return 503. The 503 log message is identical
+whether those peers are held up by legitimately busy work or by a wedged one, which is what makes stuck slots annoying to diagnose from logs alone.
+
+|                                     | Queue wait (state 1) | Running (state 2) | Stuck slot        |
+| ----------------------------------- | -------------------- | ----------------- | ----------------- |
+| Bounded by `timeout`                | yes                  | no                | no                |
+| `blockedRequests` counter           | incremented          | -                 | -                 |
+| `runningRequests` counter           | -                    | incremented       | incremented       |
+| Entry in `ACTIVE_RUNNING`           | no                   | yes               | yes               |
+| Clears on its own                   | yes (slot or 503)    | yes (op returns)  | **no**            |
+| Recovery                            | automatic            | automatic         | restart / fix bug |
+
+That last row is the point: control-flow's built-in `timeout` only bounds states that clear themselves anyway. The watchdog adds
+visibility for the state that does not.
+
+### What the watchdog does
+
+`ControlFlowCallback` maintains a live map of currently-running requests (`ACTIVE_RUNNING`, keyed by thread id; populated once all
+controllers have granted, cleared on release). Two hooks use it:
+
+1. **Timeout-triggered peer dump.** When `requestIncoming` returns `false` and the callback is about to throw a 503, it walks
+`ACTIVE_RUNNING` once and emits one `WARNING` per peer whose hold duration exceeds `timeout`. Each line names the peer thread,
+the `Request` it is running, and the **top stack frame** of that thread. So at the moment of the 503 the log already distinguishes
+a peer doing real work (top frame inside the renderer, the datastore query, etc.) from a peer wedged in, e.g. `org.sqlite.core.NativeDB._open_utf8(Native Method)`,
+without needing a separate `jstack`.
+2. **Release-time confirmation.** When a request finally releases after holding its slot longer than `timeout`, the release path
+logs a single `WARNING` naming the request and the hold duration. If the operation never returns - the stuck case - this line
+never appears; the peer dump from (1) is the primary signal.
+
+The heuristic is "a hold longer than the queue-wait budget is suspicious, not necessarily stuck". A legitimately slow 20-second
+render with `timeout=10` will also trigger the WARN, but its top frame reads as progress (e.g. `StreamingRenderer.drawFeature`), not as a wedge.
+A stuck slot has a top frame that is identical across successive dumps and inside I/O or native code. The watchdog is a pointer,
+not a verdict; the stack frame is the evidence.
+
+The message format is stable so alerts can key off it:
+
+```
+Request [<timedOutRequest>] timed out waiting on <controller>; peer thread <name> has been holding a slot for <heldMs>ms running [<peerRequest>] - top frame: <stack element>
+```
+
+Sample output from a real incident - a GetMap request on thread `-148` times out waiting on `wms.getmap` because four
+peer threads have been wedged in native SQLite calls for ~770 seconds:
+
+```
+'qtp1439007204-148' INFO   [geoserver.flow] - Request [WMS 1.1.0 GetMap] starting, processing through flow controllers
+'qtp1439007204-148' WARN   [geoserver.flow] - Request [WMS 1.1.0 GetMap] timed out waiting on BasicOWSController(wms.getmap,SimpleBlocker(4)); peer thread qtp1439007204-81 has been holding a slot for 769328ms running [WMS 1.1.1 GetMap] - top frame: org.sqlite.core.NativeDB._open_utf8(Native Method)
+'qtp1439007204-148' WARN   [geoserver.flow] - Request [WMS 1.1.0 GetMap] timed out waiting on BasicOWSController(wms.getmap,SimpleBlocker(4)); peer thread qtp1439007204-149 has been holding a slot for 769348ms running [WMS 1.1.1 GetMap] - top frame: org.sqlite.core.NativeDB._close(Native Method)
+'qtp1439007204-148' WARN   [geoserver.flow] - Request [WMS 1.1.0 GetMap] timed out waiting on BasicOWSController(wms.getmap,SimpleBlocker(4)); peer thread qtp1439007204-154 has been holding a slot for 769349ms running [WMS 1.1.1 GetMap] - top frame: org.sqlite.core.NativeDB._open_utf8(Native Method)
+'qtp1439007204-148' WARN   [geoserver.flow] - Request [WMS 1.1.0 GetMap] timed out waiting on BasicOWSController(wms.getmap,SimpleBlocker(4)); peer thread qtp1439007204-155 has been holding a slot for 769349ms running [WMS 1.1.1 GetMap] - top frame: org.sqlite.core.NativeDB._open_utf8(Native Method)
+'qtp1439007204-148' INFO   [geoserver.flow] - Request control-flow performed, running requests: 4, blocked requests: 0
+'qtp1439007204-148' INFO   [geoserver.flow] - releasing flow controllers for [WMS 1.1.0 GetMap]
+'qtp1439007204-148' INFO   [geoserver.flow] - Request completed, running requests: 4, blocked requests: 0
+```
+
+That block points straight at the root cause: every peer has held its slot for ~770 s (hold times consistent across the
+four WARN lines), and every top frame is inside `org.sqlite.core.NativeDB`. The problem is in the SQLite/GeoPackage connection layer,
+not in control-flow, and the evidence is right there in the log without a separate `jstack`.
+
+The watchdog introduces no background threads or scheduled tasks; it runs inline on the 503-throwing path and on the normal release path.
+
 ## Log format cheatsheet
 
 Messages emitted under the `geoserver.flow` logger:
@@ -229,13 +306,15 @@ Messages emitted under the `geoserver.flow` logger:
 | INFO  | `releasing flow controllers for [...]` | Release path has started (`finished()` or the `doFilter` `finally`). |
 | INFO  | `Request completed, running requests: X, blocked requests: Y` | End of release path. |
 | FINE  | `Nested request found, not locking on it` | Re-entrant `operationDispatched` on the same thread; only `nestingLevel` was incremented. |
+| WARN  | `Request [...] timed out waiting on <controller>; peer thread <name> has been holding a slot for <N>ms running [...] - top frame: ...` | Stuck-slot watchdog (see above). |
 | WARN  | `Request [...] held flow-controller slot for <N>ms, over the configured <timeout>ms timeout; peer requests may have returned HTTP 503 while waiting for this one.` | Release-time stuck-slot warning. |
 
 Because `/N` is a shared counter read at log-emission time, values across different threads' `enter`/`exit` lines fluctuate freely. Do not read them as belonging to a single request.
 
 ## Operational notes
 
-- **Only queue waits are bounded.** `timeout` caps time spent in a queue, not execution time.
+- **Only queue waits are bounded.** `timeout` caps time spent in a queue, not execution time. A slot held by a stuck operation remains
+held until that operation returns - which may be never. The [stuck-slot watchdog](#stuck-slot-watchdog) is the first-line diagnostic; `jstack` confirms.
 - **`timeout=0` or omitted disables the queue-wait deadline.** Waiters then block on `BlockingQueue.put` with no timeout. Not recommended
 for production: a slow operation can cause waiters to pile up indefinitely.
 - **`controlflow.properties` is hot-reloaded.** Changes are picked up on the next request through the `PropertyFileWatcher.isStale` check in

--- a/src/extension/control-flow/src/main/java/org/geoserver/flow/ControlFlowCallback.java
+++ b/src/extension/control-flow/src/main/java/org/geoserver/flow/ControlFlowCallback.java
@@ -12,6 +12,8 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -63,6 +65,19 @@ public class ControlFlowCallback extends AbstractDispatcherCallback
 
         int nestingLevel = 1;
 
+        /**
+         * Wall-clock time the owning thread became a "running" request (i.e. finished acquiring controllers). Used by
+         * the stuck-slot watchdog to report how long a flow-controller slot has been held when a peer request times out
+         * waiting for one. Zero until controllers are acquired; stable thereafter.
+         */
+        long runningStartMs;
+
+        /**
+         * Thread that owns this context; captured so {@link #ACTIVE_RUNNING} entries can dump the owner's top stack
+         * frame.
+         */
+        Thread owner;
+
         public CallbackContext(Request request, List<FlowController> controllers, long timeout) {
             this.controllers = controllers;
             this.timeout = timeout;
@@ -73,6 +88,14 @@ public class ControlFlowCallback extends AbstractDispatcherCallback
     static ThreadLocal<CallbackContext> REQUEST_CONTROLLERS = new ThreadLocal<>();
 
     static ThreadLocal<Boolean> FAILED_ON_FLOW_CONTROLLERS = new ThreadLocal<>();
+
+    /**
+     * Live view of all requests currently holding flow-controller slots, keyed by the thread id of the owner. Populated
+     * once a request successfully acquires every controller and cleared on release. Used only for observability - the
+     * stuck-slot watchdog walks it when a peer request times out on a queue wait, so operators get a log line naming
+     * the thread and its top frame instead of only the generic HTTP 503.
+     */
+    static final Map<Long, CallbackContext> ACTIVE_RUNNING = new ConcurrentHashMap<>();
 
     FlowControllerProvider provider;
 
@@ -149,6 +172,9 @@ public class ControlFlowCallback extends AbstractDispatcherCallback
                     if (timeout > 0) {
                         long maxWait = maxTime - System.currentTimeMillis();
                         if (!controller.requestIncoming(requestWithOperation, maxWait)) {
+                            // Before giving up and returning 503, surface who's still holding the slots - the
+                            // queue-wait timeout itself says nothing about whether the held slots are busy or stuck.
+                            logStuckRunningRequests(controller, requestWithOperation, timeout);
                             throw new HttpErrorCodeException(
                                     503,
                                     "Requested timeout out while waiting to be executed, please lower your request rate");
@@ -161,6 +187,9 @@ public class ControlFlowCallback extends AbstractDispatcherCallback
                         LOGGER.fine(getControllerExitMessage(controller, requestWithOperation));
                     }
                 }
+                context.runningStartMs = System.currentTimeMillis();
+                context.owner = Thread.currentThread();
+                ACTIVE_RUNNING.put(context.owner.getId(), context);
             }
             failedOnFlowControllers = false;
         } finally {
@@ -203,6 +232,32 @@ public class ControlFlowCallback extends AbstractDispatcherCallback
             message += "/" + requests;
         }
         return message;
+    }
+
+    /**
+     * Called when a request is about to return HTTP 503 because it could not acquire {@code blockedOn} within the
+     * configured timeout. Walks the live view of currently-running requests and emits one WARN line per peer that has
+     * been holding its slot for longer than the timeout. Each line includes the top stack frame of the owner thread so
+     * operators can tell queue-wait timeouts (harmless, benchmarking) apart from stuck-slot timeouts (the peer is stuck
+     * in the I/O layer, the datastore, rendering, etc.) without needing a separate jstack.
+     */
+    private static void logStuckRunningRequests(FlowController blockedOn, Request timedOutRequest, long timeout) {
+        if (!LOGGER.isLoggable(Level.WARNING) || ACTIVE_RUNNING.isEmpty()) {
+            return;
+        }
+        final long now = System.currentTimeMillis();
+        for (CallbackContext peer : ACTIVE_RUNNING.values()) {
+            boolean hasRun = peer.runningStartMs > 0 && peer.owner != null;
+            long heldMs = hasRun ? (now - peer.runningStartMs) : -1L;
+            if (hasRun && heldMs > timeout) {
+                StackTraceElement[] stack = peer.owner.getStackTrace();
+                String top = stack.length > 0 ? stack[0].toString() : "<thread exited>";
+                LOGGER.warning(
+                        "Request [%s] timed out waiting on %s; peer thread %s has been holding a slot for %dms running [%s] - top frame: %s"
+                                .formatted(
+                                        timedOutRequest, blockedOn, peer.owner.getName(), heldMs, peer.request, top));
+            }
+        }
     }
 
     @Override
@@ -280,6 +335,19 @@ public class ControlFlowCallback extends AbstractDispatcherCallback
                 if (context.nestingLevel <= 0 || forceRelease) {
                     if (Boolean.FALSE.equals(FAILED_ON_FLOW_CONTROLLERS.get())) {
                         runningRequests.decrementAndGet();
+                    }
+                    // Drop from the live-running map before we run requestComplete, so a concurrent
+                    // watchdog pass does not report a slot that is now being actively released.
+                    if (context.owner != null) {
+                        ACTIVE_RUNNING.remove(context.owner.getId(), context);
+                        if (context.timeout > 0 && context.runningStartMs > 0) {
+                            long heldMs = System.currentTimeMillis() - context.runningStartMs;
+                            if (heldMs > context.timeout) {
+                                LOGGER.warning("Request [" + context.request + "] held flow-controller slot for "
+                                        + heldMs + "ms, over the configured " + context.timeout + "ms timeout; "
+                                        + "peer requests may have returned HTTP 503 while waiting for this one.");
+                            }
+                        }
                     }
                     // call back the same controllers we used when the operation started, releasing
                     // them in inverse order

--- a/src/extension/control-flow/src/test/java/org/geoserver/flow/ControlFlowCallbackTest.java
+++ b/src/extension/control-flow/src/test/java/org/geoserver/flow/ControlFlowCallbackTest.java
@@ -6,6 +6,7 @@
 package org.geoserver.flow;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -20,7 +21,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.geoserver.flow.controller.BasicOWSController;
 import org.geoserver.flow.controller.SimpleThreadBlocker;
 import org.geoserver.ows.HttpErrorCodeException;
@@ -240,6 +248,133 @@ public class ControlFlowCallbackTest {
         assertEquals(0, callback.getRunningRequests());
         assertEquals(0, callback.getBlockedRequests());
         assertEquals(0, controller.getRequestsInQueue());
+    }
+
+    /**
+     * A peer thread holds the only BasicOWSController slot past the configured timeout; a second request then times out
+     * on the queue. The stuck-slot watchdog must emit a WARN naming the peer thread, the peer's {@link Request} and a
+     * {@code top frame:} string.
+     */
+    @Test
+    public void testStuckSlotWatchdogLogsPeerOnQueueTimeout() throws Exception {
+        final ControlFlowCallback callback = new ControlFlowCallback();
+        TestingConfigurator tc = new TestingConfigurator();
+        tc.timeout = 200;
+        BasicOWSController controller = new BasicOWSController("WMS", 1, new SimpleThreadBlocker(1));
+        tc.controllers.add(controller);
+        callback.provider = new DefaultFlowControllerProvider(tc);
+
+        CapturingHandler handler = new CapturingHandler();
+        Logger logger = ControlFlowCallback.LOGGER;
+        Level previous = logger.getLevel();
+        logger.setLevel(Level.ALL);
+        logger.addHandler(handler);
+
+        CountDownLatch enteredRunning = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Request peerRequest = new Request();
+        peerRequest.setService("WMS");
+        Thread peer = new Thread(
+                () -> {
+                    callback.operationDispatched(peerRequest, null);
+                    enteredRunning.countDown();
+                    try {
+                        release.await();
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                    callback.finished(peerRequest);
+                },
+                "stuck-slot-peer");
+        peer.setDaemon(true);
+        peer.start();
+
+        try {
+            assertTrue("peer thread failed to acquire slot", enteredRunning.await(5, TimeUnit.SECONDS));
+            // give the peer a cushion so its held time is clearly past the timeout when the watchdog fires
+            Thread.sleep(tc.timeout + 100);
+
+            Request mainRequest = new Request();
+            mainRequest.setService("WMS");
+            try {
+                callback.operationDispatched(mainRequest, null);
+                fail("HTTP 503 expected");
+            } catch (HttpErrorCodeException e) {
+                assertEquals(503, e.getErrorCode());
+            }
+
+            List<LogRecord> warns = handler.recordsAt(Level.WARNING);
+            assertFalse("expected a watchdog WARN record", warns.isEmpty());
+            LogRecord warn = warns.get(0);
+            String message = warn.getMessage();
+            assertTrue(message, message.contains("peer thread stuck-slot-peer"));
+            assertTrue(message, message.contains("holding a slot for"));
+            assertTrue(message, message.contains("top frame:"));
+        } finally {
+            release.countDown();
+            peer.join(5000);
+            callback.finished(null);
+            logger.removeHandler(handler);
+            logger.setLevel(previous);
+            ControlFlowCallback.ACTIVE_RUNNING.clear();
+        }
+    }
+
+    /**
+     * Single request holds its slot past the configured timeout, then releases normally. The release path must emit a
+     * WARN naming the hold duration and referencing the configured timeout.
+     */
+    @Test
+    public void testHeldSlotWarnsOnSlowRelease() throws Exception {
+        ControlFlowCallback callback = new ControlFlowCallback();
+        TestingConfigurator tc = new TestingConfigurator();
+        tc.timeout = 100;
+        BasicOWSController controller = new BasicOWSController("WMS", 1, new SimpleThreadBlocker(1));
+        tc.controllers.add(controller);
+        callback.provider = new DefaultFlowControllerProvider(tc);
+
+        CapturingHandler handler = new CapturingHandler();
+        Logger logger = ControlFlowCallback.LOGGER;
+        Level previous = logger.getLevel();
+        logger.setLevel(Level.ALL);
+        logger.addHandler(handler);
+
+        try {
+            Request request = new Request();
+            request.setService("WMS");
+            callback.operationDispatched(request, null);
+            Thread.sleep(tc.timeout + 100);
+            callback.finished(request);
+
+            boolean matched = handler.recordsAt(Level.WARNING).stream()
+                    .map(LogRecord::getMessage)
+                    .anyMatch(m -> m.contains("held flow-controller slot for") && m.contains("over the configured"));
+            assertTrue("expected a release-path watchdog WARN", matched);
+        } finally {
+            logger.removeHandler(handler);
+            logger.setLevel(previous);
+            ControlFlowCallback.ACTIVE_RUNNING.clear();
+        }
+    }
+
+    /** Minimal JUL {@link Handler} that records every published record for later inspection. */
+    private static final class CapturingHandler extends Handler {
+        private final List<LogRecord> records = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void close() {}
+
+        List<LogRecord> recordsAt(Level level) {
+            return records.stream().filter(r -> r.getLevel() == level).toList();
+        }
     }
 
     /** A wide open configurator to be used for testing */


### PR DESCRIPTION
## TL;DR

Adds a diagnostic to `ControlFlowCallback`: on an HTTP 503 queue-wait timeout, log a WARN per peer that has been holding a slot past `timeout`, including the peer thread's top stack frame. Also warn on the release path if a slot was held beyond `timeout`. No new threads, no scheduled tasks, observability only.

Also adds `src/extension/control-flow/README.md` — developer onboarding docs for the extension (first commit of this branch).

## Backstory

During stress/load testing the 3.x artifacts an incident looked like a control-flow deadlock: under concurrent WMS GetMap load on a GeoPackage-backed layer group, the server would freeze, the "running requests" counter would peg at the configured concurrency cap, and every subsequent request would return the usual `Requested timeout out while waiting to be executed` 503. Smelled like control-flow misbehaving, so started investigating inside this extension.

After reading through `ControlFlowCallback`, `SimpleThreadBlocker`, `SingleQueueFlowController`, and the nesting/release paths, nothing in control-flow itself matched the symptoms: the `SimpleThreadBlocker` queue was doing exactly what it advertises, `finished()` was not being called simply because the operation it was supposed to wrap never returned, and the `doFilter` safety net couldn't fire either for the same reason.

Reproducing with `ab -c 8` against the `ne:world` layer group, then `ab -c 32` against a single GeoPackage layer, and capturing two `jstack` dumps a few seconds apart showed the real story: the threads holding slots were all wedged in native SQLite calls (`org.sqlite.core.NativeDB._open_utf8`, `NativeDB._close`) with zero CPU time advancing between dumps. The server also hangs without the control-flow extension installed. Root cause is in `gt-geopkg` / xerial `sqlite-jdbc`, not in GeoServer. Filed as **[GEOS-12094](https://osgeo-org.atlassian.net/browse/GEOS-12094)**.

So the diagnosis cost a `jstack` cycle that could be avoided. Control-flow has all the information needed to point the finger at the right layer.

## What's in the PR

1. `ControlFlowCallback` tracks each running request's start time and owning thread in a `ConcurrentHashMap<Long, CallbackContext> ACTIVE_RUNNING`, populated after controller acquisition completes, cleared on release.
2. When a request is about to throw 503 because its queue-wait expired, the callback walks `ACTIVE_RUNNING` and logs one WARN per peer whose hold duration exceeds `timeout`. The WARN includes the peer thread name, its `Request`, and its top stack frame.
3. When a request releases after holding its slot longer than `timeout`, a WARN is logged naming the hold duration. For the truly-stuck case this line never fires (the peer-dump from (2) is the primary signal).
4. README section explaining the distinction between the queue-wait window (bounded by `timeout`) and the running window (not bounded by control-flow at all), and what the watchdog can and cannot tell you. The sample log output is the real GEOS-12094 trace.

The heuristic is "a hold longer than the queue-wait budget is suspicious, not necessarily stuck".  A legit slow render will also trigger the WARN, but its top frame will read as progress (`StreamingRenderer.drawFeature` and similar) rather than as a wedge in native I/O. The watchdog is a pointer, not a verdict; the stack frame is the evidence.

## Why it belongs in control-flow even though the bug isn't here

Control-flow is where the 503 is emitted, and it is the component with the process-wide view of who is currently holding slots. Any other place in GeoServer that tried to provide this signal would have to reimplement the same bookkeeping. Keeping the watchdog inline with the 503 path also means it has zero cost when no one is timing out.

## Tests

`ControlFlowCallbackTest` adds two tests, modelled on the existing `testTimeout`:

- `testStuckSlotWatchdogLogsPeerOnQueueTimeout`: a peer thread fills the single-capacity controller slot and parks on a `CountDownLatch`; the test thread issues a second request that 503s; a JUL `Handler` captures the emitted WARN and asserts it names the peer thread, its request, and carries a `top frame:`.
- `testHeldSlotWarnsOnSlowRelease`: single request held past `timeout` then releases normally; assert the release-path WARN fires.

## Reproduction / verification

Against the Natural Earth dataset from the release datadir:

```
ab -s 15 -t 5 -c 8 "<WMS GetMap on ne:world>"
```

Once wedged, a follow-up `curl` returns 503 and the log now reads:

```
WARN  [geoserver.flow] - Request [WMS 1.1.0 GetMap] timed out waiting on BasicOWSController(wms.getmap,SimpleBlocker(4));
      peer thread qtp…-81 has been holding a slot for 769328ms running [WMS 1.1.1 GetMap]
      - top frame: org.sqlite.core.NativeDB._open_utf8(Native Method)
```

…which is the information GEOS-12094 needed.

  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.