### PR TITLE
[GEOS-12118] ReprojectingFeatureCollection can fail with ClassCastException while inserting CompoundCurve via WFS-T

### DIFF
--- a/src/main/src/main/java/org/geoserver/feature/ReprojectingFeatureCollection.java
+++ b/src/main/src/main/java/org/geoserver/feature/ReprojectingFeatureCollection.java
@@ -223,7 +223,10 @@ public class ReprojectingFeatureCollection extends DecoratingSimpleFeatureCollec
 
             if (object instanceof Geometry geometry) {
                 // check for crs
-                CoordinateReferenceSystem crs = (CoordinateReferenceSystem) geometry.getUserData();
+                CoordinateReferenceSystem crs = null;
+                if (geometry.getUserData() instanceof CoordinateReferenceSystem) {
+                    crs = (CoordinateReferenceSystem) geometry.getUserData();
+                }
 
                 if (crs == null) {
                     // no crs specified on geometry, check default

--- a/src/wfs-core/src/test/java/org/geoserver/wfs/AbstractTransactionCurveTest.java
+++ b/src/wfs-core/src/test/java/org/geoserver/wfs/AbstractTransactionCurveTest.java
@@ -11,19 +11,24 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import javax.xml.namespace.QName;
 import org.apache.commons.io.IOUtils;
 import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.feature.ReprojectingFeatureCollection;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.data.DataUtilities;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.geometry.jts.CircularArc;
 import org.geotools.geometry.jts.CircularRing;
 import org.geotools.geometry.jts.CircularString;
+import org.geotools.geometry.jts.CompoundCurve;
 import org.geotools.geometry.jts.CompoundCurvedGeometry;
 import org.geotools.geometry.jts.CurvedGeometries;
 import org.geotools.geometry.jts.SingleCurvedGeometry;
@@ -90,6 +95,47 @@ public abstract class AbstractTransactionCurveTest extends WFSCurvesTestSupport 
         assertEquals(2, ls2.getNumPoints());
         assertEquals(new Coordinate(20, 51), ls2.getCoordinateN(0));
         assertEquals(new Coordinate(10, 51), ls2.getCoordinateN(1));
+    }
+
+    @Test
+    public void testInsertCompoundCurve() throws Exception {
+        String xml = IOUtils.toString(getClass().getResourceAsStream("insertCompoundCurve.xml"), UTF_8);
+        Document dom = postAsDOM("wfs", xml);
+
+        checkSuccesfulTransaction(dom, 1, 0, 0);
+
+        SimpleFeature first = getSingleFeature(CURVELINES, "Compound inserted");
+
+        Geometry g = (Geometry) first.getDefaultGeometry();
+        assertNotNull(g);
+        assertTrue(g instanceof CompoundCurvedGeometry<?>);
+        CompoundCurvedGeometry<?> compound = (CompoundCurvedGeometry<?>) g;
+        List<LineString> components = compound.getComponents();
+        assertEquals(3, components.size());
+
+        LineString ls1 = components.get(0);
+        assertEquals(2, ls1.getNumPoints());
+        assertEquals(new Coordinate(10, 45), ls1.getCoordinateN(0));
+        assertEquals(new Coordinate(20, 45), ls1.getCoordinateN(1));
+
+        CircularString cs = (CircularString) components.get(1);
+        assertArrayEquals(new double[] {20.0, 45.0, 23.0, 48.0, 20.0, 51.0}, cs.getControlPoints(), 0d);
+
+        LineString ls2 = components.get(2);
+        assertEquals(2, ls2.getNumPoints());
+        assertEquals(new Coordinate(20, 51), ls2.getCoordinateN(0));
+        assertEquals(new Coordinate(10, 51), ls2.getCoordinateN(1));
+
+        g.setUserData(new HashMap<>());
+
+        SimpleFeatureCollection collection = DataUtilities.collection(first);
+        ReprojectingFeatureCollection reprojected = new ReprojectingFeatureCollection(
+                collection, collection.getSchema().getCoordinateReferenceSystem());
+        try (SimpleFeatureIterator features = reprojected.features()) {
+            assertTrue(features.hasNext());
+            Geometry reprojectedGeometry = (Geometry) features.next().getDefaultGeometry();
+            assertTrue(reprojectedGeometry instanceof CompoundCurve);
+        }
     }
 
     @Test

--- a/src/wfs1_x/src/test/java/org/geoserver/wfs/v1_1/insertCompoundCurve.xml
+++ b/src/wfs1_x/src/test/java/org/geoserver/wfs/v1_1/insertCompoundCurve.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<wfs:Transaction service="WFS" version="1.1.0"
+  xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml"
+  xmlns:cite="http://www.opengis.net/cite">
+  <wfs:Insert>
+    <cite:curvelines fid="cp.5">
+      <cite:geom>
+        <gml:Curve srsName="urn:x-ogc:def:crs:EPSG:4326" srsDimension="2">
+          <gml:segments>
+            <gml:LineStringSegment interpolation="linear">
+              <gml:posList>45 10 45 20</gml:posList>
+            </gml:LineStringSegment>
+            <gml:ArcString interpolation="circularArc3Points">
+              <gml:posList>45 20 48 23 51 20</gml:posList>
+            </gml:ArcString>
+            <gml:LineStringSegment interpolation="linear">
+              <gml:posList>51 20 51 10</gml:posList>
+            </gml:LineStringSegment>
+          </gml:segments>
+        </gml:Curve>
+      </cite:geom>
+      <name>Compound inserted</name>
+    </cite:curvelines>
+  </wfs:Insert>
+</wfs:Transaction>

--- a/src/wfs2_x/src/test/java/org/geoserver/wfs/v2_0/insertCompoundCurve.xml
+++ b/src/wfs2_x/src/test/java/org/geoserver/wfs/v2_0/insertCompoundCurve.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<wfs:Transaction service="WFS" version="2.0.0"
+  xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:gml="http://www.opengis.net/gml/3.2"
+  xmlns:cite="http://www.opengis.net/cite">
+  <wfs:Insert>
+    <cite:curvelines fid="cp.5">
+      <cite:geom>
+        <gml:Curve srsName="urn:x-ogc:def:crs:EPSG:4326" srsDimension="2">
+          <gml:segments>
+            <gml:LineStringSegment interpolation="linear">
+              <gml:posList>45 10 45 20</gml:posList>
+            </gml:LineStringSegment>
+            <gml:ArcString interpolation="circularArc3Points">
+              <gml:posList>45 20 48 23 51 20</gml:posList>
+            </gml:ArcString>
+            <gml:LineStringSegment interpolation="linear">
+              <gml:posList>51 20 51 10</gml:posList>
+            </gml:LineStringSegment>
+          </gml:segments>
+        </gml:Curve>
+      </cite:geom>
+      <name>Compound inserted</name>
+    </cite:curvelines>
+  </wfs:Insert>
+</wfs:Transaction>


### PR DESCRIPTION
[![GEOS-12118](https://badgen.net/badge/JIRA/GEOS-12118/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12118) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->

This fix addres a bug that happen when trying to insert a compound curve (with the column type set as org.geotools.geometry.jts.CompoundCurve) with the WFS, this issue was causing a error leading to the failure of the request. Geoserver was throwing this error:

> Insert error: class java.util.HashMap cannot be cast to class org.geotools.api.referencing.crs.CoordinateReferenceSystem (java.util.HashMap is in module java.base of loader 'bootstrap'; org.geotools.api.referencing.crs.CoordinateReferenceSystem is in unnamed module of loader org.eclipse.jetty.webapp.WebAppClassLoader @2d2fe68a)

And in the stack trace this line was present:

> at org.geoserver.feature.ReprojectingFeatureCollection.reproject(ReprojectingFeatureCollection.java:226)

So I have copied from _src/wfs-core/src/main/java/org/geoserver/wfs/UpdateElementHandler.java_  line 286 where there is a if statement for checking if the crs was a instance of CoordinateReferenceSystem, and it worked. Leaving the crs null, which was a case already handled by a if condition right after the line I have changed.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 