### PR TITLE
Remove gs.version, preferring instead project.version

### DIFF
--- a/src/community/dds/pom.xml
+++ b/src/community/dds/pom.xml
@@ -86,13 +86,13 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms1_1</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms1_1</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/elasticsearch/pom.xml
+++ b/src/community/elasticsearch/pom.xml
@@ -39,14 +39,14 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/src/community/gdal/gdal-wcs/pom.xml
+++ b/src/community/gdal/gdal-wcs/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogr-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/src/community/gdal/gdal-wps/pom.xml
+++ b/src/community/gdal/gdal-wps/pom.xml
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-gdal-wcs</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-gdal-wcs</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/gpxppio/pom.xml
+++ b/src/community/gpxppio/pom.xml
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/graticule/pom.xml
+++ b/src/community/graticule/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/gsr/pom.xml
+++ b/src/community/gsr/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms1_1</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/community/gwc-azure-blob/pom.xml
+++ b/src/community/gwc-azure-blob/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/gwc-mbtiles/pom.xml
+++ b/src/community/gwc-mbtiles/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/gwc-sqlite/pom.xml
+++ b/src/community/gwc-sqlite/pom.xml
@@ -45,14 +45,14 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms1_1</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/importer-jdbc/pom.xml
+++ b/src/community/importer-jdbc/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.geoserver.importer</groupId>
       <artifactId>gs-importer-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
@@ -24,19 +24,19 @@
     <dependency>
       <groupId>org.geoserver.importer</groupId>
       <artifactId>gs-importer-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.importer</groupId>
       <artifactId>gs-importer-rest</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.importer</groupId>
       <artifactId>gs-importer-rest</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/mbtiles/pom.xml
+++ b/src/community/mbtiles/pom.xml
@@ -134,7 +134,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms1_1</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- TODO WICKET8 - this fix isn't WICKET8 specific -->

--- a/src/community/ncwms/pom.xml
+++ b/src/community/ncwms/pom.xml
@@ -98,19 +98,19 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms1_1</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms1_3</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/community/ogcapi/dggs/dggs-core/pom.xml
+++ b/src/community/ogcapi/dggs/dggs-core/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/community/ogcapi/dggs/dggs-rhealpix/pom.xml
+++ b/src/community/ogcapi/dggs/dggs-rhealpix/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-ows</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>

--- a/src/community/ogcapi/dggs/ogcapi-dggs-assembly/pom.xml
+++ b/src/community/ogcapi/dggs/ogcapi-dggs-assembly/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/community/ogcapi/dggs/web-dggs/pom.xml
+++ b/src/community/ogcapi/dggs/web-dggs/pom.xml
@@ -39,50 +39,50 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-ogcapi-dggs</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogcapi-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-ogcapi-dggs</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-web-ogcapi</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms1_1</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/community/ogcapi/ogcapi-3d-geovolumes-assembly/pom.xml
+++ b/src/community/ogcapi/ogcapi-3d-geovolumes-assembly/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/community/ogcapi/ogcapi-3d-geovolumes/pom.xml
+++ b/src/community/ogcapi/ogcapi-3d-geovolumes/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogcapi-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/ogcapi/ogcapi-coverages-assembly/pom.xml
+++ b/src/community/ogcapi/ogcapi-coverages-assembly/pom.xml
@@ -31,13 +31,13 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-web-coverages</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/community/ogcapi/ogcapi-images-assembly/pom.xml
+++ b/src/community/ogcapi/ogcapi-images-assembly/pom.xml
@@ -31,13 +31,13 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-web-images</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/community/ogcapi/ogcapi-maps-assembly/pom.xml
+++ b/src/community/ogcapi/ogcapi-maps-assembly/pom.xml
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-web-maps</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/community/ogcapi/ogcapi-processes-assembly/pom.xml
+++ b/src/community/ogcapi/ogcapi-processes-assembly/pom.xml
@@ -31,13 +31,13 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-web-processes</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/community/ogcapi/ogcapi-styles-assembly/pom.xml
+++ b/src/community/ogcapi/ogcapi-styles-assembly/pom.xml
@@ -31,13 +31,13 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-web-styles</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/community/ogcapi/ogcapi-tiles-assembly/pom.xml
+++ b/src/community/ogcapi/ogcapi-tiles-assembly/pom.xml
@@ -31,13 +31,13 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-web-tiles</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/community/ogcapi/ogcapi-tiles/pom.xml
+++ b/src/community/ogcapi/ogcapi-tiles/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-wms1_1</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/src/community/ogcapi/web-3d-geovolumes/pom.xml
+++ b/src/community/ogcapi/web-3d-geovolumes/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-ogcapi-3d-geovolumes</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/src/community/ogcapi/web-coverages/pom.xml
+++ b/src/community/ogcapi/web-coverages/pom.xml
@@ -16,19 +16,19 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-web-ogcapi</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-ogcapi-coverages</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/src/community/ogcapi/web-images/pom.xml
+++ b/src/community/ogcapi/web-images/pom.xml
@@ -17,19 +17,19 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-web-ogcapi</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-ogcapi-images</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/src/community/ogcapi/web-maps/pom.xml
+++ b/src/community/ogcapi/web-maps/pom.xml
@@ -17,19 +17,19 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-web-ogcapi</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-ogcapi-maps</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/src/community/ogcapi/web-processes/pom.xml
+++ b/src/community/ogcapi/web-processes/pom.xml
@@ -17,25 +17,25 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-web-wps</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-web-ogcapi</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-ogcapi-processes</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/src/community/ogcapi/web-styles/pom.xml
+++ b/src/community/ogcapi/web-styles/pom.xml
@@ -17,19 +17,19 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-web-ogcapi</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-ogcapi-styles</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/src/community/ogcapi/web-tiles/pom.xml
+++ b/src/community/ogcapi/web-tiles/pom.xml
@@ -17,19 +17,19 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-web-ogcapi</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-ogcapi-tiles</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/src/community/oseo/oseo-assembly/pom.xml
+++ b/src/community/oseo/oseo-assembly/pom.xml
@@ -18,27 +18,27 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-service</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-rest</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-stac</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-web-oseo</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/community/oseo/oseo-core/pom.xml
+++ b/src/community/oseo/oseo-core/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-features-templating-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>

