### PR TITLE
[GEOS-12104] fix: ClassCastException escaping catch block in CatalogLoader.describe()

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/ResourceInfoImpl.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ResourceInfoImpl.java
@@ -360,7 +360,7 @@ public abstract class ResourceInfoImpl implements ResourceInfo {
      * Allows access to the raw store property without the casting performed by subclasses. This is convenient during
      * the catalog load process to avoid class cast exceptions when the store is a resolving proxy
      */
-    StoreInfo rawStore() {
+    public StoreInfo rawStore() {
         return store;
     }
 

--- a/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
@@ -415,7 +415,16 @@ class CatalogLoader {
         if (info instanceof LayerInfo layer) {
             parent = layer.getResource() != null ? layer.getResource().prefixedName() : null;
         } else if (info instanceof ResourceInfo resource) {
-            StoreInfo store = resource.getStore();
+            // WMSLayerInfoImpl.getStore() and CoverageInfoImpl.getStore() override ResourceInfo.getStore()
+            // with a cast to their concrete store type. If the store reference is still an unresolved
+            // ResolvingProxy (e.g. due to a parallel loading race), that cast throws ClassCastException.
+            // This is a logging helper only, so we swallow the exception rather than propagating it.
+            StoreInfo store = null;
+            try {
+                store = resource.getStore();
+            } catch (ClassCastException e) {
+                LOGGER.log(Level.FINE, "Could not determine parent store for {0} during catalog loading", baseName);
+            }
             parent = store != null ? store.getWorkspace().getName() + "/" + store.getName() : null;
         } else if (info instanceof StoreInfo store) {
             parent = store.getWorkspace() != null ? store.getWorkspace().getName() : null;

--- a/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/datadir/CatalogLoader.java
@@ -30,6 +30,7 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
 import org.geoserver.catalog.impl.ResolvingProxy;
+import org.geoserver.catalog.impl.ResourceInfoImpl;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.config.GeoServerInfo;
@@ -414,18 +415,13 @@ class CatalogLoader {
         String parent = null;
         if (info instanceof LayerInfo layer) {
             parent = layer.getResource() != null ? layer.getResource().prefixedName() : null;
-        } else if (info instanceof ResourceInfo resource) {
-            // WMSLayerInfoImpl.getStore() and CoverageInfoImpl.getStore() override ResourceInfo.getStore()
-            // with a cast to their concrete store type. If the store reference is still an unresolved
-            // ResolvingProxy (e.g. due to a parallel loading race), that cast throws ClassCastException.
-            // This is a logging helper only, so we swallow the exception rather than propagating it.
-            StoreInfo store = null;
-            try {
-                store = resource.getStore();
-            } catch (ClassCastException e) {
-                LOGGER.log(Level.FINE, "Could not determine parent store for {0} during catalog loading", baseName);
+        } else if (info instanceof ResourceInfoImpl impl) {
+            StoreInfo store = impl.rawStore();
+            if (store != null && ResolvingProxy.getRef(store) == null) {
+                parent = store.getWorkspace().getName() + "/" + store.getName();
+            } else {
+                parent = "unresolved proxy";
             }
-            parent = store != null ? store.getWorkspace().getName() + "/" + store.getName() : null;
         } else if (info instanceof StoreInfo store) {
             parent = store.getWorkspace() != null ? store.getWorkspace().getName() : null;
         } else if (info instanceof StyleInfo style) {

--- a/src/main/src/test/java/org/geoserver/config/datadir/DataDirectoryGeoServerLoaderTest.java
+++ b/src/main/src/test/java/org/geoserver/config/datadir/DataDirectoryGeoServerLoaderTest.java
@@ -40,6 +40,7 @@ import org.geoserver.catalog.Predicates;
 import org.geoserver.catalog.ResourceInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.catalog.impl.CatalogImpl;
@@ -47,6 +48,7 @@ import org.geoserver.catalog.impl.DataStoreInfoImpl;
 import org.geoserver.catalog.impl.LayerGroupInfoImpl;
 import org.geoserver.catalog.impl.ModificationProxy;
 import org.geoserver.catalog.impl.StyleInfoImpl;
+import org.geoserver.catalog.impl.WMSLayerInfoImpl;
 import org.geoserver.catalog.impl.WMSStoreInfoImpl;
 import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geoserver.catalog.util.CloseableIterator;
@@ -668,6 +670,54 @@ public class DataDirectoryGeoServerLoaderTest extends GeoServerSystemTestSupport
         assertEquals(RESOURCE, styles.get("default_raster.sld").getType());
         assertEquals(RESOURCE, styles.get(StyleInfo.DEFAULT_GENERIC + ".xml").getType());
         assertEquals(RESOURCE, styles.get("default_generic.sld").getType());
+    }
+
+    /**
+     * Regression test for GEOS-12023: CatalogLoader.describe() calls resource.getStore(), which subclasses like
+     * WMSLayerInfoImpl and CoverageInfoImpl override with a type-specific cast. If the store reference is an unresolved
+     * ResolvingProxy (e.g. when the store ID can't be matched during parallel catalog loading), that cast throws
+     * ClassCastException. This exception escapes the try-catch in doAddToCatalog because the SEVERE failure-log lambda
+     * also calls describe(), causing a second throw that is uncaught, propagating fatally through ForkJoin and
+     * preventing GeoServer startup.
+     */
+    @Test
+    public void wmsLayerWithUnresolvableStoreDoesNotCrashLoader() throws Exception {
+        Catalog catalog = getCatalog();
+        WorkspaceInfo ws = support.addWorkspace("wmsRegressionWs");
+
+        // Create a WMS store and a WMS layer resource in the data directory
+        WMSStoreInfoImpl store = support.createWmsStore(ws);
+        catalog.add(store);
+        WMSStoreInfo persistedStore = catalog.getStore(store.getId(), WMSStoreInfo.class);
+
+        WMSLayerInfo wmsResource = catalog.getFactory().createWMSLayer();
+        wmsResource.setName("wmsRegressionLayer");
+        wmsResource.setNativeName("wmsRegressionLayer");
+        wmsResource.setTitle("WMS Regression Layer");
+        wmsResource.setNamespace(catalog.getNamespaceByPrefix(ws.getName()));
+        wmsResource.setStore(persistedStore);
+        catalog.add(wmsResource);
+
+        WMSLayerInfo persistedResource = catalog.getResource(wmsResource.getId(), WMSLayerInfo.class);
+        LayerInfo layer = catalog.getFactory().createLayer();
+        layer.setResource(persistedResource);
+        layer.setDefaultStyle(catalog.getStyleByName(StyleInfo.DEFAULT_RASTER));
+        catalog.add(layer);
+
+        // Overwrite the resource XML with a version pointing to a non-existent store ID.
+        // When the loader reads this file, ResolvingProxy.resolve() returns null for the
+        // unknown store ID, leaving the store field as an unresolved ResolvingProxy typed
+        // as StoreInfo. WMSLayerInfoImpl.getStore() then casts it to WMSStoreInfo, which
+        // throws ClassCastException. Without the fix this exception escapes the catch block
+        // in doAddToCatalog and propagates fatally through ForkJoin, crashing startup.
+        Resource resourceFile = getDataDirectory().config(persistedResource);
+        WMSLayerInfoImpl rawResource = (WMSLayerInfoImpl) ModificationProxy.unwrap(persistedResource);
+        WMSStoreInfoImpl bogusStore = support.createWmsStore(ws);
+        bogusStore.setId("non-existent-store-id");
+        rawResource.setStore(bogusStore);
+        persist(rawResource, resourceFile);
+
+        getLoader().reload();
     }
 
     private void deleteStyle(String infoName, String sldFile) {

--- a/src/main/src/test/java/org/geoserver/config/datadir/DataDirectoryGeoServerLoaderTest.java
+++ b/src/main/src/test/java/org/geoserver/config/datadir/DataDirectoryGeoServerLoaderTest.java
@@ -706,10 +706,10 @@ public class DataDirectoryGeoServerLoaderTest extends GeoServerSystemTestSupport
 
         // Overwrite the resource XML with a version pointing to a non-existent store ID.
         // When the loader reads this file, ResolvingProxy.resolve() returns null for the
-        // unknown store ID, leaving the store field as an unresolved ResolvingProxy typed
-        // as StoreInfo. WMSLayerInfoImpl.getStore() then casts it to WMSStoreInfo, which
-        // throws ClassCastException. Without the fix this exception escapes the catch block
-        // in doAddToCatalog and propagates fatally through ForkJoin, crashing startup.
+        // unknown store ID, leaving the store field as an unresolved ResolvingProxy. Without
+        // the fix, WMSLayerInfoImpl.getStore() casts it to WMSStoreInfo, throwing
+        // ClassCastException that escapes doAddToCatalog and propagates as
+        // IllegalStateException through ForkJoin, crashing GeoServer startup.
         Resource resourceFile = getDataDirectory().config(persistedResource);
         WMSLayerInfoImpl rawResource = (WMSLayerInfoImpl) ModificationProxy.unwrap(persistedResource);
         WMSStoreInfoImpl bogusStore = support.createWmsStore(ws);
@@ -717,7 +717,11 @@ public class DataDirectoryGeoServerLoaderTest extends GeoServerSystemTestSupport
         rawResource.setStore(bogusStore);
         persist(rawResource, resourceFile);
 
-        getLoader().reload();
+        // Use an isolated loader so we only exercise the WMS layer path, not the full catalog.
+        // Without the fix this throws IllegalStateException caused by ClassCastException.
+        DataDirectoryGeoServerLoader loader = newLoader();
+        CatalogImpl newCatalog = new CatalogImpl();
+        loader.postProcessBeforeInitialization(newCatalog, "catalog");
     }
 
     private void deleteStyle(String infoName, String sldFile) {


### PR DESCRIPTION
[![GEOS-12104](https://badgen.net/badge/JIRA/GEOS-12104/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12104) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Note: I created a Jira account to file a bug report but am blocked with an "You are not authorized to perform this operation. Please log in." error message, similar to https://discourse.osgeo.org/t/cannot-create-a-jira-account-to-log-a-geoserver-geotools-issue/148684/4

## Problem

Upgrading from 2.27.3 to 2.28.3 causes GeoServer to fail startup entirely when WMS cascade layers or Coverage layers exist in the data directory, with the following error:

  RuntimeException: IllegalStateException: ExecutionException: ClassCastException:
  $ProxyN cannot be cast to WMSStoreInfo (or CoverageStoreInfo)

This is a regression introduced by the developer logging added in GEOS-12023.

Disabling Parallel Loading with `GEOSERVER_DATA_DIR_LOADER_ENABLED` = false is a workaround.

## Root Cause

Two bugs interact:

**1.** `CatalogLoader.describe()` (added in GEOS-12023) calls `resource.getStore()` to  build a log message. `WMSLayerInfoImpl.getStore()` and `CoverageInfoImpl.getStore()` override `ResourceInfo.getStore()` with a type-specific cast:

    return (WMSStoreInfo) super.getStore();

If the store field is still an unresolved `ResolvingProxy` — which happens during parallel catalog loading when the store ID cannot be matched in the catalog — that cast throws `ClassCastException`. This is the same pitfall already documented
in `ResolvingProxyResolver` (line ~270): *"gotta use rawStore() cause the subclasses will override getStore() with a cast to their concrete store types that will fail when the store is a ResolvingProxy".*

**2.** The `ClassCastException` thrown by the CONFIG-level success-log lambda inside `doAddToCatalog()` is caught correctly. However, the SEVERE failure-log lambda *also* calls `describe()`, throwing a *second* `ClassCastException` from inside the catch
block. This second exception is uncaught and propagates through `ForkJoinTask.get()` as an `ExecutionException`, wrapped in `IllegalStateException`, wrapped in `RuntimeException`, preventing the `rawCatalog` Spring bean from initializing.

## Fix

Wrap `resource.getStore()` in `describe()` with a `ClassCastException` catch. `describe()` is a logging helper only and must never propagate exceptions.

## Testing

Added regression test `wmsLayerWithUnresolvableStoreDoesNotCrashLoader` in `DataDirectoryGeoServerLoaderTest`. The test creates a WMS store and layer, then overwrites the resource XML with a bogus store ID to reliably reproduce the
unresolved-proxy condition. Verified the test fails without the fix and passes with it.

Fixes GEOS-12104
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 