### PR TITLE
[QA] Replace UselessOperationOnImmutable with UselessPureMethodCall

### DIFF
--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -94,7 +94,7 @@ GeoTools ruleset. See https://pmd.github.io/latest/pmd_userdocs_understanding_ru
   <rule ref="category/java/errorprone.xml/UnconditionalIfStatement"/>
   <rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary"/>
   <rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals"/>
-  <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable"/>
+  <rule ref="category/java/errorprone.xml/UselessPureMethodCall"/>
   <rule ref="category/java/errorprone.xml/CloseResource">
     <properties>
         <!-- When calling the store to close, PMD wants the full prefix before the call to -->

--- a/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/GetCoverage.java
+++ b/src/wcs2_0/src/main/java/org/geoserver/wcs2_0/GetCoverage.java
@@ -1582,7 +1582,6 @@ public class GetCoverage {
                     WCS20Exception.WCS20ExceptionCode.InterpolationMethodNotSupported,
                     "");
         }
-        returnValue.get("Lat");
         return returnValue;
     }
 


### PR DESCRIPTION
As UselessOperationOnImmutable is deprecated and generating a ton of warnings in the build log.

see 
- https://pmd.github.io/pmd/pmd_rules_java_errorprone.html#uselessoperationonimmutable
- https://github.com/geotools/geotools/pull/5621


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.