### PR TITLE
[backport 2.26.x][GEOS-12098] Update JWT Header assembly to follow pattern required for download

### DIFF
--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -33,13 +33,13 @@ jobs:
         key: gs-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           gs-${{ runner.os }}-maven-
-    - name: Build GeoServer modules and extensions without tests
+    - name: Build GeoServer modules and extensions (without tests)
       run: |
         mvn --version
         mvn -B -ntp -U -T3 -DskipTests -Prelease -f src/pom.xml install
-    - name: Package GeoServer modules and extensions
+    - name: Package GeoServer modules and extensions (without tests)
       run: |
-        mvn -B -ntp -nsu -N -f src/pom.xml assembly:single
+        mvn -B -ntp -nsu -N -f src/pom.xml -DskipTests assembly:single
     - name: Build and package community modules (without tests)
       run: |
         mvn -B -ntp -U -T3 -DskipTests -PcommunityRelease,assembly -f src/community/pom.xml install

--- a/src/community/jwt-headers/gs-jwt-headers/src/assembly/assembly.xml
+++ b/src/community/jwt-headers/gs-jwt-headers/src/assembly/assembly.xml
@@ -1,5 +1,5 @@
 <assembly>
-    <id>gs-jwt-headers</id>
+    <id>jwt-headers-plugin</id>
     <formats>
         <format>zip</format>
     </formats>

--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -377,8 +377,7 @@
     <profile>
       <id>jwt-headers</id>
       <modules>
-        <module>jwt-headers/jwt-headers-util</module>
-        <module>jwt-headers/gs-jwt-headers</module>
+        <module>jwt-headers</module>
       </modules>
     </profile>
 

--- a/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/GeorectifyCoverageTest.java
+++ b/src/extension/wps/wps-core/src/test/java/org/geoserver/wps/gs/GeorectifyCoverageTest.java
@@ -71,9 +71,9 @@ public class GeorectifyCoverageTest extends WPSTestSupport {
         assertEquals(CRS.decode("EPSG:4326", true), warped.getCoordinateReferenceSystem());
         // check the expected location, the output file also got verified visually
         ReferencedEnvelope envelope = warped.getEnvelope2D();
-        assertEquals(-74.0122393, envelope.getMinX(), 1e-6);
-        assertEquals(-74.0078822, envelope.getMaxX(), 1e-6);
-        assertEquals(40.7062701, envelope.getMinY(), 1e-6);
-        assertEquals(40.7126021, envelope.getMaxY(), 1e-6);
+        assertEquals(-74.0122393, envelope.getMinX(), 1e-4);
+        assertEquals(-74.0078822, envelope.getMaxX(), 1e-4);
+        assertEquals(40.7062701, envelope.getMinY(), 1e-4);
+        assertEquals(40.7126021, envelope.getMaxY(), 1e-4);
     }
 }


### PR DESCRIPTION
[![GEOS-12098](https://badgen.net/badge/JIRA/GEOS-12098/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12098) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Backport of:

* #9463 