--- a/src/community/oseo/oseo-integration-tests/pom.xml
+++ b/src/community/oseo/oseo-integration-tests/pom.xml
@@ -51,13 +51,13 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogcapi-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
     </dependency>
     <dependency>

--- a/src/community/oseo/oseo-rest/pom.xml
+++ b/src/community/oseo/oseo-rest/pom.xml
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-service</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
@@ -54,14 +54,14 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-service</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/oseo/oseo-service/pom.xml
+++ b/src/community/oseo/oseo-service/pom.xml
@@ -23,22 +23,22 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs1_x</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/oseo/oseo-stac/pom.xml
+++ b/src/community/oseo/oseo-stac/pom.xml
@@ -23,17 +23,17 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogcapi-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-features-templating-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -64,14 +64,14 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogcapi-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/oseo/web-oseo/pom.xml
+++ b/src/community/oseo/web-oseo/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-service</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.web</groupId>
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-oseo-service</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/security/oidc/oidc-web/pom.xml
+++ b/src/community/security/oidc/oidc-web/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/src/community/smart-data-loader/pom.xml
+++ b/src/community/smart-data-loader/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-app-schema-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/solr/pom.xml
+++ b/src/community/solr/pom.xml
@@ -38,14 +38,14 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/src/community/vector-mosaic/vector-mosaic-assembly/pom.xml
+++ b/src/community/vector-mosaic/vector-mosaic-assembly/pom.xml
@@ -17,12 +17,12 @@
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-vector-mosaic-rest</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-web-vector-mosaic</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/community/vector-mosaic/vector-mosaic-rest/pom.xml
+++ b/src/community/vector-mosaic/vector-mosaic-rest/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/community/wps-download-netcdf/pom.xml
+++ b/src/community/wps-download-netcdf/pom.xml
@@ -17,37 +17,37 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-netcdf-out</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-download</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-download</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/extension/app-schema/app-schema-geopkg-test/pom.xml
+++ b/src/extension/app-schema/app-schema-geopkg-test/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-app-schema-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-mongo-test/pom.xml
+++ b/src/extension/app-schema/app-schema-mongo-test/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-mongodb</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-oracle-test/pom.xml
+++ b/src/extension/app-schema/app-schema-oracle-test/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-app-schema-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-postgis-test/pom.xml
+++ b/src/extension/app-schema/app-schema-postgis-test/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-app-schema-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/app-schema/app-schema-test/pom.xml
+++ b/src/extension/app-schema/app-schema-test/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-app-schema-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>

--- a/src/extension/excel-wfs/pom.xml
+++ b/src/extension/excel-wfs/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-excel-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/src/extension/excel-wps/pom.xml
+++ b/src/extension/excel-wps/pom.xml
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-excel-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/extension/feature-pregeneralized/pom.xml
+++ b/src/extension/feature-pregeneralized/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/extension/gwc-s3/pom.xml
+++ b/src/extension/gwc-s3/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-wms-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/extension/mapml/pom.xml
+++ b/src/extension/mapml/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-demo</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
@@ -155,7 +155,7 @@
         <dependency>
           <groupId>org.geoserver.web</groupId>
           <artifactId>gs-web-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
