### PR TITLE
pmtiles-store: normalize forward-compatible storage.* keys in EditPanel

### DIFF
--- a/src/community/pmtiles-store/src/main/java/org/geoserver/pmtiles/web/data/PMTilesDataStoreEditPanel.java
+++ b/src/community/pmtiles-store/src/main/java/org/geoserver/pmtiles/web/data/PMTilesDataStoreEditPanel.java
@@ -9,8 +9,10 @@ import static org.geotools.tileverse.rangereader.RangeReaderParams.MEMORY_CACHE_
 import static org.geotools.tileverse.rangereader.RangeReaderParams.RANGEREADER_PROVIDER_ID;
 import static org.geotools.tileverse.rangereader.RangeReaderParams.S3_AWS_REGION;
 
+import io.tileverse.rangereader.spi.RangeReaderConfig;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,9 +74,19 @@ public class PMTilesDataStoreEditPanel extends DefaultDataStoreEditPanel {
 
     @Override
     protected void onBeforeRender() {
-        super.onBeforeRender();
         DataStoreInfo storeInfo = (DataStoreInfo) super.storeEditForm.getModelObject();
-        String providerId = (String) storeInfo.getConnectionParameters().get(RANGEREADER_PROVIDER_ID.key);
+        Map<String, Serializable> params = storeInfo.getConnectionParameters();
+        // Translate forward-compatible storage.* keys (canonical in tileverse 2.x) to the canonical
+        // io.tileverse.rangereader.* form in place so Wicket MapModel widgets, which are bound to the
+        // factory's canonical Param.key, populate correctly for stores persisted by a future
+        // GeoServer 3.1+/tileverse 2.0 consumer.
+        Map<String, Serializable> rewritten = new LinkedHashMap<>(params.size());
+        params.forEach((k, v) -> rewritten.put(RangeReaderConfig.normalizeKey(k), v));
+        params.clear();
+        params.putAll(rewritten);
+
+        super.onBeforeRender();
+        String providerId = (String) params.get(RANGEREADER_PROVIDER_ID.key);
         sendEvent(new RangeReaderChangedEvent(providerId, null));
     }
 


### PR DESCRIPTION
Tileverse `1.4` keeps the canonical `io.tileverse.rangereader.*` parameter prefix. A future tileverse 2.x consumer (GeoServer 3.1+) will persist DataStoreInfo with the `storage.*` prefix instead. To keep the `EditPanel` functional after a data dir is rolled back from 3.1 to 3.0, onBeforeRender now translates any `storage.*` keys in `connectionParameters` to canonical form in place via `RangeReaderConfig.normalizeKey` before Wicket binds the MapModel widgets, which are keyed off the factory's canonical Param.key. On save, the catalog picks up the canonical form -- a passive opt-in migration that preserves correct field display without any user action.

---

coordinated with geotools PR https://github.com/geotools/geotools/pull/5623

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.