### PR TITLE
Remove wicket-tester version override from all modules

### DIFF
--- a/src/community/features-templating/features-templating-web/pom.xml
+++ b/src/community/features-templating/features-templating-web/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/graticule/pom.xml
+++ b/src/community/graticule/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/gwc-azure-blob/pom.xml
+++ b/src/community/gwc-azure-blob/pom.xml
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/community/gwc-gcs-blob/pom.xml
+++ b/src/community/gwc-gcs-blob/pom.xml
@@ -85,7 +85,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/gwc-sqlite/pom.xml
+++ b/src/community/gwc-sqlite/pom.xml
@@ -29,7 +29,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/jms-cluster/jms-geoserver/pom.xml
+++ b/src/community/jms-cluster/jms-geoserver/pom.xml
@@ -60,7 +60,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/community/jwt-headers/gs-jwt-headers/pom.xml
+++ b/src/community/jwt-headers/gs-jwt-headers/pom.xml
@@ -53,7 +53,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/community/mbtiles/pom.xml
+++ b/src/community/mbtiles/pom.xml
@@ -103,7 +103,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/ncwms/pom.xml
+++ b/src/community/ncwms/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/ogcapi/dggs/web-dggs/pom.xml
+++ b/src/community/ogcapi/dggs/web-dggs/pom.xml
@@ -29,7 +29,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/oseo/web-oseo/pom.xml
+++ b/src/community/oseo/web-oseo/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/proxy-base-ext/pom.xml
+++ b/src/community/proxy-base-ext/pom.xml
@@ -34,7 +34,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/smart-data-loader/pom.xml
+++ b/src/community/smart-data-loader/pom.xml
@@ -79,7 +79,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/solr/pom.xml
+++ b/src/community/solr/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/taskmanager/core/pom.xml
+++ b/src/community/taskmanager/core/pom.xml
@@ -95,7 +95,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/community/web-service-auth/pom.xml
+++ b/src/community/web-service-auth/pom.xml
@@ -30,7 +30,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/css/pom.xml
+++ b/src/extension/css/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/extension/csw/web-csw/pom.xml
+++ b/src/extension/csw/web-csw/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/geofence/geofence-server/pom.xml
+++ b/src/extension/geofence/geofence-server/pom.xml
@@ -170,7 +170,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/extension/geofence/geofence/pom.xml
+++ b/src/extension/geofence/geofence/pom.xml
@@ -92,7 +92,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/extension/geopkg-output/wms/pom.xml
+++ b/src/extension/geopkg-output/wms/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/grib/pom.xml
+++ b/src/extension/grib/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <!-- Test dependencies -->

--- a/src/extension/gwc-s3/pom.xml
+++ b/src/extension/gwc-s3/pom.xml
@@ -40,7 +40,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/extension/importer/web/pom.xml
+++ b/src/extension/importer/web/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/extension/inspire/pom.xml
+++ b/src/extension/inspire/pom.xml
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/mapml/pom.xml
+++ b/src/extension/mapml/pom.xml
@@ -101,7 +101,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/mbstyle/pom.xml
+++ b/src/extension/mbstyle/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/extension/metadata/pom.xml
+++ b/src/extension/metadata/pom.xml
@@ -27,7 +27,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/netcdf-out/pom.xml
+++ b/src/extension/netcdf-out/pom.xml
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/netcdf/pom.xml
+++ b/src/extension/netcdf/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/ogcapi/web-ogcapi/pom.xml
+++ b/src/extension/ogcapi/web-ogcapi/pom.xml
@@ -25,7 +25,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/params-extractor/pom.xml
+++ b/src/extension/params-extractor/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/extension/printing/pom.xml
+++ b/src/extension/printing/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/rat/pom.xml
+++ b/src/extension/rat/pom.xml
@@ -43,7 +43,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/wcs2_0-eo/web/pom.xml
+++ b/src/extension/wcs2_0-eo/web/pom.xml
@@ -28,7 +28,6 @@ application directory.
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/web-resource/pom.xml
+++ b/src/extension/web-resource/pom.xml
@@ -26,7 +26,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/extension/wmts-multi-dimensional/pom.xml
+++ b/src/extension/wmts-multi-dimensional/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/wps-download/pom.xml
+++ b/src/extension/wps-download/pom.xml
@@ -77,7 +77,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/extension/wps/web-wps/pom.xml
+++ b/src/extension/wps/web-wps/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/web/demo/pom.xml
+++ b/src/web/demo/pom.xml
@@ -54,7 +54,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/web/gwc/pom.xml
+++ b/src/web/gwc/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/web/rest/pom.xml
+++ b/src/web/rest/pom.xml
@@ -37,7 +37,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/web/security/core/pom.xml
+++ b/src/web/security/core/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/web/security/jdbc/pom.xml
+++ b/src/web/security/jdbc/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/web/security/ldap/pom.xml
+++ b/src/web/security/ldap/pom.xml
@@ -53,7 +53,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/web/wcs/pom.xml
+++ b/src/web/wcs/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <!--  test dependecies -->

--- a/src/web/wfs/pom.xml
+++ b/src/web/wfs/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/web/wms/pom.xml
+++ b/src/web/wms/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-tester</artifactId>
-      <version>10.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
We should rely on dependencyManagment in the main POM file.
See: https://github.com/geoserver/geoserver/pull/9458


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.