### PR TITLE
feat(oidc): Move "Log Sensitive Information" checkbox to common parameters section

### DIFF
--- a/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginAuthProviderPanel.html
+++ b/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginAuthProviderPanel.html
@@ -58,6 +58,15 @@
                         <a href="#" wicket:id="enableResourceServerModeHelp" class="help-link"></a>
                      </label>
                   </div>
+                  <div class="choiceItem">
+                     <input id="oidcAllowUnSecureLogging" wicket:id="oidcAllowUnSecureLogging" type="checkbox" />
+                     <label for="oidcAllowUnSecureLogging">
+                        <span>
+                           <wicket:message key="oidcAllowUnSecureLogging"></wicket:message>
+                        </span>
+                        <a href="#" wicket:id="oidcAllowUnSecureLoggingHelp" class="help-link"></a>
+                     </label>
+                  </div>
                </div>
             </fieldset>
          </div>
@@ -263,15 +272,6 @@
                                     <wicket:message key="oidcUsePKCE"></wicket:message>
                                  </span>
                                  <a href="#" wicket:id="oidcUsePKCEHelp" class="help-link"></a>
-                              </label>
-                           </div>
-                           <div class="choiceItem">
-                              <input id="oidcAllowUnSecureLogging" wicket:id="oidcAllowUnSecureLogging" type="checkbox" />
-                              <label for="oidcAllowUnSecureLogging">
-                                 <span>
-                                    <wicket:message key="oidcAllowUnSecureLogging"></wicket:message>
-                                 </span>
-                                 <a href="#" wicket:id="oidcAllowUnSecureLoggingHelp" class="help-link"></a>
                               </label>
                            </div>
                         </div>

--- a/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginAuthProviderPanel.java
+++ b/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginAuthProviderPanel.java
@@ -347,6 +347,9 @@ public class OAuth2LoginAuthProviderPanel
         add(new HelpLink("enableResourceServerModeHelp", this).setDialog(dialog));
         add(new CheckBox("enableResourceServerMode"));
 
+        add(new HelpLink("oidcAllowUnSecureLoggingHelp", this).setDialog(dialog));
+        add(new CheckBox("oidcAllowUnSecureLogging"));
+
         add(new HelpLink("connectionParametersHelp", this).setDialog(dialog));
 
         add(new HelpLink("postLogoutRedirectUriHelp", this).setDialog(dialog));
@@ -425,9 +428,6 @@ public class OAuth2LoginAuthProviderPanel
 
             lOidcContainer.add(new HelpLink("oidcUsePKCEHelp", this).setDialog(dialog));
             lOidcContainer.add(new CheckBox("oidcUsePKCE"));
-
-            lOidcContainer.add(new HelpLink("oidcAllowUnSecureLoggingHelp", this).setDialog(dialog));
-            lOidcContainer.add(new CheckBox("oidcAllowUnSecureLogging"));
 
             lOidcContainer.add(new HelpLink("oidcLogoutUriHelp", this).setDialog(dialog));
             lOidcContainer.add(new TextField<>("oidcLogoutUri"));

--- a/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/OAuth2LoginAuthProviderPanelTest.java
+++ b/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/OAuth2LoginAuthProviderPanelTest.java
@@ -11,7 +11,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.wicket.Component;
+import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.util.visit.IVisit;
+import org.apache.wicket.util.visit.IVisitor;
 import org.geoserver.security.oauth2.login.GeoServerOAuth2LoginFilterConfig;
 import org.geoserver.security.web.AbstractSecurityNamedServicePanelTest;
 import org.geoserver.security.web.AbstractSecurityPage;
@@ -41,6 +44,106 @@ public class OAuth2LoginAuthProviderPanelTest extends AbstractSecurityNamedServi
         Model<GeoServerOAuth2LoginFilterConfig> model = new Model<>(new GeoServerOAuth2LoginFilterConfig());
         FormTestPage testPage = new FormTestPage(id -> new OAuth2LoginAuthProviderPanel(id, model));
         tester.startPage(testPage);
