### PR TITLE
fix(oidc): Fix MS Graph role source failing with scoped registration IDs

### DIFF
--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/common/GeoServerOAuth2RoleResolver.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/common/GeoServerOAuth2RoleResolver.java
@@ -12,6 +12,7 @@ import static org.geoserver.security.impl.GeoServerUser.ADMIN_USERNAME;
 import static org.geoserver.security.impl.GeoServerUser.ROOT_USERNAME;
 import static org.geoserver.security.jwtheaders.roles.JwtHeadersRolesExtractor.asStringList;
 import static org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId.REG_ID_MICROSOFT;
+import static org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId.isRegIdOfType;
 
 import com.nimbusds.jose.JWSObject;
 import jakarta.servlet.http.HttpServletRequest;
@@ -260,12 +261,12 @@ public class GeoServerOAuth2RoleResolver implements RoleResolver {
         OAuth2UserRequest lUsrRequest = ((OAuth2ResolverParam) pParam).getUserRequest();
         ClientRegistration lClientReg = lUsrRequest.getClientRegistration();
         String lUsr = pParam.getPrincipal();
-        if (!REG_ID_MICROSOFT.equals(lClientReg.getRegistrationId())) {
+        if (!isRegIdOfType(lClientReg.getRegistrationId(), REG_ID_MICROSOFT)) {
             // actually prevented by UI validation, but make sure here to not send foreign access
             // token around
             String lMsg = "Resolving roles failed. RoleSource Microsoft Graph API supported with "
                     + "provider %s only. Currently processing login with %s instead.";
-            LOGGER.log(SEVERE, lMsg.formatted(REG_ID_MICROSOFT, lClientReg.getClientName()));
+            LOGGER.log(SEVERE, lMsg.formatted(REG_ID_MICROSOFT, lClientReg.getRegistrationId()));
             return new ArrayList<>();
         }
         List<String> lRoles = new ArrayList<>();

--- a/src/community/security/oidc/oidc-core/src/test/java/org/geoserver/security/oauth2/common/GeoServerOAuth2RoleResolverTest.java
+++ b/src/community/security/oidc/oidc-core/src/test/java/org/geoserver/security/oauth2/common/GeoServerOAuth2RoleResolverTest.java
@@ -295,6 +295,30 @@ public class GeoServerOAuth2RoleResolverTest {
         assertThat(lRoles, containsInAnyOrder(equalTo(ROLE_NAME_AUTHENTICATED), equalTo("ROLE1"), equalTo("ROLE2")));
     }
 
+    /**
+     * Verifies that extracting roles from MS Graph API works with a scoped registration ID (e.g.
+     * "my-filter__microsoft") as used when a filter name is configured.
+     */
+    @Test
+    public void testGetRolesFromMsGraphAPIWithScopedRegistrationId() throws Exception {
+        // given
+        context = newResolverContext(OpenIdRoleSource.MSGraphAPI);
+        OAuth2ResolverParam lParam = new OAuth2ResolverParam(PRINCIPAL_NAME, mockRequest, context, userRequest);
+
+        MSGraphRolesResolver mock = mock(MSGraphRolesResolver.class);
+        sut.setMsGraphRolesResolverSupplier(() -> mock);
+
+        List<String> lRoleNames = List.of("ROLE1", "ROLE2");
+
+        // when - use a scoped registration ID like production does
+        when(mockClientReg.getRegistrationId()).thenReturn("oidc-entra__microsoft");
+        when(mock.resolveRoles(any(), any(), any(), any())).thenReturn(lRoleNames);
+        Collection<GeoServerRole> lRoles = sut.convert(lParam);
+
+        // then
+        assertThat(lRoles, containsInAnyOrder(equalTo(ROLE_NAME_AUTHENTICATED), equalTo("ROLE1"), equalTo("ROLE2")));
+    }
+
     private DefaultResolverContext newResolverContext(RoleSource pRoleSource) {
         return new DefaultResolverContext(
                 mockSecurityManager, "default", "default", null, mockRoleConverter, pRoleSource);


### PR DESCRIPTION
MS Graph role resolution always failed when a filter name was configured because getRolesFromMSGraphAPI compared the scoped registration ID (e.g. oidc-entra__microsoft) against "microsoft" using exact equality. Replaced with isRegIdOfType() which handles both scoped and unscoped IDs. Added test for scoped ID scenario.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.