### PR TITLE
[Backport 2.28.x][GEOS-12105] DiskQuotaConfigPanel: expose JDBCConfiguration.schema in the UI

### DIFF
--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/DiskQuotaConfigPanel.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/DiskQuotaConfigPanel.html
@@ -44,6 +44,10 @@
 	          <select class="text" id="dialectChooser" wicket:id="dialectChooser"></select>
             </li>
             <li>
+	          <label for="schema"><wicket:message key="jdbcQuotaSchema">database schema:</wicket:message></label>
+	          <input type="text" class="text" id="schema" wicket:id="schema" />
+            </li>
+            <li>
 	          <label for="connectionTypeChooser"><wicket:message key="connectionTypeChooser">connectionType:</wicket:message></label>
 	          <select class="text" id="connectionTypeChooser" wicket:id="connectionTypeChooser"></select>
             </li>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/DiskQuotaConfigPanel.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/diskquota/DiskQuotaConfigPanel.java
@@ -154,6 +154,12 @@ public class DiskQuotaConfigPanel extends Panel {
         dialectChooser.setRequired(true);
         jdbcContainer.add(dialectChooser);
 
+        // Optional database schema for the quota store tables. Honored by
+        // JDBCQuotaStoreFactory#getJDBCStore -> JDBCQuotaStore#setSchema.
+        IModel<String> schemaModel = new PropertyModel<>(jdbcQuotaConfigModel, "schema");
+        TextField<String> schema = new TextField<>("schema", schemaModel);
+        jdbcContainer.add(schema);
+
         // add a chooser for the connection type
         List<String> connectionTypes = Arrays.asList("JNDI", "PRIVATE_POOL");
         Model<String> connectionTypeModel = new Model<>();

--- a/src/web/gwc/src/main/resources/GeoServerApplication.properties
+++ b/src/web/gwc/src/main/resources/GeoServerApplication.properties
@@ -76,6 +76,7 @@ DiskQuotaConfigPanel.cleanUpLastRun=(Last run: ${x} ${timeUnit} ago.)
 DiskQuotaConfigPanel.cleanUpLastRunNever=(Quota limit has not been exceeded since server start up)
 DiskQuotaConfigPanel.diskQuotaStore = Disk quota store type
 DiskQuotaConfigPanel.jdbcQuotaDialect = Target database type
+DiskQuotaConfigPanel.jdbcQuotaSchema = Database schema (optional)
 DiskQuotaConfigPanel.connectionTypeChooser = JDBC data source
 DiskQuotaConfigPanel.jndiLocation = JNDI data source location
 DiskQuotaConfigPanel.H2 = In process database (H2)


### PR DESCRIPTION
[![GEOS-12105](https://badgen.net/badge/JIRA/GEOS-12105/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12105) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Backport #9484 to 2.28.x

JDBCConfiguration.schema is already honored by JDBCQuotaStoreFactory, but the JDBC quota store section of the disk quota panel had no input for it. Datadir users now have a UI path to target a non-public schema for the quota store tables.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 