+    }
+
+    /**
+     * Verifies that the oidcAllowUnSecureLogging checkbox is visible when a non-OIDC provider (Google) is selected. The
+     * checkbox lives in the common GeoServer Parameters section and should be accessible for all providers.
+     */
+    @Test
+    public void testOidcAllowUnSecureLoggingVisibleForGoogleProvider() throws Exception {
+        String filterName = "LoggingCheckboxFilter";
+        navigateToOpenIdPanel(filterName);
+
+        String prefix = "panel:content:";
+
+        // Select Google provider (index 1 in dropdown: OIDC=0, Google=1, GitHub=2, MS=3)
+        formTester.select(prefix + "providerSelector", 1);
+        Component providerSelectorComponent = formTester.getForm().get(prefix + "providerSelector");
+        tester.executeAjaxEvent(providerSelectorComponent, "change");
+
+        // The oidcAllowUnSecureLogging checkbox should be visible regardless of provider
+        Component panel = formTester.getForm().get("panel:content");
+        assertNotNull("Panel content should exist", panel);
+
+        Component[] found = new Component[1];
+        ((MarkupContainer) panel).visitChildren(Component.class, new IVisitor<Component, Void>() {
+            @Override
+            public void component(Component component, IVisit<Void> visit) {
+                if ("oidcAllowUnSecureLogging".equals(component.getId()) && component.isVisibleInHierarchy()) {
+                    found[0] = component;
+                    visit.stop();
+                }
+            }
+        });
+
+        assertNotNull("oidcAllowUnSecureLogging checkbox should be visible when Google provider is selected", found[0]);
+    }
+
+    /**
+     * Verifies that OIDC-specific advanced settings (force HTTPS, PKCE, signature validation, etc.) are visible only
+     * when the OIDC provider is selected, and hidden for non-OIDC providers like Google.
+     */
+    @Test
+    public void testOidcSpecificSettingsVisibleOnlyForOidcProvider() throws Exception {
+        String filterName = "OidcVisibilityFilter";
+        navigateToOpenIdPanel(filterName);
+
+        String prefix = "panel:content:";
+
+        // --- Part 1: Select OIDC provider (index 0) and verify OIDC-specific fields ARE visible ---
+        formTester.select(prefix + "providerSelector", 0);
+        Component providerSelectorComponent = formTester.getForm().get(prefix + "providerSelector");
+        tester.executeAjaxEvent(providerSelectorComponent, "change");
+
+        Component formPanel = formTester.getForm().get("panel:content");
+        assertNotNull("Form panel content should exist after selecting OIDC", formPanel);
+
+        String[] oidcSpecificFields = {
+            "oidcTokenUri",
+            "oidcAuthorizationUri",
+            "oidcUsePKCE",
+            "disableSignatureValidation",
+            "oidcForceAuthorizationUriHttps",
+            "oidcForceTokenUriHttps"
+        };
+
+        for (String fieldId : oidcSpecificFields) {
+            Component[] found = new Component[1];
+            ((MarkupContainer) formPanel).visitChildren(Component.class, new IVisitor<Component, Void>() {
+                @Override
+                public void component(Component component, IVisit<Void> visit) {
+                    if (fieldId.equals(component.getId()) && component.isVisibleInHierarchy()) {
+                        found[0] = component;
+                        visit.stop();
+                    }
+                }
+            });
+            assertNotNull("OIDC provider selected: field '" + fieldId + "' should be visible", found[0]);
+        }
+
+        // --- Part 2: Select Google provider (index 1) and verify OIDC-specific fields are NOT visible ---
+        formTester.select(prefix + "providerSelector", 1);
+        providerSelectorComponent = formTester.getForm().get(prefix + "providerSelector");
+        tester.executeAjaxEvent(providerSelectorComponent, "change");
+
+        formPanel = formTester.getForm().get("panel:content");
+        assertNotNull("Form panel content should exist after switching to Google", formPanel);
+
+        for (String fieldId : oidcSpecificFields) {
+            Component[] found = new Component[1];
+            ((MarkupContainer) formPanel).visitChildren(Component.class, new IVisitor<Component, Void>() {
+                @Override
+                public void component(Component component, IVisit<Void> visit) {
+                    if (fieldId.equals(component.getId()) && component.isVisibleInHierarchy()) {
+                        found[0] = component;
+                        visit.stop();
+                    }
+                }
+            });
+            assertNull(
+                    "Google provider selected: OIDC-specific field '" + fieldId + "' should NOT be visible", found[0]);
+        }
     }
 
     /**
@@ -106,7 +209,7 @@ public class OAuth2LoginAuthProviderPanelTest extends AbstractSecurityNamedServi
         formTester.setValue(prefix + "displayOnOidc:oidcForceTokenUriHttps", true);
         formTester.setValue(prefix + "displayOnOidc:disableSignatureValidation", true);
         formTester.setValue(prefix + "displayOnOidc:oidcUsePKCE", true);
-        formTester.setValue(prefix + "displayOnOidc:oidcAllowUnSecureLogging", true);
+        formTester.setValue("panel:content:oidcAllowUnSecureLogging", true);
 
         formTester.setValue(prefix + "displayOnOidc:oidcResponseMode", "query");
         formTester.setValue(prefix + "displayOnOidc:oidcAuthenticationMethodPostSecret", true);
@@ -161,7 +264,7 @@ public class OAuth2LoginAuthProviderPanelTest extends AbstractSecurityNamedServi
         formTester.setValue(prefix + "displayOnOidc:oidcForceAuthorizationUriHttps", false);
         formTester.setValue(prefix + "displayOnOidc:disableSignatureValidation", false);
         formTester.setValue(prefix + "displayOnOidc:oidcUsePKCE", false);
-        formTester.setValue(prefix + "displayOnOidc:oidcAllowUnSecureLogging", false);
+        formTester.setValue("panel:oidcAllowUnSecureLogging", false);
         formTester.setValue(prefix + "displayOnOidc:oidcResponseMode", "");
         formTester.setValue(prefix + "displayOnOidc:oidcAuthenticationMethodPostSecret", false);
 


### PR DESCRIPTION
## Move "Log Sensitive Information" checkbox to common parameters section

The `oidcAllowUnSecureLogging` checkbox was only visible when the generic OIDC provider was selected, despite the backend applying this setting globally to all providers via `ConfidentialLogger.setEnabled()` in the filter builder. Users selecting Google, GitHub, or Microsoft had no way to see or toggle this setting.

See [Step 2 of Troubleshooting](https://docs.geoserver.org/main/en/user/community/oidc/advanced/)

**Fix:** Moved the checkbox from the OIDC-only `displayOnOidc` container to the common "GeoServer Parameters" fieldset (alongside `enableRedirectAuthenticationEntryPoint` and `enableResourceServerMode`), making it accessible for all OAuth2 providers.

**Changes:**
- `OAuth2LoginAuthProviderPanel.html` — relocated checkbox markup to common fieldset
- `OAuth2LoginAuthProviderPanel.java` — moved component registration to constructor (common section)
- `OAuth2LoginAuthProviderPanelTest.java` — added tests verifying checkbox visibility for non-OIDC providers and confirming OIDC-specific settings remain correctly scoped

All existing tests continue to pass. OIDC-specific advanced settings (force HTTPS, PKCE, signature validation, etc.) remain in the OIDC-only section — only the logging checkbox was moved.

<img width="722" height="645" alt="image" src="https://github.com/user-attachments/assets/42eaeb19-04ea-495d-9d5b-7be0806cf593" />



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.