@@ -174,7 +174,7 @@
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-wfs-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/extension/ogcapi/web-features/pom.xml
+++ b/src/extension/ogcapi/web-features/pom.xml
@@ -17,19 +17,19 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-web-ogcapi</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogcapi-features</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <!--scope>compile</scope-->
     </dependency>
 

--- a/src/extension/ogr/ogr-wfs/pom.xml
+++ b/src/extension/ogr/ogr-wfs/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogr-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/src/extension/ogr/ogr-wps/pom.xml
+++ b/src/extension/ogr/ogr-wps/pom.xml
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogr-wfs</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
@@ -47,7 +47,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-ogr-wfs</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
@@ -60,7 +60,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-wps-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/extension/printing/pom.xml
+++ b/src/extension/printing/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>xerces</groupId>

--- a/src/extension/rat/pom.xml
+++ b/src/extension/rat/pom.xml
@@ -19,17 +19,17 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
@@ -69,21 +69,21 @@
         <dependency>
           <groupId>org.geoserver.web</groupId>
           <artifactId>gs-web-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-main</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-restconfig</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/extension/wps-download/pom.xml
+++ b/src/extension/wps-download/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-wps-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/extension/wps-jdbc/pom.xml
+++ b/src/extension/wps-jdbc/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
@@ -67,7 +67,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-wps-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/extension/wps/web-wps/pom.xml
+++ b/src/extension/wps/web-wps/pom.xml
@@ -41,12 +41,12 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-demo</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-sec-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.wicket</groupId>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
@@ -87,21 +87,21 @@
         <dependency>
           <groupId>org.geoserver.web</groupId>
           <artifactId>gs-web-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-main</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-wps-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/extension/wps/wps-cluster-hazelcast/pom.xml
+++ b/src/extension/wps/wps-cluster-hazelcast/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.hazelcast</groupId>
@@ -47,14 +47,14 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-wps-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-main</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/extension/wps/wps-core/pom.xml
+++ b/src/extension/wps/wps-core/pom.xml
@@ -23,22 +23,22 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs1_x</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs2_x</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wcs2_0</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools.ogc</groupId>
@@ -133,13 +133,13 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wcs1_0</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wcs1_1</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -173,21 +173,21 @@
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-main</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-platform</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-wcs2_0</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/extension/wps/wps-kml-ppio/pom.xml
+++ b/src/extension/wps/wps-kml-ppio/pom.xml
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-kml</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools.xsd</groupId>

--- a/src/extension/ysld/pom.xml
+++ b/src/extension/ysld/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-gwc</artifactId>
-      <version>${gs.version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/gwc-rest/pom.xml
+++ b/src/gwc-rest/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
           <groupId>org.geoserver</groupId>
           <artifactId>gs-gwc</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -94,7 +94,6 @@
     <!-- ================================ -->
     <!-- Project version management       -->
     <!-- ================================ -->
-    <gs.version>3.0.0-SNAPSHOT</gs.version>
     <gt.version>35-SNAPSHOT</gt.version>
     <gwc.version>2.0-SNAPSHOT</gwc.version>
     <spring.version>7.0.7</spring.version>
@@ -252,156 +251,156 @@
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-platform</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-platform</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-ows</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-ows</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-main</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-main</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-theme</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wcs</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-wcs1_0</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-wcs1_1</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wcs2_0</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wcs2_0</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wfs-core</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wfs-core</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wfs1_x</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wfs2_x</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wfs2_x</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wms-core</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wms1_1</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wms1_3</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wms-gml</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wms-core</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wms1_1</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-wms1_3</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-gwc</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-gwc-rest</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver</groupId>
         <artifactId>gs-rest</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver.web</groupId>
         <artifactId>gs-web-core</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.geoserver.extension</groupId>
         <artifactId>gs-kml</artifactId>
-        <version>${gs.version}</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -894,7 +894,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-netcdf</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1710,27 +1710,27 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-cog-core</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-cog-azure</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-cog-google</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-cog-http</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-cog-s3</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1740,7 +1740,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-cov-json</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1765,7 +1765,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-web-service-auth</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1795,7 +1795,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-libdeflate</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1838,7 +1838,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-wps-longitudinal-profile</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1848,7 +1848,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-rat</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1858,7 +1858,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-wfs-freemarker</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1868,7 +1868,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-acl-plugin</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1878,7 +1878,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-geoparquet</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1888,7 +1888,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-wps-download-netcdf</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1898,7 +1898,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-singlestore</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1908,7 +1908,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-duckdb</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -1928,7 +1928,7 @@
         <dependency>
           <groupId>org.geoserver.community</groupId>
           <artifactId>wps-openai</artifactId>
-          <version>${gs.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
The maven build system presently uses `gs.version` and `project.version` interchangeably leading to trouble if `pom.xml` does not keep these two values exactly in sync.

This PR removes `gs.version` to prevent possibility of error.

This is a non functional build change

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.