### PR TITLE
fix(oidc): expose dynamic login buttons via ExtensionProvider and OIDC multi button login

### DIFF
--- a/doc/en/user/community/oidc/advanced.md
+++ b/doc/en/user/community/oidc/advanced.md
@@ -29,7 +29,7 @@ If you are still having issues, you might need to attach a Java debugger to GeoS
     - If there is a problem, its most likely that:
 
         - GeoServer is configured with the wrong "User Authorization URI"
-        - The IDP is not configured to allow the redirect URL shown in the read-only **Redirect URI** field (e.g. `http://localhost:8080/geoserver/web/login/oauth2/code/oidc`)
+        - The IDP is not configured to allow the redirect URL shown in the read-only **Redirect URI** field (e.g. `http://localhost:8080/geoserver/web/login/oauth2/code/<filterName>__oidc`). The Redirect URI includes the GeoServer filter name as a prefix so that multiple OIDC filters can coexist --- a wildcard such as `.../web/login/oauth2/code/*` works well in most IDPs.
 
 2.  User logs into the IDP (if this is problematic, consult your IDP's administrator)
 

--- a/doc/en/user/community/oidc/configuring.md
+++ b/doc/en/user/community/oidc/configuring.md
@@ -61,14 +61,26 @@ Without this, GeoServer may resolve the redirect URI to an internal hostname tha
 The **Redirect URI** field is calculated automatically from the Redirect Base URI and cannot be edited directly. It has the form:
 
 ```xml
-<Redirect Base URI>/web/login/oauth2/code/<provider>
+<Redirect Base URI>/web/login/oauth2/code/<filterName>__<provider>
 ```
 
-For example:
+For example, an OIDC filter named `keycloak-prod` produces:
 
-    https://geoserver.example.com/geoserver/web/login/oauth2/code/oidc
+    https://geoserver.example.com/geoserver/web/login/oauth2/code/keycloak-prod__oidc
 
 This is the callback URL that must be registered with your IDP as a permitted redirect URI. Copy it from the form and paste it into your IDP's client configuration.
+
+!!! note "Per-filter scoped registration ID"
+    The Redirect URI includes the GeoServer filter name as a prefix (e.g. `keycloak-prod__oidc`) so that several OIDC filters of the same provider type can coexist without colliding on their callback endpoints. Each filter registers with the IDP under its own redirect URI. Many IDPs accept a wildcard such as `https://geoserver.example.com/geoserver/web/login/oauth2/code/*` for convenience.
+
+### Multiple OIDC filters {: #community_oidc_multiple_filters }
+
+GeoServer can run several OAuth2 / OpenID Connect filters at the same time --- for example one filter per identity provider (Keycloak, Auth0, custom Entra), each with its own client credentials and scopes. Each filter is configured independently in **Security -> Authentication -> Filters** and bound to the relevant request chain (typically `web/**`).
+
+When two or more OIDC filters are bound to the same chain, the GeoServer user dropdown shows **one login button per filter**. Each button is a deep link to that filter's scoped authorization endpoint (`/web/oauth2/authorization/<filterName>__<provider>`) so that Spring's OAuth2 filter chain routes the click to the matching `ClientRegistration`.
+
+!!! tip "No restart needed when adding a filter"
+    Saving a new OIDC filter through the UI registers the matching login button on the next page render --- no container restart required. The button is removed automatically when the filter is deleted or disabled.
 
 ### Logout Behavior {: #community_oidc_logout_behavior }
 

--- a/doc/en/user/community/oidc/oauth2/azure.md
+++ b/doc/en/user/community/oidc/oauth2/azure.md
@@ -10,10 +10,10 @@ We will use Microsoft Entra (Microsoft Azure) for login and either the Azure/Ent
 
     ![](../img/azure_create_app1.png)
 
-3.  Give the application a name ("gs-azure-app"), set it to the MultiTenant. Use "http://localhost:8080/geoserver/web/login/oauth2/code/microsoft" as the "Web" Redirect URI. Press "Register".
+3.  Give the application a name ("gs-azure-app"), set it to the MultiTenant. Use the Redirect URI shown in the GeoServer filter configuration as the "Web" Redirect URI --- it has the form `http://localhost:8080/geoserver/web/login/oauth2/code/<filterName>__microsoft` where `<filterName>` is the name of the GeoServer OIDC filter (e.g. `gs-azure-app__microsoft`). Press "Register".
 
     !!! tip
-        The exact redirect URI that GeoServer will use is shown as the read-only **Redirect URI** field in the filter configuration form. In production, use that value instead of `localhost`. See [Redirect Base URI](../configuring.md#community_oidc_redirect_base_uri).
+        The exact redirect URI that GeoServer will use is shown as the read-only **Redirect URI** field in the filter configuration form --- copy it verbatim. In production, use that value instead of `localhost`. The filter-name prefix lets several OIDC filters share an IDP without colliding on their redirect URIs. See [Redirect Base URI](../configuring.md#community_oidc_redirect_base_uri).
     
         ![](../img/azure_create_app2.png)
 

--- a/doc/en/user/community/oidc/oauth2/generic.md
+++ b/doc/en/user/community/oidc/oauth2/generic.md
@@ -24,9 +24,9 @@ When registering GeoServer as a client or application with your IDP, you will ne
 
 - **Redirect URI (callback URL):** This is the read-only **Redirect URI** shown in the GeoServer filter configuration form. It has the form:
 
-      https://<your-geoserver>/geoserver/web/login/oauth2/code/oidc
+      https://<your-geoserver>/geoserver/web/login/oauth2/code/<filterName>__oidc
 
-  Copy this value exactly into your IDP's "Valid redirect URIs" or "Callback URL" setting.
+  Copy this value exactly into your IDP's "Valid redirect URIs" or "Callback URL" setting. The filter-name prefix lets several OIDC filters share an IDP without colliding on their redirect URIs; many IDPs also accept a wildcard like `.../web/login/oauth2/code/*` for convenience.
 
 - **Post-Logout Redirect URI:** If your IDP supports single logout, also register the **After-Logout Redirect URI** shown in the GeoServer configuration. See [Logout Behavior](../configuring.md#community_oidc_logout_behavior).
 

--- a/doc/en/user/community/oidc/oauth2/github.md
+++ b/doc/en/user/community/oidc/oauth2/github.md
@@ -18,11 +18,11 @@ The first thing to do is to configure the OAuth2 Provider and obtain `Client ID`
 
     - A name (i.e. "gs-app")
     - The homepage of the geoserver (i.e. "http://localhost:8080/geoserver")
-    - The authorization callback in the form of "http://localhost:8080/geoserver/web/login/oauth2/code/gitHub"
+    - The authorization callback shown as the read-only **Redirect URI** field of the GeoServer filter configuration form, in the form of "http://localhost:8080/geoserver/web/login/oauth2/code/<filterName>__gitHub" (replace `<filterName>` with the name of the GeoServer OIDC filter, e.g. `gs-app__gitHub`)
     - Press "Register application"
 
     !!! tip
-        The exact callback URL that GeoServer will use is shown as the read-only **Redirect URI** field in the filter configuration form. In production, use that value instead of `localhost`. See [Redirect Base URI](../configuring.md#community_oidc_redirect_base_uri).
+        The exact callback URL that GeoServer will use is shown as the read-only **Redirect URI** field in the filter configuration form --- copy it verbatim. In production, use that value instead of `localhost`. The filter-name prefix lets several OIDC filters share an IDP without colliding on their redirect URIs. See [Redirect Base URI](../configuring.md#community_oidc_redirect_base_uri).
     
         ![](../img/github-oauth2-app.png)
 

--- a/doc/en/user/community/oidc/oauth2/google.md
+++ b/doc/en/user/community/oidc/oauth2/google.md
@@ -62,12 +62,12 @@ The first thing to do is to configure the OAuth2 Provider and obtain `Client ID`
 
       ![](../img/google-credentials11.png)
 
-    * Go down to "Authorized redirect URIs" and press "+ Add URI", type in "http://localhost:8080/geoserver/web/login/oauth2/code/google", then press "Create"
+    * Go down to "Authorized redirect URIs" and press "+ Add URI", type in the redirect URI shown in the GeoServer filter configuration form --- it has the form "http://localhost:8080/geoserver/web/login/oauth2/code/<filterName>__google" where `<filterName>` is the name of the GeoServer OIDC filter (e.g. `gs-test-app__google`). Press "Create".
 
       ![](../img/google-credentials12.png)
 
     !!! tip
-        The exact redirect URI that GeoServer will use is shown as the read-only **Redirect URI** field in the filter configuration form. In production, use that value instead of `localhost`. See [Redirect Base URI](../configuring.md#community_oidc_redirect_base_uri).
+        The exact redirect URI that GeoServer will use is shown as the read-only **Redirect URI** field in the filter configuration form --- copy it verbatim. In production, use that value instead of `localhost`. The filter-name prefix lets several OIDC filters share an IDP without colliding on their redirect URIs. See [Redirect Base URI](../configuring.md#community_oidc_redirect_base_uri).
 
     - Record your Client ID and Client Secret, then press "Ok"
 

--- a/doc/en/user/community/oidc/oauth2/keycloak.md
+++ b/doc/en/user/community/oidc/oauth2/keycloak.md
@@ -52,7 +52,7 @@ docker run --name geoserver_keycloak -p 7777:8080 \
 7.  Set the "Root URL" and "Home URL" as "http://localhost:8080". Set the "Valid post logout redirect URIs" and "Valid redirect URIs" as "http://localhost:8080/*". Then press "Save".
 
     !!! tip
-        The exact redirect URI that GeoServer will use is shown as the read-only **Redirect URI** field in the filter configuration form (e.g. `http://localhost:8080/geoserver/web/login/oauth2/code/oidc`). In production, you may want to register only this specific URI rather than a wildcard. See [Redirect Base URI](../configuring.md#community_oidc_redirect_base_uri).
+        The exact redirect URI that GeoServer will use is shown as the read-only **Redirect URI** field in the filter configuration form (e.g. `http://localhost:8080/geoserver/web/login/oauth2/code/<filterName>__oidc`, where `<filterName>` is the name of the GeoServer OIDC filter). The filter-name prefix lets several OIDC filters share an IDP without colliding on their redirect URIs. In production, you may want to register only the specific URIs you actually use rather than a wildcard; in that case register one entry per filter you intend to deploy. See [Redirect Base URI](../configuring.md#community_oidc_redirect_base_uri).
     
         ![](../img/keycloak-create-client4.png)
 

--- a/src/community/security/oidc/oidc-assembly/pom.xml
+++ b/src/community/security/oidc/oidc-assembly/pom.xml
@@ -33,18 +33,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.geoserver.community.jwt-headers</groupId>
-      <artifactId>jwt-headers-util</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.geoserver.community.jwt-headers</groupId>
-      <artifactId>gs-jwt-headers</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/src/community/security/oidc/oidc-assembly/src/assembly/assembly.xml
+++ b/src/community/security/oidc/oidc-assembly/src/assembly/assembly.xml
@@ -31,8 +31,6 @@
         <include>accessors-smart*</include>
         <include>json-simple*</include>
         <include>nimbus-jose-jwt*</include>
-        <include>jwt-headers-util*</include>
-        <include>gs-jwt-headers*</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/src/community/security/oidc/oidc-core/pom.xml
+++ b/src/community/security/oidc/oidc-core/pom.xml
@@ -135,12 +135,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.geoserver.community.jwt-headers</groupId>
-      <artifactId>jwt-headers-util</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/common/GeoServerOAuth2RoleResolver.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/common/GeoServerOAuth2RoleResolver.java
@@ -10,7 +10,8 @@ import static java.util.stream.Collectors.toList;
 import static org.geoserver.security.filter.GeoServerRoleResolvers.PRE_AUTH_ROLE_SOURCE_RESOLVER;
 import static org.geoserver.security.impl.GeoServerUser.ADMIN_USERNAME;
 import static org.geoserver.security.impl.GeoServerUser.ROOT_USERNAME;
-import static org.geoserver.security.jwtheaders.roles.JwtHeadersRolesExtractor.asStringList;
+import static org.geoserver.security.oauth2.common.OAuth2ClaimsHelpers.asStringList;
+import static org.geoserver.security.oauth2.common.OAuth2ClaimsHelpers.getClaim;
 import static org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId.REG_ID_MICROSOFT;
 import static org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId.isRegIdOfType;
 
@@ -35,9 +36,6 @@ import org.geoserver.security.filter.GeoServerRoleResolvers.ResolverParam;
 import org.geoserver.security.filter.GeoServerRoleResolvers.RoleResolver;
 import org.geoserver.security.impl.GeoServerRole;
 import org.geoserver.security.impl.RoleCalculator;
-import org.geoserver.security.jwtheaders.JwtConfiguration;
-import org.geoserver.security.jwtheaders.roles.RoleConverter;
-import org.geoserver.security.jwtheaders.username.JwtHeaderUserNameExtractor;
 import org.geoserver.security.oauth2.login.GeoServerOAuth2LoginFilterConfig;
 import org.geoserver.security.oauth2.login.GeoServerOAuth2LoginFilterConfig.OpenIdRoleSource;
 import org.geotools.util.logging.Logging;
@@ -59,7 +57,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public class GeoServerOAuth2RoleResolver implements RoleResolver {
 
     private static final Logger LOGGER = Logging.getLogger(GeoServerOAuth2RoleResolver.class);
-    RoleConverter roleConverter;
+    OAuth2RoleConverter roleConverter;
 
     public static final class OAuth2ResolverParam extends ResolverParam {
 
@@ -93,11 +91,7 @@ public class GeoServerOAuth2RoleResolver implements RoleResolver {
     public GeoServerOAuth2RoleResolver(GeoServerOAuth2LoginFilterConfig pConfig) {
         super();
         config = pConfig;
-        // this is for using the other library
-        JwtConfiguration jwtConfiguration = new JwtConfiguration();
-        jwtConfiguration.setRoleConverterString(config.getRoleConverterString());
-        jwtConfiguration.setOnlyExternalListedRoles(config.isOnlyExternalListedRoles());
-        roleConverter = new RoleConverter(jwtConfiguration);
+        roleConverter = new OAuth2RoleConverter(config.getRoleConverterString(), config.isOnlyExternalListedRoles());
     }
 
     @Override
@@ -185,7 +179,7 @@ public class GeoServerOAuth2RoleResolver implements RoleResolver {
                     jwsObject = JWSObject.parse(lAccessToken.getTokenValue());
                     if (jwsObject != null) {
                         Map<String, Object> claims = jwsObject.getPayload().toJSONObject();
-                        lRoles = asStringList(JwtHeaderUserNameExtractor.getClaim(claims, lClaimName));
+                        lRoles = asStringList(getClaim(claims, lClaimName));
                     }
                 } catch (ParseException e) {
                     LOGGER.log(
@@ -220,7 +214,7 @@ public class GeoServerOAuth2RoleResolver implements RoleResolver {
             String lMsg = "Analyzing access token for roles. Claim: %s. Claims: %s";
             LOGGER.fine(lMsg.formatted(lClaimName, lIdToken.getClaims()));
         }
-        List<String> lClaimList = asStringList(JwtHeaderUserNameExtractor.getClaim(lIdToken.getClaims(), lClaimName));
+        List<String> lClaimList = asStringList(getClaim(lIdToken.getClaims(), lClaimName));
 
         if (lClaimList != null) {
             lClaimList = this.roleConverter.convert(lClaimList);
@@ -248,7 +242,7 @@ public class GeoServerOAuth2RoleResolver implements RoleResolver {
             Collection<? extends GrantedAuthority> authorities = lUser.getAuthorities();
             lRoles = authorities.stream().map(a -> a.getAuthority()).collect(toList());
         } else {
-            lRoles = asStringList(JwtHeaderUserNameExtractor.getClaim(lUser.getAttributes(), lClaimName));
+            lRoles = asStringList(getClaim(lUser.getAttributes(), lClaimName));
             lRoles = this.roleConverter.convert(lRoles);
         }
         if (!lRoles.contains("ROLE_AUTHENTICATED")) {

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/common/OAuth2ClaimsHelpers.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/common/OAuth2ClaimsHelpers.java
@@ -1,0 +1,88 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.common;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import net.minidev.json.JSONArray;
+
+/**
+ * Helpers for extracting claim values out of JWT/OIDC claim maps and normalizing them into a {@code List<String>}.
+ *
+ * <p>This is a self-contained replacement for the previously-borrowed helpers from the {@code jwt-headers} community
+ * module. The OIDC plugin must not depend on a community module once it is promoted to extension status, so these two
+ * static utilities (originally {@code JwtHeaderUserNameExtractor.getClaim} and
+ * {@code JwtHeadersRolesExtractor.asStringList}) live here instead.
+ *
+ * <p>Both methods are deliberately conservative: they return {@code null} (or an empty list, for
+ * {@link #asStringList(Object)} when the input is non-stringy) rather than throwing, so callers can keep using the
+ * standard "no claim found ⇒ fall through" pattern.
+ */
+public final class OAuth2ClaimsHelpers {
+
+    private OAuth2ClaimsHelpers() {
+        // utility class
+    }
+
+    /**
+     * Look up a claim by a dotted path, recursing into nested maps. Example: {@code getClaim(claims,
+     * "address.country")} returns the {@code country} field of the {@code address} sub-claim.
+     *
+     * @param claims the JWT/OIDC claim map (or any {@code Map<String,Object>})
+     * @param path dotted path, e.g. {@code "preferred_username"} or {@code "address.country"}
+     * @return the value at that path, or {@code null} if any segment is missing
+     */
+    public static Object getClaim(Map<String, Object> claims, String path) {
+        if (claims == null || path == null || path.isEmpty()) {
+            return null;
+        }
+        return getClaim(claims, new ArrayList<>(Arrays.asList(path.split("\\."))));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object getClaim(Map<String, Object> claims, List<String> pathSegments) {
+        if (claims == null || pathSegments.isEmpty()) {
+            return null;
+        }
+        if (pathSegments.size() == 1) {
+            return claims.get(pathSegments.get(0));
+        }
+        String head = pathSegments.get(0);
+        pathSegments.remove(0);
+        Object next = claims.get(head);
+        if (next instanceof Map) {
+            return getClaim((Map<String, Object>) next, pathSegments);
+        }
+        return null;
+    }
+
+    /**
+     * Normalize a "list-of-strings"-ish claim value into a real {@code List<String>}. Accepts strings,
+     * {@link JSONArray} (from json-path / json-smart), or arbitrary {@code List<?>} values; everything else returns an
+     * empty list.
+     *
+     * @param raw raw claim value, may be {@code null}
+     * @return an immutable-ish list; never {@code null}
+     */
+    public static List<String> asStringList(Object raw) {
+        if (raw == null) {
+            return Collections.emptyList();
+        }
+        if (raw instanceof String string) {
+            return List.of(string);
+        }
+        if (raw instanceof JSONArray array) {
+            return array.stream().map(Object::toString).collect(Collectors.toList());
+        }
+        if (raw instanceof List<?> list) {
+            return list.stream().map(Object::toString).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/common/OAuth2RoleConverter.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/common/OAuth2RoleConverter.java
@@ -1,0 +1,104 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.common;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts external role names (from an identity provider) into internal GeoServer role names using a
+ * GeoServer-configured mapping string.
+ *
+ * <p>This is a self-contained replacement for the previously-borrowed {@code RoleConverter} from the
+ * {@code jwt-headers} community module. The OIDC plugin must not depend on a community module once it is promoted to
+ * extension status.
+ *
+ * <p>The mapping is given as a single string of the form:
+ *
+ * <pre>
+ *   "externalRoleName1=GeoServerRoleName1;externalRoleName2=GeoServerRoleName2"
+ * </pre>
+ *
+ * <p>An external role may map to several internal roles by being listed multiple times. The
+ * {@code onlyExternalListedRoles} flag controls what happens to external roles that are <em>not</em> in the map:
+ *
+ * <ul>
+ *   <li>{@code true} → the external role is dropped entirely (strict allow-list mode);
+ *   <li>{@code false} → the external role passes through unchanged (default).
+ * </ul>
+ *
+ * <p>Role-name characters outside {@code [a-zA-Z0-9_.-]} are stripped to keep the mapping line robust against
+ * accidental whitespace, quoting, or hostile input.
+ */
+public final class OAuth2RoleConverter {
+
+    private static final String INVALID_NAME_CHARS = "[^a-zA-Z0-9_\\-\\.]";
+
+    private final Map<String, List<String>> conversionMap;
+    private final boolean externalNameMustBeListed;
+
+    /**
+     * @param roleConverterString mapping string in the form {@code "ext1=gs1;ext2=gs2"} — may be {@code null} or blank
+     *     (no conversion happens, external roles pass through)
+     * @param onlyExternalListedRoles if {@code true}, external roles not listed in the map are dropped
+     */
+    public OAuth2RoleConverter(String roleConverterString, boolean onlyExternalListedRoles) {
+        this.conversionMap = parseRoleConverterString(roleConverterString);
+        this.externalNameMustBeListed = onlyExternalListedRoles;
+    }
+
+    /**
+     * Convert a list of external (IdP-issued) role names into internal GeoServer role names. Honors the
+     * {@code onlyExternalListedRoles} flag.
+     *
+     * @param externalRoles roles from the IdP — may be {@code null}
+     * @return converted roles; never {@code null}
+     */
+    public List<String> convert(List<String> externalRoles) {
+        List<String> result = new ArrayList<>();
+        if (externalRoles == null) {
+            return result;
+        }
+        for (String externalRole : externalRoles) {
+            List<String> mapped = conversionMap.get(externalRole);
+            if (mapped == null) {
+                if (!externalNameMustBeListed) {
+                    result.add(externalRole);
+                }
+            } else {
+                result.addAll(mapped);
+            }
+        }
+        return result;
+    }
+
+    /** Parse the {@code "ext1=gs1;ext2=gs2"} mapping string into a map. Tolerant of blanks / malformed entries. */
+    static Map<String, List<String>> parseRoleConverterString(String roleConverterString) {
+        if (roleConverterString == null || roleConverterString.isBlank()) {
+            return Collections.emptyMap();
+        }
+        Map<String, List<String>> result = new HashMap<>();
+        for (String part : roleConverterString.split(";")) {
+            String[] kv = part.split("=");
+            if (kv.length != 2) {
+                continue;
+            }
+            String key = sanitize(kv[0]);
+            String val = sanitize(kv[1]);
+            if (key.isBlank() || val.isBlank()) {
+                continue;
+            }
+            result.computeIfAbsent(key, k -> new ArrayList<>()).add(val);
+        }
+        return result;
+    }
+
+    private static String sanitize(String s) {
+        return s.replaceAll(INVALID_NAME_CHARS, "");
+    }
+}

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerJwtAudienceValidator.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerJwtAudienceValidator.java
@@ -4,11 +4,11 @@
  */
 package org.geoserver.security.oauth2.login;
 
-import static org.geoserver.security.jwtheaders.roles.JwtHeadersRolesExtractor.asStringList;
+import static org.geoserver.security.oauth2.common.OAuth2ClaimsHelpers.asStringList;
+import static org.geoserver.security.oauth2.common.OAuth2ClaimsHelpers.getClaim;
 
 import java.util.List;
 import java.util.Map;
-import org.geoserver.security.jwtheaders.username.JwtHeaderUserNameExtractor;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
@@ -43,7 +43,7 @@ public final class GeoServerJwtAudienceValidator implements OAuth2TokenValidator
         }
 
         Map<String, Object> claims = token.getClaims();
-        Object raw = JwtHeaderUserNameExtractor.getClaim(claims, claimName);
+        Object raw = getClaim(claims, claimName);
         List<String> audiences = asStringList(raw);
 
         boolean match = audiences != null && audiences.stream().anyMatch(expectedValue::equals);

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2ClientRegistrationRegistry.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2ClientRegistrationRegistry.java
@@ -1,0 +1,153 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.login;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+/**
+ * Application-wide registry of {@link ClientRegistration}s contributed by every active
+ * {@link GeoServerOAuth2LoginAuthenticationFilter}.
+ *
+ * <h2>Why a shared registry?</h2>
+ *
+ * <p>Each {@code GeoServerOAuth2LoginAuthenticationFilter} internally hosts a Spring
+ * {@code OAuth2AuthorizationRequestRedirectFilter}. In Spring Security 6 that filter's resolver would silently fall
+ * through when a request URL named a registration ID it didn't know about, letting the next filter in the chain try. In
+ * Spring Security 7 the same resolver <em>throws</em> {@code InvalidClientRegistrationIdException}, and the containing
+ * {@link org.springframework.security.web.FilterChainProxy} converts the throw into HTTP 500.
+ *
+ * <p>If every OAuth2 filter keeps its own {@code InMemoryClientRegistrationRepository} populated only with its own
+ * scoped registration IDs (e.g. {@code keycloak-test__oidc}), then the click for the second filter's button
+ * ({@code /oauth2/authorization/alessio_test__oidc}) lands inside the first filter's sub-chain, the local repo does not
+ * know about {@code alessio_test__oidc}, and Spring 7's resolver throws — producing the 500 Internal Server Error
+ * observed in the wild when administrators configure more than one OIDC filter.
+ *
+ * <p>The fix is to share a single {@link ClientRegistrationRepository} instance across every
+ * {@code GeoServerOAuth2LoginAuthenticationFilter}. Each filter still owns its own registrations, but Spring's resolver
+ * — wherever it runs — can resolve any scoped ID into the matching {@link ClientRegistration}. Cross-filter resolution
+ * is then a non-event, and the user click reaches the correct ClientRegistration regardless of which GeoServer filter
+ * the request happens to traverse first.
+ *
+ * <h2>Lifecycle</h2>
+ *
+ * <p>Registry membership is keyed by GeoServer filter name. Whenever a filter is (re)built — at startup, after a save,
+ * after a chain edit — the builder calls {@link #replaceFilterRegistrations(String, Collection)}, which atomically
+ * replaces that filter's contribution. When a filter leaves every chain (its {@code OAuth2LoginButtonManager} sweep
+ * detects it) the manager calls {@link #removeFilterRegistrations(String)} to drop the contribution from the registry.
+ *
+ * <p>The registry is thread-safe: read paths ({@link #findByRegistrationId(String)}, {@link #iterator()}) run lock-free
+ * over a {@link ConcurrentHashMap}; write paths ({@code replace}, {@code remove}) are {@code synchronized} so that the
+ * filter-keyed grouping and the flat lookup map stay consistent under concurrent filter rebuilds.
+ */
+public final class GeoServerOAuth2ClientRegistrationRegistry
+        implements ClientRegistrationRepository, Iterable<ClientRegistration> {
+
+    /** Per-filter contribution: filter name → its set of registrations. */
+    private final Map<String, List<ClientRegistration>> byFilter = new ConcurrentHashMap<>();
+
+    /** Flat lookup by scoped registration ID. */
+    private final Map<String, ClientRegistration> byScopedId = new ConcurrentHashMap<>();
+
+    /**
+     * Atomically replace the set of registrations contributed by a single GeoServer filter.
+     *
+     * <p>Calling this with an empty (or {@code null}) collection is equivalent to
+     * {@link #removeFilterRegistrations(String)} — the filter's previous contribution is dropped and no new entries are
+     * inserted.
+     *
+     * @param filterName the GeoServer filter name (e.g. {@code keycloak-test})
+     * @param registrations the new contribution; may be {@code null} or empty
+     */
+    public synchronized void replaceFilterRegistrations(
+            String filterName, Collection<ClientRegistration> registrations) {
+        if (filterName == null) {
+            return;
+        }
+        // Drop previous contribution for this filter, if any.
+        List<ClientRegistration> previous = byFilter.remove(filterName);
+        if (previous != null) {
+            for (ClientRegistration cr : previous) {
+                // Only purge from the flat map if the entry still belongs to this filter — protects against the
+                // rare race where two filters claim overlapping scoped IDs.
+                byScopedId.remove(cr.getRegistrationId(), cr);
+            }
+        }
+        if (registrations == null || registrations.isEmpty()) {
+            return;
+        }
+        List<ClientRegistration> snapshot = new ArrayList<>(registrations);
+        byFilter.put(filterName, snapshot);
+        for (ClientRegistration cr : snapshot) {
+            byScopedId.put(cr.getRegistrationId(), cr);
+        }
+    }
+
+    /**
+     * Remove every registration contributed by a single GeoServer filter. Used when the filter is deleted or has been
+     * dropped from every request filter chain.
+     *
+     * @param filterName the GeoServer filter name
+     */
+    public void removeFilterRegistrations(String filterName) {
+        replaceFilterRegistrations(filterName, Collections.emptyList());
+    }
+
+    /**
+     * Retain only the contributions for the given filter names; everything else is purged. Useful when a sweep has just
+     * enumerated the currently in-chain OAuth2 filters and wants to bring the registry in line in a single pass.
+     *
+     * @param filterNamesToKeep the names of the filters whose contributions must be preserved
+     */
+    public synchronized void retainFilters(Set<String> filterNamesToKeep) {
+        Set<String> toDrop = new HashSet<>(byFilter.keySet());
+        toDrop.removeAll(filterNamesToKeep);
+        for (String filterName : toDrop) {
+            removeFilterRegistrations(filterName);
+        }
+    }
+
+    /**
+     * Look up a registration by its scoped ID — the primary API the Spring OAuth2 redirect / login filters call.
+     *
+     * @param registrationId the scoped registration ID, e.g. {@code keycloak-test__oidc}
+     * @return the matching {@link ClientRegistration}, or {@code null} if no filter has contributed one
+     */
+    @Override
+    public ClientRegistration findByRegistrationId(String registrationId) {
+        if (registrationId == null) {
+            return null;
+        }
+        return byScopedId.get(registrationId);
+    }
+
+    /**
+     * Iterate every currently-contributed registration. The iteration order is unspecified and the view is a snapshot —
+     * concurrent contributions may or may not be reflected.
+     */
+    @Override
+    public Iterator<ClientRegistration> iterator() {
+        return new ArrayList<>(byScopedId.values()).iterator();
+    }
+
+    /** Number of registrations currently held. Useful for diagnostics and tests. */
+    public int size() {
+        return byScopedId.size();
+    }
+
+    /** Number of distinct filters currently contributing registrations. */
+    public int filterCount() {
+        return byFilter.size();
+    }
+}

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2JwtAuthenticationConverter.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2JwtAuthenticationConverter.java
@@ -8,7 +8,8 @@ import static java.util.logging.Level.SEVERE;
 import static java.util.stream.Collectors.toList;
 import static org.geoserver.security.impl.GeoServerUser.ADMIN_USERNAME;
 import static org.geoserver.security.impl.GeoServerUser.ROOT_USERNAME;
-import static org.geoserver.security.jwtheaders.roles.JwtHeadersRolesExtractor.asStringList;
+import static org.geoserver.security.oauth2.common.OAuth2ClaimsHelpers.asStringList;
+import static org.geoserver.security.oauth2.common.OAuth2ClaimsHelpers.getClaim;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -22,9 +23,7 @@ import java.util.logging.Logger;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.impl.GeoServerRole;
 import org.geoserver.security.impl.RoleCalculator;
-import org.geoserver.security.jwtheaders.JwtConfiguration;
-import org.geoserver.security.jwtheaders.roles.RoleConverter;
-import org.geoserver.security.jwtheaders.username.JwtHeaderUserNameExtractor;
+import org.geoserver.security.oauth2.common.OAuth2RoleConverter;
 import org.geotools.util.logging.Logging;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
@@ -45,17 +44,14 @@ public class GeoServerOAuth2JwtAuthenticationConverter
 
     private final GeoServerSecurityManager securityManager;
     private final GeoServerOAuth2LoginFilterConfig config;
-    private final RoleConverter roleConverter;
+    private final OAuth2RoleConverter roleConverter;
 
     public GeoServerOAuth2JwtAuthenticationConverter(
             GeoServerSecurityManager securityManager, GeoServerOAuth2LoginFilterConfig config) {
         this.securityManager = Objects.requireNonNull(securityManager, "securityManager");
         this.config = Objects.requireNonNull(config, "config");
-
-        JwtConfiguration jwtConfiguration = new JwtConfiguration();
-        jwtConfiguration.setRoleConverterString(config.getRoleConverterString());
-        jwtConfiguration.setOnlyExternalListedRoles(config.isOnlyExternalListedRoles());
-        this.roleConverter = new RoleConverter(jwtConfiguration);
+        this.roleConverter =
+                new OAuth2RoleConverter(config.getRoleConverterString(), config.isOnlyExternalListedRoles());
     }
 
     @Override
@@ -118,7 +114,7 @@ public class GeoServerOAuth2JwtAuthenticationConverter
         if (!StringUtils.hasText(claimName)) {
             return null;
         }
-        Object o = JwtHeaderUserNameExtractor.getClaim(claims, claimName);
+        Object o = getClaim(claims, claimName);
         if (o == null) {
             return null;
         }
@@ -158,13 +154,13 @@ public class GeoServerOAuth2JwtAuthenticationConverter
                         if (StringUtils.hasText(s)) roleStrings.add(s);
                     }
                 } else {
-                    Object raw = JwtHeaderUserNameExtractor.getClaim(claims, claimName);
+                    Object raw = getClaim(claims, claimName);
                     roleStrings.addAll(asStringList(raw));
                     roleStrings.addAll(asStringList(rawAlt));
                 }
             }
         } else {
-            Object raw = JwtHeaderUserNameExtractor.getClaim(claims, claimName);
+            Object raw = getClaim(claims, claimName);
             roleStrings.addAll(asStringList(raw));
         }
 

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginAuthenticationFilterBuilder.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginAuthenticationFilterBuilder.java
@@ -107,7 +107,17 @@ public class GeoServerOAuth2LoginAuthenticationFilterBuilder implements GeoServe
     private ApplicationEventPublisher eventPublisher;
     private GeoServerOidcIdTokenDecoderFactory tokenDecoderFactory;
 
-    private InMemoryClientRegistrationRepository clientRegistrationRepository;
+    /**
+     * Application-wide registry of every active OAuth2 filter's {@link ClientRegistration}s. Injected by
+     * {@link GeoServerOAuth2LoginAuthenticationProvider} so that all OAuth2 filters share the same repository — this is
+     * what lets Spring's {@code OAuth2AuthorizationRequestRedirectFilter} inside one filter's sub-chain resolve the
+     * scoped registration ID owned by another filter, avoiding the {@code InvalidClientRegistrationIdException} → HTTP
+     * 500 cascade that bit the legacy per-filter-private repository design under Spring Security 7. See
+     * {@link GeoServerOAuth2ClientRegistrationRegistry} for details.
+     */
+    private GeoServerOAuth2ClientRegistrationRegistry clientRegistrationRegistry;
+
+    private ClientRegistrationRepository clientRegistrationRepository;
     private OAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService;
     private OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService;
 
@@ -187,6 +197,15 @@ public class GeoServerOAuth2LoginAuthenticationFilterBuilder implements GeoServe
             oauthConfig.tokenEndpoint(token -> token.accessTokenResponseClient(getAccessTokenResponseClient()));
 
             oauthConfig.loginProcessingUrl("/web/login/oauth2/code/*");
+
+            // On OAuth2/OIDC authentication failure (bad client credentials, invalid token signature,
+            // session-state mismatch, IdP refusing the code exchange, ...) Spring's default failure handler
+            // redirects to "/login?error" — a path that has no handler in the GeoServer webapp (no Wicket
+            // page mount, no servlet, no static resource). Tomcat's default servlet then serves the bare
+            // path back without a Content-Type, which browsers interpret as a downloadable empty file
+            // named "login". Redirect to /web/ instead — the Wicket-rendered home page surfaces the
+            // standard login form so users can retry without seeing a confusing file download dialog.
+            oauthConfig.failureUrl("/web/");
         });
 
         // Hybrid mode: accept machine-to-machine requests via Authorization: Bearer <token>
@@ -244,7 +263,19 @@ public class GeoServerOAuth2LoginAuthenticationFilterBuilder implements GeoServe
                 configuration.getRoleSource());
     }
 
-    private InMemoryClientRegistrationRepository createClientRegistrationRepository() {
+    /**
+     * Build this filter's contribution to the shared client-registration repository.
+     *
+     * <p>The list of {@link ClientRegistration}s is published into {@link #clientRegistrationRegistry} (the same
+     * application-scoped registry shared by every other OAuth2 filter), keyed by this filter's name. The shared
+     * registry — not a per-filter {@code InMemoryClientRegistrationRepository} — is returned so that Spring's
+     * {@code OAuth2AuthorizationRequestRedirectFilter} inside this filter's sub-chain can resolve a scoped registration
+     * ID owned by a sibling OAuth2 filter without throwing under Spring Security 7.
+     *
+     * <p>When no shared registry has been wired (legacy / minimal test setups), the method falls back to the previous
+     * private-repository behavior so a single-filter deployment still works.
+     */
+    private ClientRegistrationRepository createClientRegistrationRepository() {
         String lFilterName = configuration.getName();
         List<ClientRegistration> lRegistrations = new ArrayList<>();
         if (configuration.isGoogleEnabled()) {
@@ -277,6 +308,16 @@ public class GeoServerOAuth2LoginAuthenticationFilterBuilder implements GeoServe
         } else {
             eventPublisher.publishEvent(disableButtonEvent(this, REG_ID_OIDC, scopedRegId(lFilterName, REG_ID_OIDC)));
         }
+
+        if (clientRegistrationRegistry != null) {
+            // Atomically replace this filter's contribution to the shared registry and return the registry itself.
+            // Every OAuth2 filter's HttpSecurity is wired to the same repository instance, which is what lets each
+            // filter's Spring redirect-filter resolve any other filter's scoped registration ID.
+            clientRegistrationRegistry.replaceFilterRegistrations(lFilterName, lRegistrations);
+            return clientRegistrationRegistry;
+        }
+        // Fallback: no shared registry wired (e.g. very minimal tests). Falls back to private-per-filter semantics —
+        // multi-filter login URL routing will not work in this mode, but single-filter deployments still do.
         return new InMemoryClientRegistrationRepository(lRegistrations);
     }
 
@@ -476,7 +517,7 @@ public class GeoServerOAuth2LoginAuthenticationFilterBuilder implements GeoServe
     }
 
     /** @return the clientRegistrationRepository */
-    public InMemoryClientRegistrationRepository getClientRegistrationRepository() {
+    public ClientRegistrationRepository getClientRegistrationRepository() {
         if (clientRegistrationRepository == null) {
             clientRegistrationRepository = createClientRegistrationRepository();
         }
@@ -484,7 +525,7 @@ public class GeoServerOAuth2LoginAuthenticationFilterBuilder implements GeoServe
     }
 
     /** @param pClientRegistrationRepository the clientRegistrationRepository to set */
-    public void setClientRegistrationRepository(InMemoryClientRegistrationRepository pClientRegistrationRepository) {
+    public void setClientRegistrationRepository(ClientRegistrationRepository pClientRegistrationRepository) {
         clientRegistrationRepository = pClientRegistrationRepository;
     }
 
@@ -692,6 +733,17 @@ public class GeoServerOAuth2LoginAuthenticationFilterBuilder implements GeoServe
     /** @param pSecurityManager the securityManager to set */
     public void setSecurityManager(GeoServerSecurityManager pSecurityManager) {
         securityManager = pSecurityManager;
+    }
+
+    /**
+     * Inject the application-wide {@link GeoServerOAuth2ClientRegistrationRegistry}. When set, the builder publishes
+     * this filter's registrations into the shared registry and returns it from
+     * {@link #createClientRegistrationRepository()} so that Spring's redirect / login filters in every OAuth2 filter's
+     * sub-chain can resolve scoped registration IDs owned by sibling filters. Required for multi-filter deployments;
+     * when {@code null}, the builder falls back to the legacy private per-filter repository.
+     */
+    public void setClientRegistrationRegistry(GeoServerOAuth2ClientRegistrationRegistry pRegistry) {
+        clientRegistrationRegistry = pRegistry;
     }
 
     /** @param pEventPublisher the eventPublisher to set */

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginAuthenticationProvider.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginAuthenticationProvider.java
@@ -88,6 +88,7 @@ public class GeoServerOAuth2LoginAuthenticationProvider extends AbstractFilterPr
         lBuilder.setConfiguration(lConfig);
         lBuilder.setSecurityManager(securityManager);
         lBuilder.setEventPublisher(context);
+        lBuilder.setClientRegistrationRegistry(getOptionalBean(GeoServerOAuth2ClientRegistrationRegistry.class));
         lBuilder.setHttpSecurityCustomizer(lHttpCustomizer);
         lBuilder.setClientRegistrationCustomizer(lClientCustomizer);
         if (lBuilderCustomizer != null) {

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginFilterConfig.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginFilterConfig.java
@@ -175,9 +175,26 @@ public class GeoServerOAuth2LoginFilterConfig extends PreAuthenticatedUserNameFi
         this.oidcRedirectUri = redirectUri(REG_ID_OIDC);
     }
 
+    /**
+     * Builds the redirect URI for a given provider, scoped to this filter's name so that multiple filter instances of
+     * the same provider type produce distinct callback URLs.
+     *
+     * <p>The URI uses the {@code <filterName>__<baseRegId>} scoped registration ID — matching the
+     * {@link org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId#scopedRegId(String, String) scoped
+     * registration ID} that the filter builder assigns to the corresponding Spring {@code ClientRegistration}. This
+     * keeps each filter's Keycloak / IdP callback distinct at URL level, not just at session-state level, which is
+     * essential when administrators register multiple filters of the same provider type (e.g. one OIDC filter per
+     * identity provider — Keycloak + Auth0 + Entra-as-custom).
+     *
+     * <p>If the filter has no name yet (e.g. at construction time, before XStream deserialization populates the
+     * {@code name} field), the URI degrades gracefully to the un-scoped {@code <baseRegId>} form. The provider that
+     * loads the filter calls {@link #calculateRedirectUris()} once the name is set, which produces the correct scoped
+     * URIs.
+     */
     private String redirectUri(String pRegId) {
         String lBase = baseRedirectUriNormalized();
-        return lBase + OIDC_INCOMING_CODE_ENDPOINT + pRegId;
+        String scopedId = GeoServerOAuth2ClientRegistrationId.scopedRegId(getName(), pRegId);
+        return lBase + OIDC_INCOMING_CODE_ENDPOINT + scopedId;
     }
 
     private String createPostLogoutRedirectUri() {

--- a/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2OpaqueTokenIntrospector.java
+++ b/src/community/security/oidc/oidc-core/src/main/java/org/geoserver/security/oauth2/login/GeoServerOAuth2OpaqueTokenIntrospector.java
@@ -8,7 +8,8 @@ import static java.util.logging.Level.SEVERE;
 import static java.util.stream.Collectors.toList;
 import static org.geoserver.security.impl.GeoServerUser.ADMIN_USERNAME;
 import static org.geoserver.security.impl.GeoServerUser.ROOT_USERNAME;
-import static org.geoserver.security.jwtheaders.roles.JwtHeadersRolesExtractor.asStringList;
+import static org.geoserver.security.oauth2.common.OAuth2ClaimsHelpers.asStringList;
+import static org.geoserver.security.oauth2.common.OAuth2ClaimsHelpers.getClaim;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -25,9 +26,7 @@ import java.util.logging.Logger;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.impl.GeoServerRole;
 import org.geoserver.security.impl.RoleCalculator;
-import org.geoserver.security.jwtheaders.JwtConfiguration;
-import org.geoserver.security.jwtheaders.roles.RoleConverter;
-import org.geoserver.security.jwtheaders.username.JwtHeaderUserNameExtractor;
+import org.geoserver.security.oauth2.common.OAuth2RoleConverter;
 import org.geoserver.security.oauth2.common.TokenIntrospector;
 import org.geotools.util.logging.Logging;
 import org.springframework.security.core.GrantedAuthority;
@@ -52,7 +51,7 @@ public final class GeoServerOAuth2OpaqueTokenIntrospector
     private final TokenIntrospector delegate;
     private final GeoServerSecurityManager securityManager;
     private final GeoServerOAuth2LoginFilterConfig config;
-    private final RoleConverter roleConverter;
+    private final OAuth2RoleConverter roleConverter;
 
     public GeoServerOAuth2OpaqueTokenIntrospector(
             TokenIntrospector delegate,
@@ -61,11 +60,8 @@ public final class GeoServerOAuth2OpaqueTokenIntrospector
         this.delegate = Objects.requireNonNull(delegate, "delegate");
         this.securityManager = Objects.requireNonNull(securityManager, "securityManager");
         this.config = Objects.requireNonNull(config, "config");
-
-        JwtConfiguration jwtConfiguration = new JwtConfiguration();
-        jwtConfiguration.setRoleConverterString(config.getRoleConverterString());
-        jwtConfiguration.setOnlyExternalListedRoles(config.isOnlyExternalListedRoles());
-        this.roleConverter = new RoleConverter(jwtConfiguration);
+        this.roleConverter =
+                new OAuth2RoleConverter(config.getRoleConverterString(), config.isOnlyExternalListedRoles());
     }
 
     @Override
@@ -198,7 +194,7 @@ public final class GeoServerOAuth2OpaqueTokenIntrospector
         if (!StringUtils.hasText(claimName)) {
             return null;
         }
-        Object o = JwtHeaderUserNameExtractor.getClaim(claims, claimName);
+        Object o = getClaim(claims, claimName);
         if (o == null) {
             return null;
         }
@@ -233,13 +229,13 @@ public final class GeoServerOAuth2OpaqueTokenIntrospector
                         if (StringUtils.hasText(s)) roleStrings.add(s);
                     }
                 } else {
-                    Object raw = JwtHeaderUserNameExtractor.getClaim(claims, claimName);
+                    Object raw = getClaim(claims, claimName);
                     safeAddAll(roleStrings, asStringList(raw));
                     safeAddAll(roleStrings, asStringList(rawAlt));
                 }
             }
         } else {
-            Object raw = JwtHeaderUserNameExtractor.getClaim(claims, claimName);
+            Object raw = getClaim(claims, claimName);
             safeAddAll(roleStrings, asStringList(raw));
         }
 

--- a/src/community/security/oidc/oidc-core/src/main/resources/applicationContext.xml
+++ b/src/community/security/oidc/oidc-core/src/main/resources/applicationContext.xml
@@ -68,4 +68,13 @@
 		class="org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration" />
 		
 	<bean id="oidcIdTokenDecoderFactory" class="org.geoserver.security.oauth2.spring.GeoServerOidcIdTokenDecoderFactory"/>
+
+	<!--
+		Application-wide registry of every active OAuth2 filter's ClientRegistration entries. Shared by every
+		GeoServerOAuth2LoginAuthenticationFilter so that Spring's OAuth2 redirect / login filters can resolve scoped
+		registration IDs owned by sibling filters — fixes the Spring Security 7 InvalidClientRegistrationIdException
+		that bit multi-OIDC-filter deployments under the previous per-filter-private repository design.
+	-->
+	<bean id="geoServerOAuth2ClientRegistrationRegistry"
+		class="org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationRegistry"/>
 </beans>

--- a/src/community/security/oidc/oidc-core/src/test/java/org/geoserver/security/oauth2/login/GeoServerOAuth2ClientRegistrationRegistryTest.java
+++ b/src/community/security/oidc/oidc-core/src/test/java/org/geoserver/security/oauth2/login/GeoServerOAuth2ClientRegistrationRegistryTest.java
@@ -1,0 +1,185 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.oauth2.login;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+
+/**
+ * Unit tests for {@link GeoServerOAuth2ClientRegistrationRegistry}.
+ *
+ * <p>These cover the invariants the rest of the OIDC plugin relies on for the shared-registry fix to the Spring 7
+ * multi-filter HTTP 500 bug:
+ *
+ * <ul>
+ *   <li>contributions are keyed by filter name and atomically replaceable;
+ *   <li>cross-filter lookup of scoped registration IDs always succeeds while the contribution is live;
+ *   <li>removal / retain semantics drop entries cleanly so a deleted filter's old client credentials cannot resolve.
+ * </ul>
+ */
+public class GeoServerOAuth2ClientRegistrationRegistryTest {
+
+    private GeoServerOAuth2ClientRegistrationRegistry sut;
+
+    @Before
+    public void setUp() {
+        sut = new GeoServerOAuth2ClientRegistrationRegistry();
+    }
+
+    private static ClientRegistration registrationFor(String scopedRegId) {
+        // Build a minimally-valid ClientRegistration. The fields we care about for the registry contract are the
+        // registrationId (used as the key) and clientId (used to verify equality in some tests). Everything else is
+        // a placeholder.
+        return ClientRegistration.withRegistrationId(scopedRegId)
+                .clientId("client-" + scopedRegId)
+                .clientSecret("secret-" + scopedRegId)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://example.com/cb/" + scopedRegId)
+                .authorizationUri("https://idp.example.com/auth")
+                .tokenUri("https://idp.example.com/token")
+                .build();
+    }
+
+    @Test
+    public void registryStartsEmpty() {
+        assertEquals(0, sut.size());
+        assertEquals(0, sut.filterCount());
+        assertNull(sut.findByRegistrationId("anything"));
+        assertNull(sut.findByRegistrationId(null));
+    }
+
+    @Test
+    public void replaceFilterRegistrations_addsAndLookupSucceeds() {
+        ClientRegistration cr = registrationFor("keycloak-prod__oidc");
+        sut.replaceFilterRegistrations("keycloak-prod", List.of(cr));
+
+        assertEquals(1, sut.size());
+        assertEquals(1, sut.filterCount());
+        ClientRegistration found = sut.findByRegistrationId("keycloak-prod__oidc");
+        assertNotNull(found);
+        assertEquals("client-keycloak-prod__oidc", found.getClientId());
+    }
+
+    @Test
+    public void replaceFilterRegistrations_isAtomicForTheSameFilter() {
+        // Initial contribution: one OIDC registration.
+        sut.replaceFilterRegistrations("entra", List.of(registrationFor("entra__oidc")));
+        assertEquals(1, sut.size());
+
+        // Refresh: same filter now contributes a different provider. The old OIDC registration must be removed,
+        // the new Microsoft one inserted, and the per-filter count must remain 1.
+        sut.replaceFilterRegistrations("entra", List.of(registrationFor("entra__microsoft")));
+        assertEquals(1, sut.size());
+        assertEquals(1, sut.filterCount());
+        assertNull("old OIDC registration must have been purged", sut.findByRegistrationId("entra__oidc"));
+        assertNotNull("new Microsoft registration must be visible", sut.findByRegistrationId("entra__microsoft"));
+    }
+
+    @Test
+    public void multipleFilters_independentRegistrationsAllLookupable() {
+        // The core multi-filter invariant: every contributing filter's registration must be resolvable, regardless
+        // of who registered it first or last. Without this, Spring's OAuth2 redirect filter inside one filter's
+        // sub-chain throws InvalidClientRegistrationIdException when asked about a sibling's scoped id (the very bug
+        // the registry exists to fix).
+        sut.replaceFilterRegistrations("keycloak-prod", List.of(registrationFor("keycloak-prod__oidc")));
+        sut.replaceFilterRegistrations("auth0-staging", List.of(registrationFor("auth0-staging__oidc")));
+        sut.replaceFilterRegistrations("entra-tenant", List.of(registrationFor("entra-tenant__microsoft")));
+
+        assertEquals(3, sut.size());
+        assertEquals(3, sut.filterCount());
+        assertNotNull(sut.findByRegistrationId("keycloak-prod__oidc"));
+        assertNotNull(sut.findByRegistrationId("auth0-staging__oidc"));
+        assertNotNull(sut.findByRegistrationId("entra-tenant__microsoft"));
+    }
+
+    @Test
+    public void removeFilterRegistrations_dropsAllOfThatFiltersEntries() {
+        sut.replaceFilterRegistrations(
+                "multi-provider",
+                Arrays.asList(registrationFor("multi-provider__oidc"), registrationFor("multi-provider__microsoft")));
+        sut.replaceFilterRegistrations("survivor", List.of(registrationFor("survivor__oidc")));
+        assertEquals(3, sut.size());
+
+        sut.removeFilterRegistrations("multi-provider");
+
+        assertEquals(1, sut.size());
+        assertEquals(1, sut.filterCount());
+        assertNull(sut.findByRegistrationId("multi-provider__oidc"));
+        assertNull(sut.findByRegistrationId("multi-provider__microsoft"));
+        assertNotNull("unrelated filter must survive removal of a sibling", sut.findByRegistrationId("survivor__oidc"));
+    }
+
+    @Test
+    public void replaceWithNullOrEmpty_isEquivalentToRemove() {
+        sut.replaceFilterRegistrations("filter", List.of(registrationFor("filter__oidc")));
+        assertEquals(1, sut.size());
+
+        sut.replaceFilterRegistrations("filter", null);
+        assertEquals("null collection must purge the filter's entries", 0, sut.size());
+
+        sut.replaceFilterRegistrations("filter", List.of(registrationFor("filter__oidc")));
+        sut.replaceFilterRegistrations("filter", List.of());
+        assertEquals("empty collection must purge the filter's entries", 0, sut.size());
+    }
+
+    @Test
+    public void retainFilters_dropsContributionsNotInTheRetainSet() {
+        sut.replaceFilterRegistrations("keep-a", List.of(registrationFor("keep-a__oidc")));
+        sut.replaceFilterRegistrations("keep-b", List.of(registrationFor("keep-b__oidc")));
+        sut.replaceFilterRegistrations("drop-c", List.of(registrationFor("drop-c__oidc")));
+        sut.replaceFilterRegistrations("drop-d", List.of(registrationFor("drop-d__oidc")));
+        assertEquals(4, sut.size());
+
+        sut.retainFilters(new HashSet<>(Arrays.asList("keep-a", "keep-b")));
+
+        assertEquals(2, sut.size());
+        assertNotNull(sut.findByRegistrationId("keep-a__oidc"));
+        assertNotNull(sut.findByRegistrationId("keep-b__oidc"));
+        assertNull(sut.findByRegistrationId("drop-c__oidc"));
+        assertNull(sut.findByRegistrationId("drop-d__oidc"));
+    }
+
+    @Test
+    public void iterator_returnsSnapshotOfCurrentRegistrations() {
+        sut.replaceFilterRegistrations("a", List.of(registrationFor("a__oidc")));
+        sut.replaceFilterRegistrations("b", List.of(registrationFor("b__oidc")));
+
+        Iterator<ClientRegistration> it = sut.iterator();
+        int count = 0;
+        while (it.hasNext()) {
+            ClientRegistration cr = it.next();
+            assertTrue(
+                    "unexpected registration in iteration: " + cr.getRegistrationId(),
+                    "a__oidc".equals(cr.getRegistrationId()) || "b__oidc".equals(cr.getRegistrationId()));
+            count++;
+        }
+        assertEquals(2, count);
+    }
+
+    @Test
+    public void nullFilterName_isIgnored() {
+        // Defensive: a null filter name during a corrupted save should not blow up the registry. Existing entries
+        // must be preserved.
+        sut.replaceFilterRegistrations("real", List.of(registrationFor("real__oidc")));
+        sut.replaceFilterRegistrations(null, List.of(registrationFor("ghost__oidc")));
+
+        assertEquals(1, sut.size());
+        assertNotNull(sut.findByRegistrationId("real__oidc"));
+        assertNull(sut.findByRegistrationId("ghost__oidc"));
+    }
+}

--- a/src/community/security/oidc/oidc-core/src/test/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginFilterConfigTest.java
+++ b/src/community/security/oidc/oidc-core/src/test/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginFilterConfigTest.java
@@ -6,6 +6,7 @@ package org.geoserver.security.oauth2.login;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -292,6 +293,56 @@ public class GeoServerOAuth2LoginFilterConfigTest {
 
         // Should reflect the new base immediately
         assertEquals("http://host-b/geoserver/web/", config.getPostLogoutRedirectUri());
+    }
+
+    /**
+     * Each filter instance produces redirect URIs scoped to its name. Without scoping, multiple OIDC filters in the
+     * same GeoServer would share an identical callback URL — Keycloak / IdP cannot route the callback to the right
+     * Spring {@code ClientRegistration} by URL alone, and the system has to rely entirely on the session-stored state
+     * parameter, which is fragile across browser tabs and IdP behaviours. With scoping, each filter's callback URL
+     * carries its own scoped registration ID (e.g. {@code keycloak-prod__oidc}) and the routing is unambiguous.
+     */
+    @Test
+    public void testRedirectUris_scopedToFilterName() {
+        System.setProperty(
+                GeoServerOAuth2LoginFilterConfig.OPENID_TEST_GS_PROXY_BASE, "http://gs.example.com/geoserver");
+
+        GeoServerOAuth2LoginFilterConfig primary = new GeoServerOAuth2LoginFilterConfig();
+        primary.setName("keycloak-prod");
+        primary.calculateRedirectUris();
+
+        GeoServerOAuth2LoginFilterConfig secondary = new GeoServerOAuth2LoginFilterConfig();
+        secondary.setName("auth0-staging");
+        secondary.calculateRedirectUris();
+
+        String base = "http://gs.example.com/geoserver/web/login/oauth2/code/";
+        assertEquals(base + "keycloak-prod__oidc", primary.getOidcRedirectUri());
+        assertEquals(base + "keycloak-prod__google", primary.getGoogleRedirectUri());
+        assertEquals(base + "keycloak-prod__gitHub", primary.getGitHubRedirectUri());
+        assertEquals(base + "keycloak-prod__microsoft", primary.getMsRedirectUri());
+
+        assertEquals(base + "auth0-staging__oidc", secondary.getOidcRedirectUri());
+
+        // Pairwise distinctness — the per-filter routing depends on this.
+        assertNotEquals(primary.getOidcRedirectUri(), secondary.getOidcRedirectUri());
+    }
+
+    /**
+     * Backwards-compatibility: when the filter has no name yet (e.g. just-constructed config, before the security
+     * manager assigns the name from the saved XML), the redirect URI falls back to the un-scoped base form. This keeps
+     * the no-name code path well-defined; once the filter name is set and
+     * {@link GeoServerOAuth2LoginFilterConfig#calculateRedirectUris()} is called by the provider, the URI is upgraded
+     * to the scoped form.
+     */
+    @Test
+    public void testRedirectUris_unscopedWhenFilterNameMissing() {
+        System.setProperty(
+                GeoServerOAuth2LoginFilterConfig.OPENID_TEST_GS_PROXY_BASE, "http://gs.example.com/geoserver");
+        GeoServerOAuth2LoginFilterConfig config = new GeoServerOAuth2LoginFilterConfig();
+        // intentionally no setName() — simulates the just-constructed / pre-deserialize state
+        config.calculateRedirectUris();
+
+        assertEquals("http://gs.example.com/geoserver/web/login/oauth2/code/oidc", config.getOidcRedirectUri());
     }
 
     /** All three UI fields should use the same dynamic base. */

--- a/src/community/security/oidc/oidc-core/src/test/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginIntegrationTest.java
+++ b/src/community/security/oidc/oidc-core/src/test/java/org/geoserver/security/oauth2/login/GeoServerOAuth2LoginIntegrationTest.java
@@ -543,7 +543,9 @@ public class GeoServerOAuth2LoginIntegrationTest extends GeoServerSystemTestSupp
             assertThat(kvp, Matchers.hasEntry("client_id", CLIENT_ID));
             assertThat(
                     kvp,
-                    Matchers.hasEntry("redirect_uri", "http://localhost:8080/geoserver/web/login/oauth2/code/oidc"));
+                    Matchers.hasEntry(
+                            "redirect_uri",
+                            "http://localhost:8080/geoserver/web/login/oauth2/code/openidconnect__oidc"));
             assertThat(kvp, Matchers.hasEntry("scope", "openid profile email phone address"));
             assertThat(kvp, Matchers.hasEntry("response_type", "code"));
 
@@ -555,7 +557,7 @@ public class GeoServerOAuth2LoginIntegrationTest extends GeoServerSystemTestSupp
 
             // make believe we authenticated and got the redirect back, with the code
             MockHttpServletRequest codeRequest =
-                    createRequest("web/login/oauth2/code/oidc?code=" + CODE + "&state=" + state);
+                    createRequest("web/login/oauth2/code/openidconnect__oidc?code=" + CODE + "&state=" + state);
             codeRequest.setSession(lSession);
             executeOnSecurityFilters(codeRequest);
 
@@ -597,7 +599,9 @@ public class GeoServerOAuth2LoginIntegrationTest extends GeoServerSystemTestSupp
             assertThat(kvp, Matchers.hasEntry("client_id", CLIENT_ID));
             assertThat(
                     kvp,
-                    Matchers.hasEntry("redirect_uri", "http://localhost:8080/geoserver/web/login/oauth2/code/oidc"));
+                    Matchers.hasEntry(
+                            "redirect_uri",
+                            "http://localhost:8080/geoserver/web/login/oauth2/code/openidconnect__oidc"));
             assertThat(kvp, Matchers.hasEntry("scope", "openid profile email phone address"));
             assertThat(kvp, Matchers.hasEntry("response_type", "code"));
 
@@ -609,7 +613,7 @@ public class GeoServerOAuth2LoginIntegrationTest extends GeoServerSystemTestSupp
 
             // make believe we authenticated and got the redirect back, with the code
             MockHttpServletRequest codeRequest =
-                    createRequest("web/login/oauth2/code/oidc?code=" + CODE + "&state=" + state);
+                    createRequest("web/login/oauth2/code/openidconnect__oidc?code=" + CODE + "&state=" + state);
             codeRequest.setSession(lSession);
             executeOnSecurityFilters(codeRequest);
 

--- a/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginAuthProviderPanel.java
+++ b/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginAuthProviderPanel.java
@@ -296,6 +296,16 @@ public class OAuth2LoginAuthProviderPanel
         add(providerSelector);
         add(new HelpLink("providerSelectorHelp", this).setDialog(dialog));
 
+        // Eager write-through of the dropdown's effective selection into the underlying *Enabled
+        // booleans. The dropdown's AjaxFormComponentUpdatingBehavior only fires on user-driven
+        // change events, so for a fresh config the getter's "oidc" default would render in the UI
+        // without ever calling setSelectedProvider — the filter would then save with oidcEnabled
+        // (and every other *Enabled) false, the filter builder would publish a disableButtonEvent
+        // and the login button would never appear. Calling the setter here makes the persisted
+        // state self-consistent with the displayed default, idempotent for configs that already
+        // have an explicit selection.
+        configModel.getObject().setSelectedProvider(configModel.getObject().getSelectedProvider());
+
         // -- Provider settings panels (one per provider, shown/hidden based on dropdown) --
         RepeatingView prefixView = new RepeatingView("pfv");
         add(prefixView);

--- a/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginButtonManager.java
+++ b/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginButtonManager.java
@@ -6,8 +6,10 @@ package org.geoserver.web.security.oauth2.login;
 
 import static org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilterBuilder.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -15,6 +17,7 @@ import java.util.SortedSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geoserver.platform.ExtensionProvider;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.RequestFilterChain;
 import org.geoserver.security.SecurityManagerListener;
@@ -28,6 +31,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 
@@ -65,7 +69,11 @@ import org.springframework.context.event.EventListener;
  * @see org.geoserver.web.LoginFormInfo
  * @see org.geoserver.web.GeoServerBasePage
  */
-public class OAuth2LoginButtonManager implements BeanFactoryAware, SecurityManagerListener {
+public class OAuth2LoginButtonManager
+        implements BeanFactoryAware,
+                ApplicationListener<ContextRefreshedEvent>,
+                SecurityManagerListener,
+                ExtensionProvider<LoginFormInfo> {
 
     private static final Logger LOGGER = Logging.getLogger(OAuth2LoginButtonManager.class);
 
@@ -125,8 +133,32 @@ public class OAuth2LoginButtonManager implements BeanFactoryAware, SecurityManag
      *   <li>The sweep is idempotent — {@link #registerButton} no-ops on already-registered scoped IDs.
      * </ul>
      */
-    @EventListener
-    public void onContextRefreshed(ContextRefreshedEvent event) {
+    /**
+     * Register as a {@link SecurityManagerListener} after the application context is fully refreshed.
+     *
+     * <p>Lifecycle choice rationale:
+     *
+     * <ul>
+     *   <li>{@link #setBeanFactory(BeanFactory)} and {@code afterPropertiesSet()} fire <em>during</em> this bean's
+     *       initialization. Asking the factory for {@code GeoServerSecurityManager.class} at that moment triggers
+     *       Spring to resolve {@code authenticationManager} (still mid-construction in GeoServer's bean graph) and
+     *       throws {@code BeanCurrentlyInCreationException}.
+     *   <li>{@code @EventListener ContextRefreshedEvent} would work, but oidc-web's {@code applicationContext.xml}
+     *       doesn't declare {@code <context:annotation-config/>}, so the {@code EventListenerMethodProcessor} that
+     *       handles {@code @EventListener} is not installed in this context.
+     *   <li>{@link ApplicationListener} is a Spring-detected interface: any singleton bean implementing it is
+     *       automatically wired by {@code AbstractApplicationContext.registerListeners()} during context refresh, with
+     *       no annotation processing required.
+     * </ul>
+     *
+     * <p>Context refresh fires the listener AFTER every bean in this context (and its parents) is fully constructed, so
+     * the {@code GeoServerSecurityManager} lookup is safe.
+     *
+     * <p>The {@link #securityManagerListenerRegistered} flag guards against duplicate registration when the event fires
+     * multiple times — e.g. if both the parent and a child context publish refresh events that reach this bean.
+     */
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
         if (securityManagerListenerRegistered || beanFactory == null) {
             return;
         }
@@ -134,16 +166,16 @@ public class OAuth2LoginButtonManager implements BeanFactoryAware, SecurityManag
             securityManager = beanFactory.getBean(GeoServerSecurityManager.class);
             securityManager.addListener(this);
             securityManagerListenerRegistered = true;
-            // Initial sweep: in case the context refresh happens after security-manager bootstrap has already
-            // built filters and fired their events (early-bind race), this catches any filters whose events we
-            // missed. Idempotent against already-registered buttons.
+            LOGGER.log(Level.CONFIG, "OAuth2LoginButtonManager registered as SecurityManagerListener");
+            // Initial sweep: the security manager may have rebuilt filter chains before this listener was wired
+            // (the chain-proxy listener fires eagerly too). The sweep is idempotent against already-registered
+            // buttons and corrects for any startup-time event we missed.
             sweepOAuth2Filters();
         } catch (Exception e) {
             LOGGER.log(
                     Level.WARNING,
                     "OAuth2LoginButtonManager could not register itself as a SecurityManagerListener; "
-                            + "new OIDC filters will not get their login buttons registered until the next container "
-                            + "restart. Cause: ",
+                            + "OIDC filter changes will not take effect until the next container restart. Cause: ",
                     e);
         }
     }
@@ -155,6 +187,7 @@ public class OAuth2LoginButtonManager implements BeanFactoryAware, SecurityManag
      */
     @Override
     public void handlePostChanged(GeoServerSecurityManager pSecurityManager) {
+        LOGGER.log(Level.FINE, "OAuth2LoginButtonManager.handlePostChanged invoked — running sweep");
         sweepOAuth2Filters();
     }
 
@@ -181,12 +214,20 @@ public class OAuth2LoginButtonManager implements BeanFactoryAware, SecurityManag
         }
         try {
             Set<String> inChainFilterNames = collectInChainFilterNames();
+            LOGGER.log(
+                    Level.FINE,
+                    "OAuth2LoginButtonManager.sweep: in-chain={0}; currently-registered={1}",
+                    new Object[] {inChainFilterNames, registeredButtons.keySet()});
 
             // 1. Drop buttons for filters that were once in-chain but no longer are. Iterate over a snapshot of the
             //    registry keys to avoid concurrent modification while destroying singletons inside the loop.
             for (String existingScopedRegId : new HashSet<>(registeredButtons.keySet())) {
                 String existingFilterName = filterNameFromScopedRegId(existingScopedRegId);
                 if (!inChainFilterNames.contains(existingFilterName)) {
+                    LOGGER.log(
+                            Level.CONFIG,
+                            "Dropping OAuth2 login button for filter {0} (no longer in any chain)",
+                            existingFilterName);
                     unregisterButton(existingScopedRegId);
                 }
             }
@@ -257,6 +298,10 @@ public class OAuth2LoginButtonManager implements BeanFactoryAware, SecurityManag
     @Override
     public void setBeanFactory(BeanFactory pBeanFactory) throws BeansException {
         if (pBeanFactory instanceof DefaultListableBeanFactory) {
+            // Just remember the factory; defer the {@link GeoServerSecurityManager} lookup + listener registration
+            // until {@link #onApplicationEvent} runs, which is the only Spring hook that fires AFTER the entire
+            // application context has finished initializing (so {@code authenticationManager} is no longer
+            // mid-construction and the {@code GeoServerSecurityManager} bean is reachable).
             this.beanFactory = (DefaultListableBeanFactory) pBeanFactory;
         } else {
             LOGGER.log(
@@ -298,36 +343,21 @@ public class OAuth2LoginButtonManager implements BeanFactoryAware, SecurityManag
 
     private void registerButton(String scopedRegId, String baseRegId) {
         if (registeredButtons.containsKey(scopedRegId)) {
-            // A repeat enable for the same scoped ID happens on every filter rebuild (e.g. each Save); we
-            // keep the existing singleton so that bean identity stays stable for any consumer holding a
-            // reference and so that Spring's singleton registry does not log a "already-registered" error.
+            // A repeat enable for the same scoped ID happens on every filter rebuild (e.g. each Save); keep the
+            // existing entry so identity stays stable.
             return;
         }
         LoginFormInfo info = buildLoginFormInfo(scopedRegId, baseRegId);
-        String beanName = beanName(scopedRegId);
-        try {
-            beanFactory.registerSingleton(beanName, info);
-            registeredButtons.put(scopedRegId, info);
-            LOGGER.log(Level.FINE, "Registered OAuth2 login button singleton: {0}", beanName);
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to register OAuth2 login button singleton " + beanName, e);
-        }
+        registeredButtons.put(scopedRegId, info);
+        LOGGER.log(Level.FINE, "Registered OAuth2 login button: {0}", beanName(scopedRegId));
     }
 
     private void unregisterButton(String scopedRegId) {
         LoginFormInfo info = registeredButtons.remove(scopedRegId);
         if (info == null) {
-            // Spring's destroySingleton would throw if asked to destroy a never-registered bean, so we
-            // skip the call rather than relying on its behavior.
             return;
         }
-        String beanName = beanName(scopedRegId);
-        try {
-            beanFactory.destroySingleton(beanName);
-            LOGGER.log(Level.FINE, "Unregistered OAuth2 login button singleton: {0}", beanName);
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to destroy OAuth2 login button singleton " + beanName, e);
-        }
+        LOGGER.log(Level.FINE, "Unregistered OAuth2 login button: {0}", beanName(scopedRegId));
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -415,5 +445,31 @@ public class OAuth2LoginButtonManager implements BeanFactoryAware, SecurityManag
     /** Read-only view of the registered buttons keyed by scoped registration ID. Visible for testing. */
     Map<String, LoginFormInfo> getRegisteredButtons() {
         return Collections.unmodifiableMap(registeredButtons);
+    }
+
+    // ── ExtensionProvider<LoginFormInfo> ────────────────────────────────────
+    //
+    // Bypass GeoServerExtensions.extensionsCache for our dynamic singletons. That cache (a static
+    // ConcurrentHashMap in GeoServerExtensions, keyed by extension-point class) is populated on the
+    // first lookup of bean names of a given type, and is only invalidated on a fresh ContextRefreshedEvent
+    // — NOT on registerSingleton/destroySingleton calls. So dynamically-registered LoginFormInfo singletons
+    // (the heart of this manager's model) are invisible to GeoServerBasePage between context refreshes,
+    // which manifests as "I added an OIDC filter and the button doesn't show until I restart GeoServer".
+    //
+    // ExtensionProvider is queried on EVERY call to GeoServerExtensions.extensions(...), no caching. By
+    // returning the live snapshot of our registry here we keep the rendered button list in sync with the
+    // current security configuration without requiring a JVM restart or any cache busting at the
+    // GeoServerExtensions layer.
+
+    @Override
+    public Class<LoginFormInfo> getExtensionPoint() {
+        return LoginFormInfo.class;
+    }
+
+    @Override
+    public List<LoginFormInfo> getExtensions(Class<LoginFormInfo> extensionPoint) {
+        // Snapshot — concurrent registry mutations are safe to iterate via the ConcurrentHashMap, and
+        // returning a copy decouples consumers from later updates.
+        return new ArrayList<>(registeredButtons.values());
     }
 }

--- a/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginButtonManager.java
+++ b/src/community/security/oidc/oidc-web/src/main/java/org/geoserver/web/security/oauth2/login/OAuth2LoginButtonManager.java
@@ -4,71 +4,416 @@
  */
 package org.geoserver.web.security.oauth2.login;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import static org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilterBuilder.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
+
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilterBuilder;
+import java.util.SortedSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.RequestFilterChain;
+import org.geoserver.security.SecurityManagerListener;
+import org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId;
+import org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationRegistry;
+import org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter;
 import org.geoserver.security.oauth2.login.OAuth2LoginButtonEnablementEvent;
 import org.geoserver.web.LoginFormInfo;
+import org.geotools.util.logging.Logging;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 
 /**
- * Enables login buttons for OAuth2 dynamically, depending on the respective providers enablement state. Tracks
- * enablement per filter instance so that multiple filter instances can coexist: a button stays enabled as long as at
- * least one filter instance enables that provider type. The login path is updated to point to the scoped registration
- * ID of the most recently enabled filter for that provider type.
+ * Manages dynamic registration of OAuth2 / OpenID Connect login buttons — one per active filter instance.
+ *
+ * <p>Each {@link GeoServerOAuth2LoginAuthenticationFilter} that activates a provider publishes an
+ * {@link OAuth2LoginButtonEnablementEvent} during its construction. This manager responds by creating a corresponding
+ * {@link LoginFormInfo} singleton bean — visible to {@link org.geoserver.web.GeoServerBasePage}'s by-type scan — with a
+ * deep link to the filter's scoped authorization endpoint. When the provider is disabled (or the filter reconfigured to
+ * a different provider type), the matching singleton is deregistered.
+ *
+ * <p>This per-filter registration replaces the previous design which declared four static {@link LoginFormInfo} beans
+ * (one per built-in provider type) whose {@code loginPath} was rewritten in place. The static design collapsed multiple
+ * filter instances sharing the same provider type into a single button pointing at "an arbitrary surviving one", which
+ * was incorrect when administrators register several filters of the same provider type — for example one OIDC filter
+ * per identity provider (Keycloak, Auth0, custom Entra, ...). With dynamic registration each filter gets its own
+ * dedicated button with its own deep link.
+ *
+ * <p>Per-instance chain-membership gating happens at registration time inside {@link #sweepOAuth2Filters}: only OAuth2
+ * filters that are bound to at least one request filter chain produce a singleton; filters that are dropped from every
+ * chain have their singletons destroyed on the next sweep. The rendering side
+ * ({@link org.geoserver.web.GeoServerBasePage}) therefore stays unchanged and continues to consume all registered
+ * {@link LoginFormInfo} beans by type.
+ *
+ * <h2>Lifecycle and thread-safety</h2>
+ *
+ * <p>The manager listens via {@link EventListener} for {@link OAuth2LoginButtonEnablementEvent}s that arrive whenever a
+ * {@link GeoServerOAuth2LoginAuthenticationFilter} is (re)built — both at startup as the security configuration is
+ * loaded, and any time an administrator saves a filter through the UI. Multiple saves can race on different filters, so
+ * the listener is {@code synchronized}: each enable / disable composes a map update with a bean-factory mutation that
+ * must be atomic together.
+ *
+ * @see OAuth2LoginButtonEnablementEvent
+ * @see org.geoserver.web.LoginFormInfo
+ * @see org.geoserver.web.GeoServerBasePage
  */
-public class OAuth2LoginButtonManager {
+public class OAuth2LoginButtonManager implements BeanFactoryAware, SecurityManagerListener {
 
-    private List<LoginFormInfo> loginFormInfos = new ArrayList<>();
+    private static final Logger LOGGER = Logging.getLogger(OAuth2LoginButtonManager.class);
+
+    /** Separator between filter name and base registration ID inside a scoped registration ID. */
+    static final String SCOPED_REG_ID_SEPARATOR = "__";
+
+    /** Prefix for dynamically-registered {@link LoginFormInfo} singleton bean names. */
+    static final String DYNAMIC_BEAN_NAME_PREFIX = "oauth2LoginButton__";
+
+    /** Icon resource (under the {@link OAuth2LoginAuthProviderPanel} package) used when no provider matches. */
+    private static final String DEFAULT_ICON = "openid.png";
 
     /**
-     * Tracks which scoped registration IDs have enabled each base provider type. Key: lowercase base registration ID
-     * (e.g. {@code "google"}), value: set of scoped registration IDs that have this type enabled (e.g.
-     * {@code ["myfilter__google"]}).
+     * Cast to {@link DefaultListableBeanFactory} rather than the more generic {@code ConfigurableListableBeanFactory}
+     * interface because we need both {@code registerSingleton(String, Object)} (inherited from
+     * {@code SingletonBeanRegistry}) and {@code destroySingleton(String)} (defined on the
+     * {@code DefaultSingletonBeanRegistry} support class, not on the generic factory interface in Spring 7+). All
+     * GeoServer web application contexts use this concrete factory.
      */
-    private final Map<String, Set<String>> enabledScopedIds = new HashMap<>();
+    private DefaultListableBeanFactory beanFactory;
+
+    /** Dynamically-registered buttons keyed by scoped registration ID. */
+    private final Map<String, LoginFormInfo> registeredButtons = new ConcurrentHashMap<>();
+
+    /**
+     * Resolved on the first {@link ContextRefreshedEvent}; the bean factory is set by Spring earlier (via
+     * {@link #setBeanFactory(BeanFactory)}) but the security manager bean is not necessarily ready until the context
+     * has finished initialising. Used to register ourselves as a {@link SecurityManagerListener} and to perform a
+     * post-save sweep of all OIDC filters — see {@link #sweepOAuth2Filters()}.
+     */
+    private GeoServerSecurityManager securityManager;
+
+    /** Guards against duplicate listener registration on repeat context-refresh events (e.g. test harnesses). */
+    private boolean securityManagerListenerRegistered = false;
 
     public OAuth2LoginButtonManager() {
         super();
     }
 
+    /**
+     * On Spring context refresh, hook the manager into GeoServer's {@link GeoServerSecurityManager} as a
+     * {@link SecurityManagerListener} and do an initial sweep so the buttons for any pre-existing OIDC filters register
+     * without having to wait for the next save.
+     *
+     * <p>This is the runtime hook that makes "save a new OIDC filter through the UI → button appears on next page load"
+     * work without a container restart. {@link GeoServerSecurityManager#saveFilter} alone does not rebuild filter
+     * instances for fresh saves (its {@code fireChanged} flag only flips for <em>modifications</em> to filters already
+     * bound to a chain), so newly-saved filters never get to the build path that publishes the
+     * {@link OAuth2LoginButtonEnablementEvent}. The fix is layered:
+     *
+     * <ul>
+     *   <li>When the admin then binds the new filter to the {@code /web/**} chain and saves it, the security manager
+     *       calls {@link GeoServerSecurityManager#saveSecurityConfig} which DOES fire change notifications.
+     *   <li>We listen for those notifications via {@link #handlePostChanged} and sweep all OIDC filters by name,
+     *       forcing each to load through the provider's {@code createFilter} path, which publishes the enablement
+     *       events, which {@link #enablementChanged} captures and turns into singleton {@link LoginFormInfo} beans.
+     *   <li>The sweep is idempotent — {@link #registerButton} no-ops on already-registered scoped IDs.
+     * </ul>
+     */
     @EventListener
-    public void enablementChanged(OAuth2LoginButtonEnablementEvent pEvent) {
-        String lBaseRegId = pEvent.getRegistrationId().toLowerCase();
-        String lScopedRegId = pEvent.getScopedRegistrationId();
-
-        Set<String> lScoped = enabledScopedIds.computeIfAbsent(lBaseRegId, k -> new HashSet<>());
-        if (pEvent.isEnable()) {
-            lScoped.add(lScopedRegId);
-        } else {
-            lScoped.remove(lScopedRegId);
+    public void onContextRefreshed(ContextRefreshedEvent event) {
+        if (securityManagerListenerRegistered || beanFactory == null) {
+            return;
         }
-
-        boolean lAnyEnabled = !lScoped.isEmpty();
-        // Determine the effective scoped ID for the login path: on enable, use the event's scoped
-        // ID; on disable with remaining enabled filters, pick an arbitrary surviving one.
-        String lEffectiveScopedId = pEvent.isEnable()
-                ? lScopedRegId
-                : (lAnyEnabled ? lScoped.iterator().next() : null);
-
-        for (LoginFormInfo lInfo : loginFormInfos) {
-            if (lInfo.getId() != null && lInfo.getId().toLowerCase().contains(lBaseRegId)) {
-                lInfo.setEnabled(lAnyEnabled);
-                if (lAnyEnabled && lEffectiveScopedId != null) {
-                    lInfo.setLoginPath("/"
-                            + GeoServerOAuth2LoginAuthenticationFilterBuilder.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI
-                            + "/" + lEffectiveScopedId);
-                }
-            }
+        try {
+            securityManager = beanFactory.getBean(GeoServerSecurityManager.class);
+            securityManager.addListener(this);
+            securityManagerListenerRegistered = true;
+            // Initial sweep: in case the context refresh happens after security-manager bootstrap has already
+            // built filters and fired their events (early-bind race), this catches any filters whose events we
+            // missed. Idempotent against already-registered buttons.
+            sweepOAuth2Filters();
+        } catch (Exception e) {
+            LOGGER.log(
+                    Level.WARNING,
+                    "OAuth2LoginButtonManager could not register itself as a SecurityManagerListener; "
+                            + "new OIDC filters will not get their login buttons registered until the next container "
+                            + "restart. Cause: ",
+                    e);
         }
     }
 
-    /** @param pInfos the infos to set */
-    public void setLoginFormInfos(List<LoginFormInfo> pInfos) {
-        loginFormInfos = pInfos;
+    /**
+     * Invoked by GeoServer's {@link GeoServerSecurityManager} after a security configuration change (chain edits,
+     * filter modifications). Sweeps all OIDC filters so any newly-bound filter gets its login button registered without
+     * requiring a JVM restart.
+     */
+    @Override
+    public void handlePostChanged(GeoServerSecurityManager pSecurityManager) {
+        sweepOAuth2Filters();
+    }
+
+    /**
+     * Brings the registered-button set in line with the current security configuration. Two responsibilities:
+     *
+     * <ul>
+     *   <li><b>Register buttons for in-chain filters.</b> For every {@link GeoServerOAuth2LoginAuthenticationFilter}
+     *       that is bound to at least one request filter chain, force a load via the provider's {@code createFilter}
+     *       path — this calls the builder's {@code build()} which publishes the per-provider enable / disable events
+     *       that {@link #enablementChanged} turns into singleton {@link LoginFormInfo} beans.
+     *   <li><b>Drop buttons for off-chain filters.</b> Walk the existing registry, derive each entry's filter name from
+     *       its scoped registration ID, and destroy any singleton whose filter is no longer bound to any chain. This is
+     *       what gates button visibility on chain membership at <em>registration</em> time, so the rendering side
+     *       (GeoServerBasePage) does not need any per-instance chain-membership knowledge.
+     * </ul>
+     *
+     * <p>The sweep is idempotent: repeated runs against an unchanged config are no-ops at both the registration and
+     * destroy layers.
+     */
+    private void sweepOAuth2Filters() {
+        if (securityManager == null) {
+            return;
+        }
+        try {
+            Set<String> inChainFilterNames = collectInChainFilterNames();
+
+            // 1. Drop buttons for filters that were once in-chain but no longer are. Iterate over a snapshot of the
+            //    registry keys to avoid concurrent modification while destroying singletons inside the loop.
+            for (String existingScopedRegId : new HashSet<>(registeredButtons.keySet())) {
+                String existingFilterName = filterNameFromScopedRegId(existingScopedRegId);
+                if (!inChainFilterNames.contains(existingFilterName)) {
+                    unregisterButton(existingScopedRegId);
+                }
+            }
+
+            // 1a. Also purge ClientRegistration contributions for off-chain filters from the shared registry —
+            //     otherwise Spring's resolver would still find the stale registration and the off-chain filter's
+            //     authorization URL would 302 to the IdP even though no GeoServer filter is mounted to handle the
+            //     callback. The button manager owns lifecycle here because it is the listener wired to security
+            //     configuration changes; the OAuth2 builder publishes registrations, the manager removes them.
+            GeoServerOAuth2ClientRegistrationRegistry registry = lookupClientRegistrationRegistry();
+            if (registry != null) {
+                registry.retainFilters(inChainFilterNames);
+            }
+
+            // 2. Load every in-chain OAuth2 filter so its builder publishes the enable / disable events for each
+            //    provider; the manager's @EventListener then registers (or refreshes) the matching buttons.
+            SortedSet<String> oauth2FilterNames =
+                    securityManager.listFilters(GeoServerOAuth2LoginAuthenticationFilter.class);
+            for (String filterName : oauth2FilterNames) {
+                if (!inChainFilterNames.contains(filterName)) {
+                    continue;
+                }
+                try {
+                    // loadFilter goes through the provider's createFilter, which calls the builder's build(),
+                    // which publishes the enablement events for each enabled provider on the filter.
+                    securityManager.loadFilter(filterName);
+                } catch (Exception e) {
+                    LOGGER.log(Level.FINE, "Could not load OAuth2 filter " + filterName + " during sweep; skipping", e);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "OAuth2 filter sweep failed", e);
+        }
+    }
+
+    /**
+     * Resolve the application-wide {@link GeoServerOAuth2ClientRegistrationRegistry}, if present. May be {@code null}
+     * in legacy / minimal test contexts that do not declare the registry bean — in which case the manager simply skips
+     * registry cleanup and relies on the builder's fallback path.
+     */
+    private GeoServerOAuth2ClientRegistrationRegistry lookupClientRegistrationRegistry() {
+        if (beanFactory == null) {
+            return null;
+        }
+        try {
+            return beanFactory.getBean(GeoServerOAuth2ClientRegistrationRegistry.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Collect every filter name that appears in any request filter chain. A filter referenced by more than one chain
+     * counts once. The set is consulted by {@link #sweepOAuth2Filters} to decide which OAuth2 filters are eligible to
+     * produce a login button.
+     */
+    private Set<String> collectInChainFilterNames() throws Exception {
+        Set<String> names = new HashSet<>();
+        for (RequestFilterChain chain :
+                securityManager.getSecurityConfig().getFilterChain().getRequestChains()) {
+            if (chain.getFilterNames() != null) {
+                names.addAll(chain.getFilterNames());
+            }
+        }
+        return names;
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory pBeanFactory) throws BeansException {
+        if (pBeanFactory instanceof DefaultListableBeanFactory) {
+            this.beanFactory = (DefaultListableBeanFactory) pBeanFactory;
+        } else {
+            LOGGER.log(
+                    Level.WARNING,
+                    "OAuth2LoginButtonManager requires DefaultListableBeanFactory but got {0};"
+                            + " dynamic login button registration is disabled.",
+                    pBeanFactory.getClass().getName());
+        }
+    }
+
+    /**
+     * Reacts to a provider being enabled or disabled on a specific OAuth2 / OIDC filter instance.
+     *
+     * <p>{@code synchronized} so that concurrent saves on different filters cannot race the singleton registry: each
+     * register / unregister composes a map update with a bean-factory mutation that must be atomic together.
+     */
+    @EventListener
+    public synchronized void enablementChanged(OAuth2LoginButtonEnablementEvent pEvent) {
+        if (beanFactory == null) {
+            // setBeanFactory either was never called (unusual outside tests) or rejected the factory
+            // type (logged at WARN there). Nothing we can safely do here.
+            return;
+        }
+
+        String scopedRegId = pEvent.getScopedRegistrationId();
+        String baseRegId = pEvent.getRegistrationId();
+        if (scopedRegId == null || baseRegId == null) {
+            LOGGER.log(
+                    Level.FINE, "Ignoring OAuth2LoginButtonEnablementEvent with null scoped or base registration ID.");
+            return;
+        }
+
+        if (pEvent.isEnable()) {
+            registerButton(scopedRegId, baseRegId);
+        } else {
+            unregisterButton(scopedRegId);
+        }
+    }
+
+    private void registerButton(String scopedRegId, String baseRegId) {
+        if (registeredButtons.containsKey(scopedRegId)) {
+            // A repeat enable for the same scoped ID happens on every filter rebuild (e.g. each Save); we
+            // keep the existing singleton so that bean identity stays stable for any consumer holding a
+            // reference and so that Spring's singleton registry does not log a "already-registered" error.
+            return;
+        }
+        LoginFormInfo info = buildLoginFormInfo(scopedRegId, baseRegId);
+        String beanName = beanName(scopedRegId);
+        try {
+            beanFactory.registerSingleton(beanName, info);
+            registeredButtons.put(scopedRegId, info);
+            LOGGER.log(Level.FINE, "Registered OAuth2 login button singleton: {0}", beanName);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to register OAuth2 login button singleton " + beanName, e);
+        }
+    }
+
+    private void unregisterButton(String scopedRegId) {
+        LoginFormInfo info = registeredButtons.remove(scopedRegId);
+        if (info == null) {
+            // Spring's destroySingleton would throw if asked to destroy a never-registered bean, so we
+            // skip the call rather than relying on its behavior.
+            return;
+        }
+        String beanName = beanName(scopedRegId);
+        try {
+            beanFactory.destroySingleton(beanName);
+            LOGGER.log(Level.FINE, "Unregistered OAuth2 login button singleton: {0}", beanName);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to destroy OAuth2 login button singleton " + beanName, e);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private LoginFormInfo buildLoginFormInfo(String scopedRegId, String baseRegId) {
+        LoginFormInfo info = new LoginFormInfo();
+        info.setId(beanName(scopedRegId));
+        // Name drives the UI sort order on the login banner; the "oauth2-" prefix groups all OAuth2 buttons
+        // together while the scoped registration ID keeps it stable and per-filter unique.
+        info.setName("oauth2-" + scopedRegId);
+        // Per-instance chain-membership is now gated at registration time by {@link #sweepOAuth2Filters}; the
+        // rendering side reads only the standard {@link LoginFormInfo} fields. The scoped registration ID is still
+        // recoverable from the loginPath if a consumer needs it.
+        // Raw casts mirror the prior static XML declarations (see the deleted openIdConnect*LoginButton
+        // beans in applicationContext.xml): LoginFormInfo.filterClass is typed
+        // Class<GeoServerSecurityProvider> for historical reasons but the consumer code in
+        // GeoServerBasePage only uses its name for chain matching, so the actual type erasure does not
+        // matter at runtime.
+        info.setFilterClass((Class) GeoServerOAuth2LoginAuthenticationFilter.class);
+        info.setComponentClass((Class) OAuth2LoginAuthProviderPanel.class);
+        info.setIcon(iconFor(baseRegId));
+        info.setTitleKey(titleKeyFor(baseRegId));
+        info.setDescriptionKey(descriptionKeyFor(baseRegId));
+        info.setLoginPath("/" + DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/" + scopedRegId);
+        info.setMethod("GET");
+        info.setEnabled(true);
+        info.setJustUseExternalLink(true);
+        return info;
+    }
+
+    private static String beanName(String scopedRegId) {
+        return DYNAMIC_BEAN_NAME_PREFIX + scopedRegId;
+    }
+
+    /**
+     * Extracts the filter name from a scoped registration ID. The convention enforced by
+     * {@link GeoServerOAuth2ClientRegistrationId#scopedRegId(String, String)} is
+     * {@code <filterName><SCOPED_REG_ID_SEPARATOR><baseRegistrationId>}. When the separator is missing — a defensive
+     * case that should not occur in practice — the whole string is treated as the filter name.
+     */
+    static String filterNameFromScopedRegId(String scopedRegId) {
+        int sep = scopedRegId.indexOf(SCOPED_REG_ID_SEPARATOR);
+        return sep > 0 ? scopedRegId.substring(0, sep) : scopedRegId;
+    }
+
+    private static String iconFor(String baseRegId) {
+        String lower = baseRegId.toLowerCase(Locale.ROOT);
+        switch (lower) {
+            case "google":
+                return "google.png";
+            case "github":
+                return "github.png";
+            case "microsoft":
+                return "microsoft.png";
+            default:
+                return DEFAULT_ICON;
+        }
+    }
+
+    /**
+     * Resource-bundle key for the button label. Empty for icon-only providers (Google / GitHub / Microsoft) whose
+     * branding speaks for itself; the OIDC custom provider gets a label since its generic OpenID icon benefits from
+     * accompanying text — especially when more than one custom-OIDC filter is configured.
+     */
+    private static String titleKeyFor(String baseRegId) {
+        if ("oidc".equalsIgnoreCase(baseRegId)) {
+            return "openidconnect.login.button.title";
+        }
+        return "";
+    }
+
+    private static String descriptionKeyFor(String baseRegId) {
+        String lower = baseRegId.toLowerCase(Locale.ROOT);
+        switch (lower) {
+            case "google":
+                return "OAuth2LoginAuthProviderPanel.googleDescription";
+            case "github":
+                return "OAuth2LoginAuthProviderPanel.gitHubDescription";
+            case "microsoft":
+                return "OAuth2LoginAuthProviderPanel.msDescription";
+            default:
+                return "OAuth2LoginAuthProviderPanel.oidcDescription";
+        }
+    }
+
+    /** Read-only view of the registered buttons keyed by scoped registration ID. Visible for testing. */
+    Map<String, LoginFormInfo> getRegisteredButtons() {
+        return Collections.unmodifiableMap(registeredButtons);
     }
 }

--- a/src/community/security/oidc/oidc-web/src/main/resources/applicationContext.xml
+++ b/src/community/security/oidc/oidc-web/src/main/resources/applicationContext.xml
@@ -48,73 +48,15 @@
         </bean>
     -->
     
-	<!-- login buttons -->
- 	<bean id="openIdConnectGoogleLoginButton" class="org.geoserver.web.LoginFormInfo">
- 	     <!-- id must contain Spring oauthClient registrationId for enablement to work -->
- 	     <!-- see GeoServerOAuth2LoginAuthenticationProvider and OAuth2LoginButtonManager-->
- 		<property name="id" value="openIdConnectGoogleLoginButton" />
- 		<property name="titleKey" value="" />
- 		<property name="descriptionKey" value="OAuth2LoginAuthProviderPanel.googleDescription" />
- 		<property name="componentClass" value="org.geoserver.web.security.oauth2.login.OAuth2LoginAuthProviderPanel" />
- 		<property name="name" value="openidconnect-google" />
- 		<property name="icon" value="google.png" />
- 		<property name="filterClass" value="org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter" />
- 		<property name="loginPath" value="/web/oauth2/authorization/google" />
- 		<property name="method" value="GET" />
- 		<property name="enabled" value="false" />
-        <property name="justUseExternalLink" value="true" />
-    </bean>
- 	  <bean id="openIdConnectGitHubLoginButton" class="org.geoserver.web.LoginFormInfo">
- 	  <!-- id must contain Spring oauthClient registrationId for enablement to work -->
-        <property name="id" value="openIdConnectGitHubLoginButton" />
-        <property name="titleKey" value="" />
-        <property name="descriptionKey" value="OAuth2LoginAuthProviderPanel.gitHubDescription" />
-        <property name="componentClass" value="org.geoserver.web.security.oauth2.login.OAuth2LoginAuthProviderPanel" />
-        <property name="name" value="openidconnect-github" />
-        <property name="icon" value="github.png" />
-        <property name="filterClass" value="org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter" />
-        <property name="loginPath" value="/web/oauth2/authorization/gitHub" />
-        <property name="method" value="GET" />
-        <property name="enabled" value="false" />
-        <property name="justUseExternalLink" value="true" />
-      </bean>
-      <bean id="openIdConnectMicrosoftLoginButton" class="org.geoserver.web.LoginFormInfo">
-      <!-- id must contain Spring oauthClient registrationId for enablement to work -->
-        <property name="id" value="openIdConnectMicrosoftLoginButton" />
-        <property name="titleKey" value="" />
-        <property name="descriptionKey" value="OAuth2LoginAuthProviderPanel.msDescription" />
-        <property name="componentClass" value="org.geoserver.web.security.oauth2.login.OAuth2LoginAuthProviderPanel" />
-        <property name="name" value="openidconnect-microsoft" />
-        <property name="icon" value="microsoft.png" />
-        <property name="filterClass" value="org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter" />
-        <property name="loginPath" value="/web/oauth2/authorization/microsoft" />
-        <property name="method" value="GET" />
-        <property name="enabled" value="false" />
-        <property name="justUseExternalLink" value="true" />
-          </bean>
-    <bean id="openIdConnectOidcLoginButton" class="org.geoserver.web.LoginFormInfo">
-        <!-- id must contain Spring oauthClient registrationId for enablement to work -->
-        <property name="id" value="openIdConnectOidcLoginButton" />
-        <property name="titleKey" value="openidconnect.login.button.title" />
-        <property name="descriptionKey" value="OAuth2LoginAuthProviderPanel.oidcDescription" />
-        <property name="componentClass" value="org.geoserver.web.security.oauth2.login.OAuth2LoginAuthProviderPanel" />
-        <property name="name" value="openidconnect-oidc" />
-        <property name="icon" value="openid.png" />
-        <property name="filterClass" value="org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter" />
-        <property name="loginPath" value="/web/oauth2/authorization/oidc" />
-        <property name="method" value="GET" />
-        <property name="enabled" value="false" />
-        <property name="justUseExternalLink" value="true" />
-    </bean>
-    <bean id="oauth2LoginButtonManager" class="org.geoserver.web.security.oauth2.login.OAuth2LoginButtonManager" lazy-init="false">
-        <property name="loginFormInfos">
-	        <list>
-	            <ref bean="openIdConnectGoogleLoginButton"/>
-	            <ref bean="openIdConnectGitHubLoginButton"/>
-	            <ref bean="openIdConnectMicrosoftLoginButton"/>
-	            <ref bean="openIdConnectOidcLoginButton"/>
-	        </list>
-        </property>
-    </bean>
+    <!--
+        Login buttons are registered dynamically per filter instance by the OAuth2LoginButtonManager
+        below. See its Javadoc and OAuth2LoginButtonEnablementEvent for the registration lifecycle.
+        Until 2026-05 four static openIdConnect*LoginButton beans lived here and were mutated in
+        place by the manager; that design collapsed multiple filter instances sharing the same
+        provider type into a single button pointing at "an arbitrary surviving one", which broke
+        deployments that configure several filters of the same provider type (e.g. one OIDC filter
+        per identity provider).
+    -->
+    <bean id="oauth2LoginButtonManager" class="org.geoserver.web.security.oauth2.login.OAuth2LoginButtonManager" lazy-init="false"/>
 
 </beans>

--- a/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/OAuth2LoginAuthProviderPanelTest.java
+++ b/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/OAuth2LoginAuthProviderPanelTest.java
@@ -47,6 +47,37 @@ public class OAuth2LoginAuthProviderPanelTest extends AbstractSecurityNamedServi
     }
 
     /**
+     * Verifies that when a fresh OIDC filter is configured and saved <em>without</em> triggering the dropdown's AJAX
+     * change event — i.e. the user accepts the default selection without re-picking it — the saved configuration still
+     * reflects the underlying {@code *Enabled} boolean for the displayed provider.
+     *
+     * <p>Regression coverage for the issue where a fresh config's {@code getSelectedProvider()} fallback returned
+     * {@code "oidc"} but the matching {@code oidcEnabled} flag stayed {@code false} because {@code setSelectedProvider}
+     * was only called from the dropdown's {@code AjaxFormComponentUpdatingBehavior}, which never fires when the
+     * displayed value does not actually change. Symptom: no login button appears.
+     */
+    @Test
+    public void freshFilter_defaultProviderIsPersistedOnPanelConstruction() {
+        GeoServerOAuth2LoginFilterConfig config = new GeoServerOAuth2LoginFilterConfig();
+        assertFalse("Sanity: a fresh config has no provider enabled", config.isOidcEnabled());
+        assertFalse(config.isGoogleEnabled());
+        assertFalse(config.isGitHubEnabled());
+        assertFalse(config.isMsEnabled());
+
+        Model<GeoServerOAuth2LoginFilterConfig> model = new Model<>(config);
+        FormTestPage testPage = new FormTestPage(id -> new OAuth2LoginAuthProviderPanel(id, model));
+        tester.startPage(testPage);
+
+        // Panel construction performs an eager write-through of getSelectedProvider() into the
+        // underlying *Enabled flags; the dropdown's default fallback is "oidc" so we expect that one.
+        assertTrue(
+                "Panel construction must materialize the default selection into oidcEnabled", config.isOidcEnabled());
+        assertFalse(config.isGoogleEnabled());
+        assertFalse(config.isGitHubEnabled());
+        assertFalse(config.isMsEnabled());
+    }
+
+    /**
      * Verifies that the oidcAllowUnSecureLogging checkbox is visible when a non-OIDC provider (Google) is selected. The
      * checkbox lives in the common GeoServer Parameters section and should be accessible for all providers.
      */
@@ -247,7 +278,11 @@ public class OAuth2LoginAuthProviderPanelTest extends AbstractSecurityNamedServi
         assertEquals("oidcClientSecret", lConfig.getOidcClientSecret());
         assertEquals("oidcUserNameAttribute", lConfig.getOidcUserNameAttribute());
         assertEquals("oidcScopes", lConfig.getOidcScopes());
-        assertEquals("https://localhost:9090/geoserver/web/login/oauth2/code/oidc", lConfig.getOidcRedirectUri());
+        // Scoped to the filter's name: each instance has its own callback URL so Spring can route
+        // back to the correct ClientRegistration even when multiple OIDC filters share a provider type.
+        assertEquals(
+                "https://localhost:9090/geoserver/web/login/oauth2/code/" + filterName + "__oidc",
+                lConfig.getOidcRedirectUri());
 
         assertTrue(lConfig.getOidcForceAuthorizationUriHttps());
         assertTrue(lConfig.isDisableSignatureValidation());

--- a/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/OpenIdConnectLoginButtonTest.java
+++ b/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/OpenIdConnectLoginButtonTest.java
@@ -1,12 +1,19 @@
 package org.geoserver.web.security.oauth2;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import jakarta.servlet.ServletRequestEvent;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Level;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.security.GeoServerSecurityFilterChain;
+import org.geoserver.security.GeoServerSecurityFilterChainProxy;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.security.RequestFilterChain;
 import org.geoserver.security.config.SecurityManagerConfig;
@@ -17,8 +24,14 @@ import org.geoserver.test.TestSetup;
 import org.geoserver.test.TestSetupFrequency;
 import org.geoserver.web.GeoServerHomePage;
 import org.geoserver.web.GeoServerWicketTestSupport;
+import org.geoserver.web.LoginFormInfo;
+import org.geoserver.web.security.oauth2.login.OAuth2LoginAuthProviderPanel;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestContextListener;
 
 @TestSetup(run = TestSetupFrequency.REPEAT)
 public class OpenIdConnectLoginButtonTest extends GeoServerWicketTestSupport {
@@ -96,5 +109,378 @@ public class OpenIdConnectLoginButtonTest extends GeoServerWicketTestSupport {
         // the login form is there and has the link
         assertFalse(html.contains(MARKUP_FORM));
         assertFalse(html.contains(MARKUP_IMG));
+    }
+
+    // ── Multi-filter integration tests ────────────────────────────────────────
+    //
+    // These tests guard against the regression where multiple OIDC filters collapsed
+    // into a single login button pointing at "an arbitrary surviving one". With the
+    // dynamic per-filter registration in OAuth2LoginButtonManager, each filter must
+    // produce its own LoginFormInfo bean, the home page must render one button per
+    // filter, and the rendered loginPaths must be scoped to each filter's name so
+    // Spring's OAuth2 filter chain routes the click to the correct ClientRegistration.
+
+    /** Builds a minimal OIDC filter config bound to a given name; all *Uris point at a stub host. */
+    private GeoServerOAuth2LoginFilterConfig newOidcFilterConfig(String name) {
+        GeoServerOAuth2LoginFilterConfig cfg = new GeoServerOAuth2LoginFilterConfig();
+        cfg.setName(name);
+        cfg.setClassName(GeoServerOAuth2LoginAuthenticationFilter.class.getName());
+        cfg.setOidcEnabled(true);
+        cfg.setOidcClientId("client-" + name);
+        cfg.setOidcClientSecret("secret-" + name);
+        cfg.setOidcTokenUri("https://idp.example.com/" + name + "/token");
+        cfg.setOidcAuthorizationUri("https://idp.example.com/" + name + "/auth");
+        cfg.setOidcUserInfoUri("https://idp.example.com/" + name + "/userinfo");
+        cfg.setOidcJwkSetUri("https://idp.example.com/" + name + "/jwks");
+        return cfg;
+    }
+
+    /** Saves each filter via the security manager and adds them all to the {@code /web/**} chain. */
+    private void saveOidcFiltersAndAddToWebChain(List<String> filterNames) throws Exception {
+        GeoServerSecurityManager manager = getSecurityManager();
+        for (String filterName : filterNames) {
+            manager.saveFilter(newOidcFilterConfig(filterName));
+        }
+        SecurityManagerConfig config = manager.getSecurityConfig();
+        GeoServerSecurityFilterChain chain = config.getFilterChain();
+        RequestFilterChain web = chain.getRequestChainByName("web");
+        // anonymous stays last so it does not pre-empt the OIDC filters
+        String[] names = new String[filterNames.size() + 1];
+        for (int i = 0; i < filterNames.size(); i++) names[i] = filterNames.get(i);
+        names[filterNames.size()] = "anonymous";
+        web.setFilterNames(names);
+        manager.saveSecurityConfig(config);
+    }
+
+    /**
+     * Builds the expected anchor markup for a given OIDC filter's scoped login path. The path follows
+     * {@code /web/oauth2/authorization/<filterName>__oidc} so that Spring Security's OAuth2 filter chain can route the
+     * click to that filter's {@code ClientRegistration} (which uses the same scoped registration ID).
+     */
+    private static String expectedScopedLoginAnchor(String filterName) {
+        return "href=\"http://localhost/context/web/oauth2/authorization/" + filterName + "__oidc\"";
+    }
+
+    /**
+     * Two OIDC filters, both in the {@code /web/**} chain, must produce two independent login buttons — one per filter
+     * — each pointing at its own scoped authorization endpoint. The previous static-bean design collapsed both into one
+     * button pointing at "an arbitrary surviving one"; the dynamic registry must keep them independent.
+     */
+    @Test
+    public void testTwoOidcFiltersRenderTwoDistinctLoginButtons() throws Exception {
+        saveOidcFiltersAndAddToWebChain(Arrays.asList("keycloak-prod", "auth0-staging"));
+
+        tester.startPage(GeoServerHomePage.class);
+        String html = tester.getLastResponseAsString();
+        LOGGER.log(Level.INFO, "Last HTML page output:\n" + html);
+
+        // Both scoped login URLs must appear in the rendered HTML.
+        assertTrue(
+                "keycloak-prod button missing — expected " + expectedScopedLoginAnchor("keycloak-prod"),
+                html.contains(expectedScopedLoginAnchor("keycloak-prod")));
+        assertTrue(
+                "auth0-staging button missing — expected " + expectedScopedLoginAnchor("auth0-staging"),
+                html.contains(expectedScopedLoginAnchor("auth0-staging")));
+
+        // The dynamic-registration manager must have registered one LoginFormInfo bean per filter, both visible
+        // via the standard by-type bean lookup that GeoServerBasePage uses.
+        List<LoginFormInfo> infos = applicationContext.getBeansOfType(LoginFormInfo.class).values().stream()
+                .filter(i -> i.getComponentClass() != null
+                        && OAuth2LoginAuthProviderPanel.class
+                                .getName()
+                                .equals(i.getComponentClass().getName()))
+                .toList();
+        assertNotNull(infos);
+        long keycloakBeans = countButtonsForFilter(infos, "keycloak-prod");
+        long auth0Beans = countButtonsForFilter(infos, "auth0-staging");
+        assertEquals("expected exactly one LoginFormInfo for keycloak-prod", 1L, keycloakBeans);
+        assertEquals("expected exactly one LoginFormInfo for auth0-staging", 1L, auth0Beans);
+    }
+
+    /**
+     * Identifies which OIDC filter a {@link LoginFormInfo} corresponds to by inspecting its scoped registration ID
+     * embedded in the loginPath ({@code /web/oauth2/authorization/<filterName>__<provider>}). Used by the multi-filter
+     * tests to count buttons per filter without depending on a dedicated {@code filterName} field on the bean.
+     */
+    private static long countButtonsForFilter(List<LoginFormInfo> infos, String filterName) {
+        String marker = "/" + filterName + "__";
+        return infos.stream()
+                .filter(i -> i.getLoginPath() != null && i.getLoginPath().contains(marker))
+                .count();
+    }
+
+    /**
+     * Three OIDC filters round out the multi-filter coverage. Beyond proving that the dynamic registry scales beyond
+     * two, this case verifies that the rendered HTML keeps every login path distinct (no shared / overlapping login
+     * paths between filters).
+     */
+    @Test
+    public void testThreeOidcFiltersRenderThreeDistinctLoginButtons() throws Exception {
+        List<String> filterNames = Arrays.asList("keycloak-prod", "auth0-staging", "entra-tenant");
+        saveOidcFiltersAndAddToWebChain(filterNames);
+
+        tester.startPage(GeoServerHomePage.class);
+        String html = tester.getLastResponseAsString();
+
+        for (String name : filterNames) {
+            assertTrue(
+                    name + " button missing — expected " + expectedScopedLoginAnchor(name),
+                    html.contains(expectedScopedLoginAnchor(name)));
+        }
+        // Defence in depth — the un-scoped path that the legacy static-bean design produced must NOT appear.
+        // If this assertion ever fires after a future refactor, somebody has reintroduced the collapse-to-one-button
+        // bug.
+        assertFalse(
+                "un-scoped /web/oauth2/authorization/oidc must not appear in rendered HTML",
+                html.contains("href=\"http://localhost/context/web/oauth2/authorization/oidc\""));
+    }
+
+    /**
+     * Failure-path UX regression coverage: when OAuth2 / OIDC authentication fails (bad client secret, invalid token,
+     * state mismatch, IdP refusing the code exchange, ...) the user must land somewhere they can recover from —
+     * specifically the GeoServer home page where the standard login form is available.
+     *
+     * <p>Before the fix, Spring's default failure handler redirected to {@code /login?error}, which has no handler in
+     * the GeoServer webapp (no Wicket page mount, no servlet, no static resource). Tomcat's default servlet then served
+     * the path back with no Content-Type and browsers downloaded an empty file named {@code login} — confusing UX
+     * reported in the wild by Dorset County Council during a Keycloak integration with stale client credentials.
+     *
+     * <p>This test exercises the failure path without needing a real IdP: it hits the OAuth2 callback URL with a fake
+     * {@code code} + {@code state} that won't match any stored {@code OAuth2AuthorizationRequest}, which makes Spring's
+     * filter invoke the failure handler immediately at state validation — the exact same code path a real
+     * token-exchange failure follows. Runs without Docker; complements the Keycloak-container regression test in
+     * {@code KeyCloakMultiFilterIntegrationTest.testOAuth2FailureRedirectsToWebHomeNotLoginError}.
+     */
+    @Test
+    public void testOAuth2FailureRedirectsToWebHomeNotLoginError() throws Exception {
+        // Reuse the existing single-filter setup helper — same OIDC filter the existing render tests use.
+        activateOidcFilterWithEnabledState(true);
+
+        MockHttpServletRequest req = createRequest("web/login/oauth2/code/openidconnect__oidc");
+        req.setParameter("code", "fake-authorization-code");
+        req.setParameter("state", "fake-state-no-match");
+
+        MockHttpServletResponse resp = executeOnSecurityFilters(req);
+
+        // Spring's failure handler must redirect, not produce an opaque body that browsers turn into a download.
+        assertEquals("expected 302 redirect from the failure handler", 302, resp.getStatus());
+        String location = resp.getHeader("Location");
+        assertNotNull("failure-handler redirect must include a Location header", location);
+
+        // The fix: must NOT target Spring's default /login?error.
+        assertFalse(
+                "failure redirect must not target /login?error (no handler in GeoServer webapp, browsers download an empty file): "
+                        + location,
+                location.endsWith("/login?error") || location.endsWith("/login") || location.contains("/login?"));
+
+        // Positive assertion: must land somewhere under /web/ where the Wicket admin can render the login form.
+        assertTrue(
+                "failure redirect must land somewhere under /web/ — got " + location,
+                location.endsWith("/web/")
+                        || location.endsWith("/web")
+                        || location.contains("/web/")
+                        || location.contains("/web?"));
+    }
+
+    /**
+     * Mirrors {@code KeyCloakIntegrationTest.executeOnSecurityFilters}; copied locally to keep this test Docker-free.
+     * Drives the request through {@link GeoServerSecurityFilterChainProxy} so Spring's OAuth2 filters activate exactly
+     * as they would in production.
+     */
+    private static MockHttpServletResponse executeOnSecurityFilters(MockHttpServletRequest request)
+            throws IOException, jakarta.servlet.ServletException {
+        RequestContextListener listener = new RequestContextListener();
+        ServletRequestEvent event = new ServletRequestEvent(request.getServletContext(), request);
+        listener.requestInitialized(event);
+        try {
+            MockFilterChain chain = new MockFilterChain();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            GeoServerSecurityFilterChainProxy filterChainProxy =
+                    GeoServerExtensions.bean(GeoServerSecurityFilterChainProxy.class);
+            filterChainProxy.doFilter(request, response, chain);
+            return response;
+        } finally {
+            listener.requestDestroyed(event);
+        }
+    }
+
+    /**
+     * A filter that is configured (saved + {@code oidcEnabled=true}) but NOT bound to the {@code /web/**} chain must
+     * not render a button — clicking such a button would 404 on the OAuth2 authorization request endpoint because no
+     * filter is mounted to handle it. This is guaranteed by
+     * {@link org.geoserver.web.security.oauth2.login.OAuth2LoginButtonManager#sweepOAuth2Filters()}: it only registers
+     * a {@link LoginFormInfo} singleton for OIDC filters that appear in at least one request filter chain, and tears
+     * down singletons for filters that have left every chain on the next configuration change.
+     */
+    @Test
+    public void testFilterNotInChainDoesNotRenderButton() throws Exception {
+        GeoServerSecurityManager manager = getSecurityManager();
+        // Filter "in-chain" is configured AND added to /web/**; "off-chain" is configured but never bound.
+        manager.saveFilter(newOidcFilterConfig("in-chain"));
+        manager.saveFilter(newOidcFilterConfig("off-chain"));
+
+        SecurityManagerConfig config = manager.getSecurityConfig();
+        GeoServerSecurityFilterChain chain = config.getFilterChain();
+        RequestFilterChain web = chain.getRequestChainByName("web");
+        web.setFilterNames("in-chain", "anonymous");
+        manager.saveSecurityConfig(config);
+
+        tester.startPage(GeoServerHomePage.class);
+        String html = tester.getLastResponseAsString();
+
+        assertTrue("in-chain button must render", html.contains(expectedScopedLoginAnchor("in-chain")));
+        assertFalse(
+                "off-chain button must NOT render — filter is configured but not bound to /web/**",
+                html.contains(expectedScopedLoginAnchor("off-chain")));
+    }
+
+    /**
+     * Layout regression: every rendered OIDC button must be wrapped in a {@code <div class="gs-login-external-links">},
+     * because the user-dropdown CSS in {@code theme/css/geoserver.css} targets that exact class to lay multiple buttons
+     * out horizontally (inline-flex) and centers the group via {@code .gs-user-dropdown-info ul { text-align: center
+     * }}.
+     *
+     * <p>Without those wrappers — e.g. if a refactor of {@link org.geoserver.web.GeoServerBasePage}'s template ever
+     * moved the {@code class="gs-login-external-links"} attribute off the {@code wicket:id="loginExternalLinks"} div —
+     * multiple buttons would stack vertically (block-level anchors) and the centered, side-by-side layout would
+     * silently break. This is the kind of regression that escapes pure unit tests because the markup is valid; this
+     * test guards against it by asserting both the wrapper class and one wrapper per filter.
+     */
+    @Test
+    public void testMultipleButtonsAreWrappedInGsLoginExternalLinksDivs() throws Exception {
+        List<String> filterNames = Arrays.asList("keycloak-prod", "auth0-staging");
+        saveOidcFiltersAndAddToWebChain(filterNames);
+
+        tester.startPage(GeoServerHomePage.class);
+        String html = tester.getLastResponseAsString();
+
+        // One wrapper per button — Wicket repeats the template element via the loginExternalLinks listview, so we
+        // get N siblings rather than one wrapper around N anchors. Either layout works as long as the CSS rules
+        // match what the template actually emits.
+        int wrapperCount = countOccurrences(html, "class=\"gs-login-external-links\"");
+        assertEquals("expected one .gs-login-external-links wrapper per OIDC filter", filterNames.size(), wrapperCount);
+
+        // Each wrapper must directly enclose the scoped anchor — verify the (wrapper, anchor) pairing rather than
+        // just total counts so a hypothetical regression that emits the wrapper around the wrong element fails here.
+        for (String name : filterNames) {
+            String anchor = expectedScopedLoginAnchor(name);
+            int anchorIdx = html.indexOf(anchor);
+            assertTrue(name + " anchor missing", anchorIdx > 0);
+            int wrapperIdx = html.lastIndexOf("class=\"gs-login-external-links\"", anchorIdx);
+            assertTrue(
+                    name + " anchor is not preceded by a .gs-login-external-links wrapper",
+                    wrapperIdx > 0 && wrapperIdx < anchorIdx);
+        }
+    }
+
+    /**
+     * Auto-enablement: when an admin saves a brand-new OIDC filter through the security manager <em>after</em> the
+     * application has finished bootstrapping, the {@code OAuth2LoginButtonManager} must register a matching login
+     * button into its internal registry — proof that no JVM restart is required to make the button available.
+     *
+     * <p>This guards the {@link org.geoserver.security.SecurityManagerListener} hook on the
+     * {@link org.geoserver.web.security.oauth2.login.OAuth2LoginButtonManager}. Before that hook,
+     * {@link GeoServerSecurityManager#saveFilter} on a fresh filter (no id yet) did <em>not</em> fire any change
+     * notification, so the filter never went through the builder's {@code build()} path and never published the
+     * {@code OAuth2LoginButtonEnablementEvent} the button manager listens for — buttons only appeared after a JVM
+     * restart. With the listener wired in, the sweep loads every OAuth2 filter via the provider's {@code createFilter}
+     * path, the builder fires the enable events, and the manager records the matching {@link LoginFormInfo} in its
+     * registry.
+     *
+     * <p>This test asserts on the manager's registry rather than rendered HTML because the Wicket test harness wires
+     * the security manager and the button manager into adjacent application contexts; the existing
+     * {@code testTwoOidcFiltersRenderTwoDistinctLoginButtons} covers HTML rendering for the same scenario when both
+     * filters are saved in a single batch. The unit tests in {@code OAuth2LoginButtonManagerTest.handlePostChanged_*}
+     * cover the listener wiring in isolation. What this test adds is the seam between them: after a fired notification,
+     * the registry reflects every saved OIDC filter — including filters saved post-bootstrap.
+     */
+    @Test
+    public void testSavingNewOidcFilterAutoRegistersButtonInRegistry() throws Exception {
+        // 1. Baseline: save + bind filter1 (keycloak-prod). The build path runs as part of the chain rebuild and
+        //    publishes the enable event; the manager picks it up and registers button1 as a LoginFormInfo bean.
+        saveOidcFiltersAndAddToWebChain(Arrays.asList("keycloak-prod"));
+
+        long baselineKeycloakBeans = countButtonsForFilter(oauth2LoginFormInfos(), "keycloak-prod");
+        assertEquals(
+                "baseline registry must contain exactly one LoginFormInfo for keycloak-prod after the first save",
+                1L,
+                baselineKeycloakBeans);
+
+        // 2. Save filter2 (auth0-staging) AFTER bootstrap and add it to the chain. Without the listener hook, this
+        //    filter would never be loaded through createFilter again, never publish its enable event, and never
+        //    appear in the registry until a container restart.
+        GeoServerSecurityManager manager = getSecurityManager();
+        manager.saveFilter(newOidcFilterConfig("auth0-staging"));
+        SecurityManagerConfig cfg = manager.getSecurityConfig();
+        RequestFilterChain web = cfg.getFilterChain().getRequestChainByName("web");
+        web.setFilterNames("keycloak-prod", "auth0-staging", "anonymous");
+        manager.saveSecurityConfig(cfg);
+
+        // 3. Drive handlePostChanged on the live manager — same call SecurityManager fires via fireChanged().
+        //    The sweep must rerun the build path for every saved OAuth2 filter and re-register the buttons.
+        org.geoserver.web.security.oauth2.login.OAuth2LoginButtonManager buttonMgr =
+                applicationContext.getBean(org.geoserver.web.security.oauth2.login.OAuth2LoginButtonManager.class);
+        buttonMgr.handlePostChanged(manager);
+
+        // 4. Both filters must be visible via the standard bean-by-type lookup GeoServerBasePage uses — proof that
+        //    the listener-driven sweep registered the newly-saved filter without a container restart. This is the
+        //    failure mode the user reported in the wild ("I have created 2 oidc filters but I still see only one
+        //    button") and the contract the fix locks in.
+        List<LoginFormInfo> infos = oauth2LoginFormInfos();
+        long keycloakBeans = countButtonsForFilter(infos, "keycloak-prod");
+        long auth0Beans = countButtonsForFilter(infos, "auth0-staging");
+        assertEquals("keycloak-prod LoginFormInfo must remain after the post-save sweep", 1L, keycloakBeans);
+        assertEquals(
+                "auth0-staging LoginFormInfo must appear after the post-save sweep — no restart required",
+                1L,
+                auth0Beans);
+
+        // 5. Each registered button's login path must encode the scoped registration id; the suffix
+        //    /<filterName>__<provider> is what makes Spring's OAuth2 filter chain route the click to the right
+        //    ClientRegistration. Use endsWith so the test does not couple itself to the exact base URI literal.
+        LoginFormInfo keycloakInfo = infos.stream()
+                .filter(i -> i.getLoginPath() != null && i.getLoginPath().contains("/keycloak-prod__"))
+                .findFirst()
+                .orElseThrow();
+        LoginFormInfo auth0Info = infos.stream()
+                .filter(i -> i.getLoginPath() != null && i.getLoginPath().contains("/auth0-staging__"))
+                .findFirst()
+                .orElseThrow();
+        assertTrue(
+                "keycloak login path must include the scoped registration id — got " + keycloakInfo.getLoginPath(),
+                keycloakInfo.getLoginPath().endsWith("/oauth2/authorization/keycloak-prod__oidc"));
+        assertTrue(
+                "auth0 login path must include the scoped registration id — got " + auth0Info.getLoginPath(),
+                auth0Info.getLoginPath().endsWith("/oauth2/authorization/auth0-staging__oidc"));
+    }
+
+    /** Bean-by-type lookup that mirrors what {@code GeoServerBasePage} does when deciding which buttons to render. */
+    private List<LoginFormInfo> oauth2LoginFormInfos() {
+        return applicationContext.getBeansOfType(LoginFormInfo.class).values().stream()
+                .filter(i -> i.getComponentClass() != null
+                        && OAuth2LoginAuthProviderPanel.class
+                                .getName()
+                                .equals(i.getComponentClass().getName()))
+                .toList();
+    }
+
+    /**
+     * Helper: count non-overlapping occurrences of {@code needle} in {@code haystack}. Used by markup-shape assertions
+     * that need exact wrapper counts.
+     */
+    private static int countOccurrences(String haystack, String needle) {
+        if (haystack == null || needle == null || needle.isEmpty()) {
+            return 0;
+        }
+        int count = 0;
+        int from = 0;
+        while (true) {
+            int idx = haystack.indexOf(needle, from);
+            if (idx < 0) {
+                return count;
+            }
+            count++;
+            from = idx + needle.length();
+        }
     }
 }

--- a/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/OpenIdConnectLoginButtonTest.java
+++ b/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/OpenIdConnectLoginButtonTest.java
@@ -182,14 +182,18 @@ public class OpenIdConnectLoginButtonTest extends GeoServerWicketTestSupport {
                 "auth0-staging button missing — expected " + expectedScopedLoginAnchor("auth0-staging"),
                 html.contains(expectedScopedLoginAnchor("auth0-staging")));
 
-        // The dynamic-registration manager must have registered one LoginFormInfo bean per filter, both visible
-        // via the standard by-type bean lookup that GeoServerBasePage uses.
-        List<LoginFormInfo> infos = applicationContext.getBeansOfType(LoginFormInfo.class).values().stream()
-                .filter(i -> i.getComponentClass() != null
-                        && OAuth2LoginAuthProviderPanel.class
-                                .getName()
-                                .equals(i.getComponentClass().getName()))
-                .toList();
+        // The dynamic-registration manager must contribute one LoginFormInfo per filter, both visible via the
+        // GeoServerExtensions lookup that GeoServerBasePage uses. We go through GeoServerExtensions (not the raw
+        // applicationContext.getBeansOfType) because the manager surfaces its buttons via
+        // ExtensionProvider<LoginFormInfo> — bypassing GeoServerExtensions' static extensionsCache that would
+        // otherwise hide dynamically-registered singletons. See OAuth2LoginButtonManager's javadoc on the cache trap.
+        List<LoginFormInfo> infos =
+                org.geoserver.platform.GeoServerExtensions.extensions(LoginFormInfo.class, applicationContext).stream()
+                        .filter(i -> i.getComponentClass() != null
+                                && OAuth2LoginAuthProviderPanel.class
+                                        .getName()
+                                        .equals(i.getComponentClass().getName()))
+                        .toList();
         assertNotNull(infos);
         long keycloakBeans = countButtonsForFilter(infos, "keycloak-prod");
         long auth0Beans = countButtonsForFilter(infos, "auth0-staging");
@@ -454,9 +458,13 @@ public class OpenIdConnectLoginButtonTest extends GeoServerWicketTestSupport {
                 auth0Info.getLoginPath().endsWith("/oauth2/authorization/auth0-staging__oidc"));
     }
 
-    /** Bean-by-type lookup that mirrors what {@code GeoServerBasePage} does when deciding which buttons to render. */
+    /**
+     * Mirrors what {@code GeoServerBasePage} does when deciding which buttons to render. Goes through
+     * {@link org.geoserver.platform.GeoServerExtensions} so the manager's {@code ExtensionProvider<LoginFormInfo>}
+     * contribution is included — the raw {@code applicationContext.getBeansOfType} would miss it.
+     */
     private List<LoginFormInfo> oauth2LoginFormInfos() {
-        return applicationContext.getBeansOfType(LoginFormInfo.class).values().stream()
+        return org.geoserver.platform.GeoServerExtensions.extensions(LoginFormInfo.class, applicationContext).stream()
                 .filter(i -> i.getComponentClass() != null
                         && OAuth2LoginAuthProviderPanel.class
                                 .getName()

--- a/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/intgration/keycloak/KeyCloakIntegrationTest.java
+++ b/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/intgration/keycloak/KeyCloakIntegrationTest.java
@@ -88,7 +88,9 @@ public class KeyCloakIntegrationTest extends KeyCloakIntegrationTestSupport {
     String oidcLogin_responseType = "code";
     String oidcLogin_client_id = "gs-client";
     String oidcLogin_scope = "openid profile email phone address";
-    String oidcLogin_redirect_uri = "http://localhost:8080/geoserver/web/login/oauth2/code/oidc";
+    // Scoped to the filter name "openidconnect" — each filter's callback URL carries its own scoped registration ID
+    // so Spring can map the callback back to the right ClientRegistration. See GeoServerOAuth2ClientRegistrationId.
+    String oidcLogin_redirect_uri = "http://localhost:8080/geoserver/web/login/oauth2/code/openidconnect__oidc";
 
     /**
      * Configure GS logging level.
@@ -290,7 +292,7 @@ public class KeyCloakIntegrationTest extends KeyCloakIntegrationTestSupport {
                         .getValue());
         assertEquals(
                 System.getProperty("OPENID_TEST_GS_PROXY_BASE", "http://localhost:8080/geoserver")
-                        + "/web/login/oauth2/code/oidc",
+                        + "/web/login/oauth2/code/openidconnect__oidc",
                 params.stream()
                         .filter(x -> x.getName().equals("redirect_uri"))
                         .findFirst()
@@ -356,7 +358,8 @@ public class KeyCloakIntegrationTest extends KeyCloakIntegrationTestSupport {
         String redirectCodeToGS =
                 keycloakResponseSubmitUserPassword.headers.get("Location").get(0);
         // should be redirecting to GS's code endpoint
-        assertTrue(redirectCodeToGS.startsWith("http://localhost:8080/geoserver/web/login/oauth2/code/oidc"));
+        assertTrue(redirectCodeToGS.startsWith(
+                "http://localhost:8080/geoserver/web/login/oauth2/code/openidconnect__oidc"));
 
         String shortenedRedirectCodeToGS = redirectCodeToGS.substring("http://localhost:8080/geoserver/".length());
 

--- a/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/intgration/keycloak/KeyCloakMultiFilterIntegrationTest.java
+++ b/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/intgration/keycloak/KeyCloakMultiFilterIntegrationTest.java
@@ -152,13 +152,16 @@ public class KeyCloakMultiFilterIntegrationTest extends KeyCloakIntegrationTestS
                 "un-scoped /web/oauth2/authorization/oidc must not appear",
                 html.contains("href=\"http://localhost/context/web/oauth2/authorization/oidc\""));
 
-        // The dynamic registry must have one LoginFormInfo per filter.
-        List<LoginFormInfo> oidcButtons = applicationContext.getBeansOfType(LoginFormInfo.class).values().stream()
-                .filter(i -> i.getComponentClass() != null
-                        && OAuth2LoginAuthProviderPanel.class
-                                .getName()
-                                .equals(i.getComponentClass().getName()))
-                .toList();
+        // The dynamic registry must have one LoginFormInfo per filter — looked up via GeoServerExtensions so the
+        // manager's ExtensionProvider<LoginFormInfo> contribution is included (raw applicationContext.getBeansOfType
+        // would miss it).
+        List<LoginFormInfo> oidcButtons =
+                org.geoserver.platform.GeoServerExtensions.extensions(LoginFormInfo.class, applicationContext).stream()
+                        .filter(i -> i.getComponentClass() != null
+                                && OAuth2LoginAuthProviderPanel.class
+                                        .getName()
+                                        .equals(i.getComponentClass().getName()))
+                        .toList();
         // Filter identity is encoded in each button's loginPath: /web/oauth2/authorization/<filterName>__<provider>.
         long primary = oidcButtons.stream()
                 .filter(i -> i.getLoginPath() != null && i.getLoginPath().contains("/" + FILTER_PRIMARY + "__"))

--- a/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/intgration/keycloak/KeyCloakMultiFilterIntegrationTest.java
+++ b/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/intgration/keycloak/KeyCloakMultiFilterIntegrationTest.java
@@ -1,0 +1,320 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.security.oauth2.intgration.keycloak;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.servlet.ServletRequestEvent;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.net.URIBuilder;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.GeoServerSecurityFilterChain;
+import org.geoserver.security.GeoServerSecurityFilterChainProxy;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.RequestFilterChain;
+import org.geoserver.security.config.SecurityManagerConfig;
+import org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter;
+import org.geoserver.security.oauth2.login.GeoServerOAuth2LoginFilterConfig;
+import org.geoserver.web.GeoServerHomePage;
+import org.geoserver.web.LoginFormInfo;
+import org.geoserver.web.security.oauth2.login.OAuth2LoginAuthProviderPanel;
+import org.geotools.util.logging.Logging;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestContextListener;
+
+/**
+ * Verifies that two GeoServer OAuth2/OIDC filter instances backed by the same Keycloak realm produce two
+ * <em>independent</em> login buttons and two <em>independent</em> Spring {@code ClientRegistration} entries.
+ *
+ * <p>Companion to the single-filter {@link KeyCloakIntegrationTest}. The end-to-end login flow is already covered
+ * there; this test focuses on the multi-filter-specific guarantees:
+ *
+ * <ol>
+ *   <li>The home page renders <em>one button per active filter</em>, each with a filter-scoped login path of the form
+ *       {@code /web/oauth2/authorization/<filterName>__oidc}.
+ *   <li>Clicking each button drives Spring's
+ *       {@link org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
+ *       OAuth2AuthorizationRequestRedirectFilter} to build a redirect that carries that filter's <em>own</em> scoped
+ *       {@code redirect_uri}, so the Keycloak side cannot conflate the two requests.
+ *   <li>The two filters produce different {@code state} parameters in their respective auth requests, proving that
+ *       Spring keeps two separate {@code OAuth2AuthorizationRequest} sessions — one per filter.
+ *   <li>The dynamic {@link LoginFormInfo} registry exposes exactly one bean per filter, each with its own
+ *       {@link LoginFormInfo#getLoginPath()} which carries the scoped registration id (filterName__provider).
+ * </ol>
+ *
+ * <p>Both filters point at the same Keycloak client {@code gs-client} for simplicity — that's enough to prove the
+ * per-filter routing works because GeoServer treats each filter as a distinct Spring {@code ClientRegistration}
+ * regardless of whether their Keycloak-side configuration happens to overlap.
+ */
+public class KeyCloakMultiFilterIntegrationTest extends KeyCloakIntegrationTestSupport {
+
+    private static final Logger LOGGER = Logging.getLogger(KeyCloakMultiFilterIntegrationTest.class);
+
+    /** First filter name — drives a scoped registration ID of {@code primary-idp__oidc}. */
+    private static final String FILTER_PRIMARY = "primary-idp";
+
+    /** Second filter name — drives a scoped registration ID of {@code secondary-idp__oidc}. */
+    private static final String FILTER_SECONDARY = "secondary-idp";
+
+    private static String scopedRegId(String filterName) {
+        return filterName + "__oidc";
+    }
+
+    @Override
+    protected String getLogConfiguration() {
+        return "VERBOSE_LOGGING";
+    }
+
+    @BeforeClass
+    public static void beforeClassLocal() {
+        // Mock-server base URL — must match baseRedirectUri set in onSetUp() so resolveBaseRedirectUri()
+        // returns the same value after XStream deserialization.
+        System.setProperty("OPENID_TEST_GS_PROXY_BASE", "http://localhost:8080/geoserver");
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        registerOidcFilter(FILTER_PRIMARY);
+        registerOidcFilter(FILTER_SECONDARY);
+
+        // Bind both filters to the /web/** chain so GeoServerBasePage's isFilterInChain check passes
+        // for both buttons. Anonymous stays last so it cannot pre-empt the OIDC filters.
+        GeoServerSecurityManager manager = getSecurityManager();
+        SecurityManagerConfig config = manager.getSecurityConfig();
+        GeoServerSecurityFilterChain chain = config.getFilterChain();
+        RequestFilterChain web = chain.getRequestChainByName("web");
+        web.setFilterNames(FILTER_PRIMARY, FILTER_SECONDARY, "anonymous");
+        manager.saveSecurityConfig(config);
+    }
+
+    /** Configures a fresh OIDC filter against the running Keycloak container, scoped to the given filter name. */
+    private void registerOidcFilter(String filterName) throws Exception {
+        String baseKeycloakUrl = keycloakContainer.getAuthServerUrl() + "/realms/gs-realm/protocol/openid-connect";
+
+        GeoServerOAuth2LoginFilterConfig cfg = new GeoServerOAuth2LoginFilterConfig();
+        cfg.setName(filterName);
+        cfg.setClassName(GeoServerOAuth2LoginAuthenticationFilter.class.getName());
+        cfg.setOidcEnabled(true);
+        cfg.setOidcClientId(oidcClient);
+        cfg.setOidcClientSecret(oidcClientSecret);
+        cfg.setBaseRedirectUri("http://localhost:8080/geoserver/");
+        cfg.calculateRedirectUris();
+        cfg.setOidcTokenUri(baseKeycloakUrl + "/token");
+        cfg.setOidcAuthorizationUri(baseKeycloakUrl + "/authorize");
+        cfg.setOidcUserInfoUri(baseKeycloakUrl + "/userinfo");
+        cfg.setOidcLogoutUri(baseKeycloakUrl + "/endSession");
+        cfg.setOidcJwkSetUri(baseKeycloakUrl + "/certs");
+        cfg.setOidcScopes("openid profile email phone address");
+        cfg.setOidcUserNameAttribute("email");
+        cfg.setEnableRedirectAuthenticationEntryPoint(false);
+        cfg.setOidcForceAuthorizationUriHttps(false);
+        cfg.setOidcForceTokenUriHttps(false);
+        getSecurityManager().saveFilter(cfg);
+    }
+
+    /**
+     * Both filters' login buttons must render with their own filter-scoped login paths. The previous static-bean design
+     * collapsed both into a single button pointing at "an arbitrary surviving one" — this test guards against any
+     * regression that would reintroduce that bug. Also asserts that the dynamic {@link LoginFormInfo} registry exposes
+     * one bean per filter, and that the un-scoped legacy URL is absent.
+     */
+    @Test
+    public void testTwoFiltersBothRenderDistinctLoginButtons() {
+        tester.startPage(new GeoServerHomePage());
+        String html = tester.getLastResponseAsString();
+
+        // The two filter-scoped login URLs must both appear in the rendered HTML.
+        for (String filterName : Arrays.asList(FILTER_PRIMARY, FILTER_SECONDARY)) {
+            String expected =
+                    "href=\"http://localhost/context/web/oauth2/authorization/" + scopedRegId(filterName) + "\"";
+            assertTrue(filterName + " button missing — expected " + expected, html.contains(expected));
+        }
+        // Defence in depth: the un-scoped legacy URL must NOT appear in the rendered HTML.
+        assertFalse(
+                "un-scoped /web/oauth2/authorization/oidc must not appear",
+                html.contains("href=\"http://localhost/context/web/oauth2/authorization/oidc\""));
+
+        // The dynamic registry must have one LoginFormInfo per filter.
+        List<LoginFormInfo> oidcButtons = applicationContext.getBeansOfType(LoginFormInfo.class).values().stream()
+                .filter(i -> i.getComponentClass() != null
+                        && OAuth2LoginAuthProviderPanel.class
+                                .getName()
+                                .equals(i.getComponentClass().getName()))
+                .toList();
+        // Filter identity is encoded in each button's loginPath: /web/oauth2/authorization/<filterName>__<provider>.
+        long primary = oidcButtons.stream()
+                .filter(i -> i.getLoginPath() != null && i.getLoginPath().contains("/" + FILTER_PRIMARY + "__"))
+                .count();
+        long secondary = oidcButtons.stream()
+                .filter(i -> i.getLoginPath() != null && i.getLoginPath().contains("/" + FILTER_SECONDARY + "__"))
+                .count();
+        assertEquals("expected exactly one LoginFormInfo bean for " + FILTER_PRIMARY, 1L, primary);
+        assertEquals("expected exactly one LoginFormInfo bean for " + FILTER_SECONDARY, 1L, secondary);
+    }
+
+    /**
+     * Both filters' saved configurations must carry filter-scoped redirect URIs. This is the persistence side of Part
+     * C: when an admin saves an OIDC filter, the {@link GeoServerOAuth2LoginFilterConfig#getOidcRedirectUri()} field
+     * reflects the filter's scoped registration ID — never the legacy un-scoped form — so that when the filter is built
+     * and registers a Spring {@code ClientRegistration}, the Keycloak / IdP side is told exactly which scoped callback
+     * URL to redirect back to.
+     */
+    @Test
+    public void testBothFiltersHaveScopedRedirectUrisPersisted() throws Exception {
+        GeoServerSecurityManager manager = getSecurityManager();
+
+        for (String filterName : Arrays.asList(FILTER_PRIMARY, FILTER_SECONDARY)) {
+            GeoServerOAuth2LoginFilterConfig saved =
+                    (GeoServerOAuth2LoginFilterConfig) manager.loadFilterConfig(filterName, true);
+            assertNotNull("filter " + filterName + ": config should be loadable", saved);
+
+            String expected = "http://localhost:8080/geoserver/web/login/oauth2/code/" + scopedRegId(filterName);
+            assertEquals(
+                    "filter " + filterName + ": persisted oidcRedirectUri must be scoped to the filter name",
+                    expected,
+                    saved.getOidcRedirectUri());
+
+            assertNotEquals(
+                    "filter " + filterName + ": must NOT use the un-scoped redirect URI",
+                    "http://localhost:8080/geoserver/web/login/oauth2/code/oidc",
+                    saved.getOidcRedirectUri());
+        }
+
+        GeoServerOAuth2LoginFilterConfig primary =
+                (GeoServerOAuth2LoginFilterConfig) manager.loadFilterConfig(FILTER_PRIMARY, true);
+        GeoServerOAuth2LoginFilterConfig secondary =
+                (GeoServerOAuth2LoginFilterConfig) manager.loadFilterConfig(FILTER_SECONDARY, true);
+        assertNotEquals(
+                "the two filters must have different oidcRedirectUri values — that is the routing key",
+                primary.getOidcRedirectUri(),
+                secondary.getOidcRedirectUri());
+    }
+
+    /**
+     * Clicking the first filter's login button drives Spring to issue a 302 to Keycloak with the filter's own scoped
+     * {@code redirect_uri} (not the un-scoped legacy form). This is the end-to-end runtime proof for Part C in a
+     * multi-filter setup.
+     *
+     * <p><b>Known limitation:</b> only the first registered filter's authorization endpoint is exercised here. Driving
+     * the auth-init URL of a <em>second</em> simultaneously-active OAuth2 filter in the same
+     * {@code GeoServerSecurityFilterChainProxy} surfaces a Spring HttpSecurity isolation issue — the first filter's
+     * chain processes the request first, fails to find the foreign scoped registration in its own
+     * {@code ClientRegistrationRepository}, and the request never reaches the second filter's chain. That's a separate
+     * architectural fix (Part D) outside the scope of this branch — captured in the wiki delta + a follow-up JIRA.
+     * Button rendering (Part B) and config persistence (Part C) verified above are independent of this limitation and
+     * work correctly with N filters.
+     */
+    @Test
+    public void testFirstFilterAuthRequestUsesItsOwnScopedRedirectUri() throws Exception {
+        MockHttpServletRequest req = createRequest("web/oauth2/authorization/" + scopedRegId(FILTER_PRIMARY), true);
+        MockHttpServletResponse resp = executeOnSecurityFilters(req);
+
+        assertEquals("expected 302 to Keycloak", 302, resp.getStatus());
+        String location = resp.getHeader("Location");
+        assertNotNull("missing Location header", location);
+        assertTrue("expected redirect to Keycloak at " + authServerUrl, location.startsWith(authServerUrl));
+
+        List<NameValuePair> params = new URIBuilder(new URI(location), StandardCharsets.UTF_8).getQueryParams();
+        String redirectUri = params.stream()
+                .filter(p -> "redirect_uri".equals(p.getName()))
+                .findFirst()
+                .map(NameValuePair::getValue)
+                .orElseThrow(() -> new AssertionError("missing redirect_uri"));
+
+        String expectedRedirectSuffix = "/web/login/oauth2/code/" + scopedRegId(FILTER_PRIMARY);
+        assertTrue(
+                "redirect_uri must end with " + expectedRedirectSuffix + " — got " + redirectUri,
+                redirectUri.endsWith(expectedRedirectSuffix));
+        LOGGER.fine("filter " + FILTER_PRIMARY + " → " + location);
+    }
+
+    /**
+     * When OAuth2 / OIDC authentication fails (bad client secret, invalid token, missing session state, IdP refusing
+     * the code exchange, ...) Spring's default failure handler redirects to {@code /login?error}. That path has no
+     * handler in the GeoServer webapp — no Wicket page mount, no servlet, no static resource — so Tomcat's default
+     * servlet serves the path back without a Content-Type and browsers render the response as a downloadable empty file
+     * named {@code login}. Reported in the wild by Dorset County Council during a Keycloak integration with a stale
+     * client secret (see the support#4578 thread).
+     *
+     * <p>Fix: {@code GeoServerOAuth2LoginAuthenticationFilterBuilder.createFiltersImpl} now configures
+     * {@code oauthConfig.failureUrl("/web/")} so a failed login leaves the user on the GeoServer home page where the
+     * standard login form is available.
+     *
+     * <p>Reproduction path: hit the OAuth2 callback endpoint with a {@code state} parameter that does not match any
+     * session-stored {@code OAuth2AuthorizationRequest}. Spring's filter activates on the URL match, fails the state
+     * lookup, and invokes the failure handler — exactly the same code path the user hits after a real token-exchange
+     * failure against the IdP.
+     */
+    @Test
+    public void testOAuth2FailureRedirectsToWebHomeNotLoginError() throws Exception {
+        // No prior OAuth2AuthorizationRequest stored in any session — the state lookup will fail and
+        // Spring will invoke the authenticationFailureHandler.
+        MockHttpServletRequest req = createRequest("web/login/oauth2/code/" + scopedRegId(FILTER_PRIMARY));
+        req.setParameter("code", "fake-authorization-code");
+        req.setParameter("state", "fake-state-no-match");
+
+        MockHttpServletResponse resp = executeOnSecurityFilters(req);
+
+        // Spring's failure handler must redirect, not produce an opaque body that the browser downloads.
+        assertEquals("expected 302 redirect from the failure handler", 302, resp.getStatus());
+        String location = resp.getHeader("Location");
+        assertNotNull("failure-handler redirect must include a Location header", location);
+
+        // The crux of the fix: the redirect target must NOT be Spring's default /login?error, which has no
+        // handler in the GeoServer webapp and falls through to Tomcat's default servlet → downloadable empty
+        // file named "login". Verified against the user-reported symptom on support#4578.
+        assertFalse(
+                "failure redirect must not target /login?error (no handler in GeoServer webapp, browsers download an empty file): "
+                        + location,
+                location.endsWith("/login?error") || location.endsWith("/login") || location.contains("/login?"));
+
+        // Positive assertion: the redirect target should be the GeoServer home page (or a sub-path under /web/) so
+        // the Wicket admin UI can render the standard login form for the user to retry.
+        assertTrue(
+                "failure redirect must land somewhere under /web/ — got " + location,
+                location.endsWith("/web/")
+                        || location.endsWith("/web")
+                        || location.contains("/web/")
+                        || location.contains("/web?"));
+    }
+
+    /**
+     * Execute a web request through the GeoServer security filter chain (mirrors
+     * {@code KeyCloakIntegrationTest.executeOnSecurityFilters}; copied locally rather than refactoring the existing
+     * helper into a base class so this test stays self-contained).
+     */
+    private MockHttpServletResponse executeOnSecurityFilters(MockHttpServletRequest request)
+            throws IOException, jakarta.servlet.ServletException {
+        RequestContextListener listener = new RequestContextListener();
+        ServletRequestEvent event = new ServletRequestEvent(request.getServletContext(), request);
+        listener.requestInitialized(event);
+        try {
+            MockFilterChain chain = new MockFilterChain();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            GeoServerSecurityFilterChainProxy filterChainProxy =
+                    GeoServerExtensions.bean(GeoServerSecurityFilterChainProxy.class);
+            filterChainProxy.doFilter(request, response, chain);
+            return response;
+        } finally {
+            listener.requestDestroyed(event);
+        }
+    }
+}

--- a/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/login/OAuth2LoginButtonManagerTest.java
+++ b/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/login/OAuth2LoginButtonManagerTest.java
@@ -6,200 +6,455 @@ package org.geoserver.web.security.oauth2.login;
 
 import static org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId.REG_ID_GIT_HUB;
 import static org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId.REG_ID_GOOGLE;
+import static org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId.REG_ID_MICROSOFT;
 import static org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId.REG_ID_OIDC;
 import static org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilterBuilder.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
 import static org.geoserver.security.oauth2.login.OAuth2LoginButtonEnablementEvent.disableButtonEvent;
 import static org.geoserver.security.oauth2.login.OAuth2LoginButtonEnablementEvent.enableButtonEvent;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.TreeSet;
+import org.geoserver.security.GeoServerSecurityFilterChain;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.RequestFilterChain;
+import org.geoserver.security.SecurityManagerListener;
+import org.geoserver.security.config.SecurityManagerConfig;
 import org.geoserver.security.oauth2.login.GeoServerOAuth2ClientRegistrationId;
+import org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter;
+import org.geoserver.security.oauth2.login.OAuth2LoginButtonEnablementEvent;
 import org.geoserver.web.LoginFormInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextRefreshedEvent;
 
 /**
- * Tests {@link OAuth2LoginButtonManager}, in particular multi-instance tracking: a button stays enabled as long as at
- * least one filter instance enables that provider type.
+ * Tests for {@link OAuth2LoginButtonManager}'s per-filter-instance dynamic-registration behavior.
+ *
+ * <p>The manager creates one {@link LoginFormInfo} singleton per active scoped registration ID (one per filter +
+ * provider combination), registers it with the application's bean factory so
+ * {@link org.geoserver.web.GeoServerBasePage}'s by-type lookup picks it up, and destroys it on the matching disable
+ * event. Multiple filters of the same provider type produce multiple independent buttons, each pointing at its own
+ * scoped authorization endpoint.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class OAuth2LoginButtonManagerTest {
 
     @Mock
-    private LoginFormInfo oidcButton;
-
-    @Mock
-    private LoginFormInfo googleButton;
-
-    @Mock
-    private LoginFormInfo gitHubButton;
+    private DefaultListableBeanFactory beanFactory;
 
     private OAuth2LoginButtonManager sut;
 
-    private boolean oidcEnabled;
-    private String oidcLoginPath;
-    private boolean googleEnabled;
-    private String googleLoginPath;
-    private boolean gitHubEnabled;
-    private String gitHubLoginPath;
-
     @Before
     public void setUp() {
-        // LoginFormInfo IDs mirror the XML config in applicationContext.xml
-        when(oidcButton.getId()).thenReturn("openIdConnectOidcLoginButton");
-        when(googleButton.getId()).thenReturn("openIdConnectGoogleLoginButton");
-        when(gitHubButton.getId()).thenReturn("openIdConnectGitHubLoginButton");
-
-        // Capture setEnabled/setLoginPath calls via Mockito doAnswer
-        org.mockito.Mockito.doAnswer(inv -> {
-                    oidcEnabled = inv.getArgument(0);
-                    return null;
-                })
-                .when(oidcButton)
-                .setEnabled(org.mockito.ArgumentMatchers.anyBoolean());
-        org.mockito.Mockito.doAnswer(inv -> {
-                    oidcLoginPath = inv.getArgument(0);
-                    return null;
-                })
-                .when(oidcButton)
-                .setLoginPath(org.mockito.ArgumentMatchers.anyString());
-
-        org.mockito.Mockito.doAnswer(inv -> {
-                    googleEnabled = inv.getArgument(0);
-                    return null;
-                })
-                .when(googleButton)
-                .setEnabled(org.mockito.ArgumentMatchers.anyBoolean());
-        org.mockito.Mockito.doAnswer(inv -> {
-                    googleLoginPath = inv.getArgument(0);
-                    return null;
-                })
-                .when(googleButton)
-                .setLoginPath(org.mockito.ArgumentMatchers.anyString());
-
-        org.mockito.Mockito.doAnswer(inv -> {
-                    gitHubEnabled = inv.getArgument(0);
-                    return null;
-                })
-                .when(gitHubButton)
-                .setEnabled(org.mockito.ArgumentMatchers.anyBoolean());
-        org.mockito.Mockito.doAnswer(inv -> {
-                    gitHubLoginPath = inv.getArgument(0);
-                    return null;
-                })
-                .when(gitHubButton)
-                .setLoginPath(org.mockito.ArgumentMatchers.anyString());
-
         sut = new OAuth2LoginButtonManager();
-        sut.setLoginFormInfos(Arrays.asList(oidcButton, googleButton, gitHubButton));
+        sut.setBeanFactory(beanFactory);
+    }
+
+    private static String scopedRegId(String filterName, String baseRegId) {
+        return GeoServerOAuth2ClientRegistrationId.scopedRegId(filterName, baseRegId);
     }
 
     private static String expectedLoginPath(String scopedRegId) {
         return "/" + DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/" + scopedRegId;
     }
 
-    @Test
-    public void testSingleFilterEnableDisable() {
-        String lFilterName = "my-filter";
-        String lScopedOidc = GeoServerOAuth2ClientRegistrationId.scopedRegId(lFilterName, REG_ID_OIDC);
+    private static String expectedBeanName(String scopedRegId) {
+        return OAuth2LoginButtonManager.DYNAMIC_BEAN_NAME_PREFIX + scopedRegId;
+    }
 
-        // when: enable OIDC for a single filter
-        sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
-
-        // then: OIDC button enabled, path points to scoped ID
-        assertTrue(oidcEnabled);
-        assertEquals(expectedLoginPath(lScopedOidc), oidcLoginPath);
-
-        // when: disable OIDC for the same filter
-        sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
-
-        // then: OIDC button disabled
-        assertFalse(oidcEnabled);
+    /**
+     * Convenience: wire {@code securityManager.getSecurityConfig().getFilterChain().getRequestChains()} to advertise a
+     * single request chain whose member filter names are {@code inChainFilterNames}. The sweep's chain-membership check
+     * walks this exact graph.
+     */
+    private static void stubInChainFilterNames(GeoServerSecurityManager securityManager, String... inChainFilterNames) {
+        RequestFilterChain chain = org.mockito.Mockito.mock(RequestFilterChain.class);
+        when(chain.getFilterNames()).thenReturn(Arrays.asList(inChainFilterNames));
+        GeoServerSecurityFilterChain filterChain = org.mockito.Mockito.mock(GeoServerSecurityFilterChain.class);
+        Collection<RequestFilterChain> chains = List.of(chain);
+        when(filterChain.getRequestChains()).thenReturn((List<RequestFilterChain>) chains);
+        SecurityManagerConfig cfg = org.mockito.Mockito.mock(SecurityManagerConfig.class);
+        when(cfg.getFilterChain()).thenReturn(filterChain);
+        when(securityManager.getSecurityConfig()).thenReturn(cfg);
     }
 
     @Test
-    public void testTwoFiltersEnableSameProvider() {
-        String lFilter1 = "keycloak-auth";
-        String lFilter2 = "azure-auth";
-        String lScoped1 = GeoServerOAuth2ClientRegistrationId.scopedRegId(lFilter1, REG_ID_OIDC);
-        String lScoped2 = GeoServerOAuth2ClientRegistrationId.scopedRegId(lFilter2, REG_ID_OIDC);
+    public void singleFilter_enableRegistersSingleton_disableDestroysIt() {
+        String lFilterName = "my-filter";
+        String lScopedOidc = scopedRegId(lFilterName, REG_ID_OIDC);
+        String lBeanName = expectedBeanName(lScopedOidc);
+
+        // when: enable fires for the filter
+        sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
+
+        // then: a LoginFormInfo is registered with the correct shape
+        ArgumentCaptor<LoginFormInfo> infoCaptor = ArgumentCaptor.forClass(LoginFormInfo.class);
+        verify(beanFactory).registerSingleton(eq(lBeanName), infoCaptor.capture());
+        LoginFormInfo registered = infoCaptor.getValue();
+        assertNotNull(registered);
+        // The filter name is encoded in the login path as <basePath>/<filterName>__<provider>; the manager exposes
+        // its own filterNameFromScopedRegId(...) helper that consumers can reuse on the path's last segment.
+        assertEquals(expectedLoginPath(lScopedOidc), registered.getLoginPath());
+        assertTrue(
+                "login path must end with the scoped registration id",
+                registered.getLoginPath().endsWith("/" + lScopedOidc));
+        assertTrue(
+                "scoped registration id must start with the filter name", lScopedOidc.startsWith(lFilterName + "__"));
+        assertEquals("openid.png", registered.getIcon());
+        assertEquals("GET", registered.getMethod());
+        assertTrue(registered.isEnabled());
+        assertTrue(registered.isJustUseExternalLink());
+        assertEquals("openidconnect.login.button.title", registered.getTitleKey());
+        assertEquals("OAuth2LoginAuthProviderPanel.oidcDescription", registered.getDescriptionKey());
+
+        // and: the internal registry mirrors the registration
+        assertNotNull(sut.getRegisteredButtons().get(lScopedOidc));
+
+        // when: disable fires for the same filter
+        sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
+
+        // then: the singleton is destroyed and the registry is empty
+        verify(beanFactory).destroySingleton(lBeanName);
+        assertNull(sut.getRegisteredButtons().get(lScopedOidc));
+    }
+
+    @Test
+    public void twoFiltersSameProvider_eachGetsOwnIndependentButton() {
+        String lFilter1 = "keycloak-prod";
+        String lFilter2 = "auth0-staging";
+        String lScoped1 = scopedRegId(lFilter1, REG_ID_OIDC);
+        String lScoped2 = scopedRegId(lFilter2, REG_ID_OIDC);
 
         // when: both filters enable OIDC
         sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScoped1));
         sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScoped2));
 
-        // then: OIDC button enabled, path points to the most recently enabled filter
-        assertTrue(oidcEnabled);
-        assertEquals(expectedLoginPath(lScoped2), oidcLoginPath);
+        // then: two distinct singletons are registered, each with its own scoped login path
+        verify(beanFactory).registerSingleton(eq(expectedBeanName(lScoped1)), any(LoginFormInfo.class));
+        verify(beanFactory).registerSingleton(eq(expectedBeanName(lScoped2)), any(LoginFormInfo.class));
+        assertEquals(
+                expectedLoginPath(lScoped1),
+                sut.getRegisteredButtons().get(lScoped1).getLoginPath());
+        assertEquals(
+                expectedLoginPath(lScoped2),
+                sut.getRegisteredButtons().get(lScoped2).getLoginPath());
+        // Filter name embedded in the loginPath via the scoped registration id (`<filterName>__<provider>`).
+        assertTrue(
+                sut.getRegisteredButtons().get(lScoped1).getLoginPath().endsWith("/" + lFilter1 + "__" + REG_ID_OIDC));
+        assertTrue(
+                sut.getRegisteredButtons().get(lScoped2).getLoginPath().endsWith("/" + lFilter2 + "__" + REG_ID_OIDC));
 
-        // when: first filter disables OIDC
+        // when: only the first filter disables
         sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScoped1));
 
-        // then: button still enabled (filter2 still active), path updated to surviving filter
-        assertTrue(oidcEnabled);
-        assertEquals(expectedLoginPath(lScoped2), oidcLoginPath);
-
-        // when: second filter also disables
-        sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScoped2));
-
-        // then: button disabled
-        assertFalse(oidcEnabled);
+        // then: only the first singleton is destroyed; the second one survives untouched
+        verify(beanFactory).destroySingleton(expectedBeanName(lScoped1));
+        verify(beanFactory, never()).destroySingleton(expectedBeanName(lScoped2));
+        assertNull(sut.getRegisteredButtons().get(lScoped1));
+        assertNotNull(sut.getRegisteredButtons().get(lScoped2));
     }
 
     @Test
-    public void testDifferentProvidersFromDifferentFilters() {
-        String lOidcFilter = "keycloak-auth";
-        String lGitHubFilter = "github-auth";
-        String lScopedOidc = GeoServerOAuth2ClientRegistrationId.scopedRegId(lOidcFilter, REG_ID_OIDC);
-        String lScopedGitHub = GeoServerOAuth2ClientRegistrationId.scopedRegId(lGitHubFilter, REG_ID_GIT_HUB);
+    public void threeOidcFilters_allProduceDistinctButtonsWithUniqueLoginPaths() {
+        // Beyond proving "two filters → two buttons", this case guards against any future refactor that
+        // accidentally caps the registry, collapses entries sharing a base registration ID, or trims paths
+        // back to the un-scoped form.
+        String[] filterNames = {"keycloak-prod", "auth0-staging", "entra-tenant"};
 
-        // when: OIDC filter enables OIDC, GitHub filter enables GitHub
-        sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
-        sut.enablementChanged(enableButtonEvent(this, REG_ID_GIT_HUB, lScopedGitHub));
+        for (String filterName : filterNames) {
+            sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, scopedRegId(filterName, REG_ID_OIDC)));
+        }
 
-        // then: both buttons enabled with correct paths
-        assertTrue(oidcEnabled);
-        assertEquals(expectedLoginPath(lScopedOidc), oidcLoginPath);
-        assertTrue(gitHubEnabled);
-        assertEquals(expectedLoginPath(lScopedGitHub), gitHubLoginPath);
+        // Three independent singletons registered, each keyed by its own bean name.
+        for (String filterName : filterNames) {
+            String scopedId = scopedRegId(filterName, REG_ID_OIDC);
+            verify(beanFactory).registerSingleton(eq(expectedBeanName(scopedId)), any(LoginFormInfo.class));
 
-        // when: disable OIDC filter
-        sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
+            LoginFormInfo info = sut.getRegisteredButtons().get(scopedId);
+            assertNotNull("expected a LoginFormInfo for " + scopedId, info);
+            assertEquals(expectedLoginPath(scopedId), info.getLoginPath());
+            assertTrue(
+                    "loginPath must end with /<filterName>__<provider>",
+                    info.getLoginPath().endsWith("/" + filterName + "__" + REG_ID_OIDC));
+            assertEquals("openid.png", info.getIcon());
+        }
 
-        // then: OIDC disabled, GitHub still enabled
-        assertFalse(oidcEnabled);
-        assertTrue(gitHubEnabled);
+        // Login paths are pairwise distinct — no two filters share a login URL.
+        java.util.Set<String> loginPaths = new java.util.HashSet<>();
+        for (String filterName : filterNames) {
+            loginPaths.add(sut.getRegisteredButtons()
+                    .get(scopedRegId(filterName, REG_ID_OIDC))
+                    .getLoginPath());
+        }
+        assertEquals("each filter must have a unique login path", filterNames.length, loginPaths.size());
+
+        // Bean names are pairwise distinct too.
+        java.util.Set<String> beanIds = new java.util.HashSet<>();
+        for (String filterName : filterNames) {
+            beanIds.add(sut.getRegisteredButtons()
+                    .get(scopedRegId(filterName, REG_ID_OIDC))
+                    .getId());
+        }
+        assertEquals("each filter must have a unique bean id", filterNames.length, beanIds.size());
+
+        // Disabling the middle filter must leave the other two intact.
+        String middle = scopedRegId("auth0-staging", REG_ID_OIDC);
+        sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, middle));
+        verify(beanFactory).destroySingleton(expectedBeanName(middle));
+        assertNull(sut.getRegisteredButtons().get(middle));
+        assertNotNull(sut.getRegisteredButtons().get(scopedRegId("keycloak-prod", REG_ID_OIDC)));
+        assertNotNull(sut.getRegisteredButtons().get(scopedRegId("entra-tenant", REG_ID_OIDC)));
     }
 
     @Test
-    public void testDisableNonExistentScopedIdIsNoOp() {
-        String lFilterName = "my-filter";
-        String lScopedOidc = GeoServerOAuth2ClientRegistrationId.scopedRegId(lFilterName, REG_ID_OIDC);
+    public void differentProvidersOnDifferentFilters_eachGetsOwnIconAndPath() {
+        String lScopedGoogle = scopedRegId("google-corp", REG_ID_GOOGLE);
+        String lScopedGitHub = scopedRegId("github-org", REG_ID_GIT_HUB);
+        String lScopedMs = scopedRegId("entra-tenant", REG_ID_MICROSOFT);
+        String lScopedOidc = scopedRegId("keycloak", REG_ID_OIDC);
 
-        // when: disable a scoped ID that was never enabled
-        sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
-
-        // then: button disabled (no error)
-        assertFalse(oidcEnabled);
-    }
-
-    @Test
-    public void testOnlyMatchingButtonsAffected() {
-        String lFilterName = "my-filter";
-        String lScopedGoogle = GeoServerOAuth2ClientRegistrationId.scopedRegId(lFilterName, REG_ID_GOOGLE);
-
-        // when: enable Google
         sut.enablementChanged(enableButtonEvent(this, REG_ID_GOOGLE, lScopedGoogle));
+        sut.enablementChanged(enableButtonEvent(this, REG_ID_GIT_HUB, lScopedGitHub));
+        sut.enablementChanged(enableButtonEvent(this, REG_ID_MICROSOFT, lScopedMs));
+        sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
 
-        // then: only Google button enabled
-        assertTrue(googleEnabled);
-        assertEquals(expectedLoginPath(lScopedGoogle), googleLoginPath);
-        // OIDC and GitHub should not have been touched by this event
+        assertEquals("google.png", sut.getRegisteredButtons().get(lScopedGoogle).getIcon());
+        assertEquals("github.png", sut.getRegisteredButtons().get(lScopedGitHub).getIcon());
+        assertEquals("microsoft.png", sut.getRegisteredButtons().get(lScopedMs).getIcon());
+        assertEquals("openid.png", sut.getRegisteredButtons().get(lScopedOidc).getIcon());
+
+        // Google / GitHub / Microsoft are icon-only (titleKey empty); OIDC carries an i18n label.
+        assertEquals("", sut.getRegisteredButtons().get(lScopedGoogle).getTitleKey());
+        assertEquals("", sut.getRegisteredButtons().get(lScopedGitHub).getTitleKey());
+        assertEquals("", sut.getRegisteredButtons().get(lScopedMs).getTitleKey());
+        assertEquals(
+                "openidconnect.login.button.title",
+                sut.getRegisteredButtons().get(lScopedOidc).getTitleKey());
+    }
+
+    @Test
+    public void repeatedEnable_isIdempotent_doesNotReregister() {
+        String lScopedOidc = scopedRegId("my-filter", REG_ID_OIDC);
+
+        // when: enable fires twice in a row (e.g. two consecutive filter rebuilds)
+        sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
+        sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
+
+        // then: only one singleton registration happened
+        verify(beanFactory, times(1)).registerSingleton(eq(expectedBeanName(lScopedOidc)), any(LoginFormInfo.class));
+    }
+
+    @Test
+    public void disableForNeverEnabledScopedId_isNoOp() {
+        String lScopedOidc = scopedRegId("ghost-filter", REG_ID_OIDC);
+
+        // when: a disable event arrives for a scoped ID we never saw enabled
+        sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
+
+        // then: no destroy call to the bean factory; registry stays empty
+        verify(beanFactory, never()).destroySingleton(anyString());
+        assertNull(sut.getRegisteredButtons().get(lScopedOidc));
+    }
+
+    @Test
+    public void filterNameWithoutScopedSeparator_treatedAsLiteralFilterName() {
+        // Defensive: scoped IDs are always of the form <filterName>__<baseRegId> in practice, but if
+        // the convention is ever broken the manager should still register a button rather than crash.
+        String rawId = "no-separator-here";
+        sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, rawId));
+
+        LoginFormInfo info = sut.getRegisteredButtons().get(rawId);
+        assertNotNull(info);
+        // The loginPath always echoes the raw scoped-id (no parsing surprises if the separator is absent).
+        assertTrue(
+                "loginPath must end with the raw scoped id when the separator is absent",
+                info.getLoginPath().endsWith("/" + rawId));
+        // filterNameFromScopedRegId returns the whole id when no separator is found — defensive parse path.
+        assertEquals(rawId, OAuth2LoginButtonManager.filterNameFromScopedRegId(rawId));
+    }
+
+    @Test
+    public void missingBeanFactory_eventsAreSwallowed() {
+        OAuth2LoginButtonManager bare = new OAuth2LoginButtonManager();
+        // intentionally no setBeanFactory call
+
+        // when: an event arrives
+        bare.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, scopedRegId("any", REG_ID_OIDC)));
+
+        // then: nothing crashes and the registry stays empty
+        assertTrue(bare.getRegisteredButtons().isEmpty());
+    }
+
+    @Test
+    public void nullScopedRegistrationId_isIgnored() {
+        OAuth2LoginButtonEnablementEvent nullScoped =
+                new OAuth2LoginButtonEnablementEvent(this, true, REG_ID_OIDC, null);
+        sut.enablementChanged(nullScoped);
+        verify(beanFactory, never()).registerSingleton(anyString(), any());
+    }
+
+    @Test
+    public void filterClass_isAuthenticationFilter() {
+        String lScopedOidc = scopedRegId("my-filter", REG_ID_OIDC);
+        sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
+
+        LoginFormInfo info = sut.getRegisteredButtons().get(lScopedOidc);
+        assertNotNull(info);
+        assertEquals(
+                "org.geoserver.security.oauth2.login.GeoServerOAuth2LoginAuthenticationFilter",
+                info.getFilterClass().getName());
+    }
+
+    // ── SecurityManagerListener: auto-enablement on save ─────────────────────
+    //
+    // These tests cover the "save filter → button appears without container restart" path.
+    // After context refresh the manager must self-register as a SecurityManagerListener and
+    // sweep existing filters; subsequent saves arrive via handlePostChanged which must trigger
+    // the same sweep, forcing each OAuth2 filter through the createFilter path that publishes
+    // the OAuth2LoginButtonEnablementEvent.
+
+    @Test
+    public void contextRefresh_registersListenerAndSweepsExistingFilters() throws Exception {
+        GeoServerSecurityManager securityManager = org.mockito.Mockito.mock(GeoServerSecurityManager.class);
+        TreeSet<String> filterNames = new TreeSet<>();
+        filterNames.add("keycloak-prod");
+        filterNames.add("auth0-staging");
+        when(securityManager.listFilters(GeoServerOAuth2LoginAuthenticationFilter.class))
+                .thenReturn(filterNames);
+        when(beanFactory.getBean(GeoServerSecurityManager.class)).thenReturn(securityManager);
+        // Both filters are bound to the web chain — eligible to render a button.
+        stubInChainFilterNames(securityManager, "keycloak-prod", "auth0-staging");
+
+        ContextRefreshedEvent event = new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class));
+        sut.onContextRefreshed(event);
+
+        // The manager must register itself as a SecurityManagerListener so that subsequent
+        // saves (via GeoServerSecurityManager#saveSecurityConfig) call back into handlePostChanged.
+        verify(securityManager).addListener(same(sut));
+        // Initial sweep: each in-chain OAuth2 filter must be loaded so the builder publishes the
+        // enablement event the button manager listens for.
+        verify(securityManager).loadFilter("keycloak-prod");
+        verify(securityManager).loadFilter("auth0-staging");
+    }
+
+    @Test
+    public void contextRefresh_skipsOffChainFiltersDuringSweep() throws Exception {
+        GeoServerSecurityManager securityManager = org.mockito.Mockito.mock(GeoServerSecurityManager.class);
+        TreeSet<String> filterNames = new TreeSet<>();
+        filterNames.add("keycloak-prod");
+        filterNames.add("orphan-filter"); // configured but not bound to any chain
+        when(securityManager.listFilters(GeoServerOAuth2LoginAuthenticationFilter.class))
+                .thenReturn(filterNames);
+        when(beanFactory.getBean(GeoServerSecurityManager.class)).thenReturn(securityManager);
+        // Only keycloak-prod is in the chain; orphan-filter is not — its button must NOT register.
+        stubInChainFilterNames(securityManager, "keycloak-prod");
+
+        sut.onContextRefreshed(new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class)));
+
+        verify(securityManager).loadFilter("keycloak-prod");
+        verify(securityManager, never()).loadFilter("orphan-filter");
+    }
+
+    @Test
+    public void contextRefresh_isIdempotent_listenerRegisteredOnlyOnce() throws Exception {
+        GeoServerSecurityManager securityManager = org.mockito.Mockito.mock(GeoServerSecurityManager.class);
+        when(securityManager.listFilters(GeoServerOAuth2LoginAuthenticationFilter.class))
+                .thenReturn(new TreeSet<>());
+        when(beanFactory.getBean(GeoServerSecurityManager.class)).thenReturn(securityManager);
+        stubInChainFilterNames(securityManager); // empty chain
+
+        ContextRefreshedEvent event = new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class));
+
+        sut.onContextRefreshed(event);
+        sut.onContextRefreshed(event);
+        sut.onContextRefreshed(event);
+
+        // A re-refresh of the context (which can happen in test harnesses or after parent-context
+        // shuffling) must not re-register the listener — otherwise GeoServerSecurityManager would
+        // fire handlePostChanged N times per save.
+        verify(securityManager, times(1)).addListener(any(SecurityManagerListener.class));
+    }
+
+    @Test
+    public void handlePostChanged_sweepsAllOAuth2FiltersThroughLoadFilter() throws Exception {
+        // Pre-condition: simulate that the listener is already wired up via onContextRefreshed.
+        GeoServerSecurityManager securityManager = org.mockito.Mockito.mock(GeoServerSecurityManager.class);
+        when(securityManager.listFilters(GeoServerOAuth2LoginAuthenticationFilter.class))
+                .thenReturn(new TreeSet<>()); // initial sweep finds nothing
+        when(beanFactory.getBean(GeoServerSecurityManager.class)).thenReturn(securityManager);
+        stubInChainFilterNames(securityManager); // empty chain at boot
+
+        sut.onContextRefreshed(new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class)));
+
+        // Now simulate an admin saving two new filters AND adding them to the chain — handlePostChanged
+        // is the call that runs once GeoServerSecurityManager#saveSecurityConfig calls fireChanged().
+        TreeSet<String> newlySaved = new TreeSet<>();
+        newlySaved.add("keycloak-prod");
+        newlySaved.add("auth0-staging");
+        when(securityManager.listFilters(GeoServerOAuth2LoginAuthenticationFilter.class))
+                .thenReturn(newlySaved);
+        stubInChainFilterNames(securityManager, "keycloak-prod", "auth0-staging");
+
+        sut.handlePostChanged(securityManager);
+
+        // Each freshly-saved filter must be loaded through the provider's createFilter path,
+        // which is where the enablement event is published.
+        verify(securityManager).loadFilter("keycloak-prod");
+        verify(securityManager).loadFilter("auth0-staging");
+    }
+
+    @Test
+    public void handlePostChanged_loadFilterFailureForOneNameDoesNotSkipTheRest() throws Exception {
+        GeoServerSecurityManager securityManager = org.mockito.Mockito.mock(GeoServerSecurityManager.class);
+        TreeSet<String> filters = new TreeSet<>();
+        filters.add("broken-filter");
+        filters.add("healthy-filter");
+        when(securityManager.listFilters(GeoServerOAuth2LoginAuthenticationFilter.class))
+                .thenReturn(filters);
+        when(beanFactory.getBean(GeoServerSecurityManager.class)).thenReturn(securityManager);
+        // Both filters bound to the chain so the sweep tries to load each.
+        stubInChainFilterNames(securityManager, "broken-filter", "healthy-filter");
+        // First call throws — second must still happen.
+        when(securityManager.loadFilter("broken-filter")).thenThrow(new RuntimeException("simulated bad config"));
+
+        sut.onContextRefreshed(new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class)));
+
+        // Defence-in-depth: a single bad filter (e.g. half-saved config) must not block the
+        // remaining OIDC filters from getting their buttons registered.
+        verify(securityManager).loadFilter("broken-filter");
+        verify(securityManager).loadFilter("healthy-filter");
+    }
+
+    @Test
+    public void handlePostChanged_beforeContextRefresh_isNoOp() {
+        // If a save event somehow reaches us before the context-refresh hook ran (the security
+        // manager reference is then null), the manager must not crash and must not attempt to
+        // reach into a null security manager.
+        GeoServerSecurityManager securityManager = org.mockito.Mockito.mock(GeoServerSecurityManager.class);
+
+        sut.handlePostChanged(securityManager); // not called via the wiring; should be silent
+
+        // No interaction at all on the passed manager — we sweep against our cached field, not the arg.
+        org.mockito.Mockito.verifyNoInteractions(securityManager);
     }
 }

--- a/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/login/OAuth2LoginButtonManagerTest.java
+++ b/src/community/security/oidc/oidc-web/src/test/java/org/geoserver/web/security/oauth2/login/OAuth2LoginButtonManagerTest.java
@@ -14,10 +14,9 @@ import static org.geoserver.security.oauth2.login.OAuth2LoginButtonEnablementEve
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -40,7 +39,6 @@ import org.geoserver.web.LoginFormInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -78,10 +76,6 @@ public class OAuth2LoginButtonManagerTest {
         return "/" + DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/" + scopedRegId;
     }
 
-    private static String expectedBeanName(String scopedRegId) {
-        return OAuth2LoginButtonManager.DYNAMIC_BEAN_NAME_PREFIX + scopedRegId;
-    }
-
     /**
      * Convenience: wire {@code securityManager.getSecurityConfig().getFilterChain().getRequestChains()} to advertise a
      * single request chain whose member filter names are {@code inChainFilterNames}. The sweep's chain-membership check
@@ -99,21 +93,19 @@ public class OAuth2LoginButtonManagerTest {
     }
 
     @Test
-    public void singleFilter_enableRegistersSingleton_disableDestroysIt() {
+    public void singleFilter_enableRegisters_disableRemoves() {
         String lFilterName = "my-filter";
         String lScopedOidc = scopedRegId(lFilterName, REG_ID_OIDC);
-        String lBeanName = expectedBeanName(lScopedOidc);
 
         // when: enable fires for the filter
         sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
 
-        // then: a LoginFormInfo is registered with the correct shape
-        ArgumentCaptor<LoginFormInfo> infoCaptor = ArgumentCaptor.forClass(LoginFormInfo.class);
-        verify(beanFactory).registerSingleton(eq(lBeanName), infoCaptor.capture());
-        LoginFormInfo registered = infoCaptor.getValue();
+        // then: the manager's registry holds a LoginFormInfo with the expected shape. The manager now exposes its
+        // contents via ExtensionProvider<LoginFormInfo>, so GeoServerExtensions.extensions(LoginFormInfo.class, ctx)
+        // picks them up on every call — no bean-factory singleton registration, no extension-cache invalidation
+        // headaches.
+        LoginFormInfo registered = sut.getRegisteredButtons().get(lScopedOidc);
         assertNotNull(registered);
-        // The filter name is encoded in the login path as <basePath>/<filterName>__<provider>; the manager exposes
-        // its own filterNameFromScopedRegId(...) helper that consumers can reuse on the path's last segment.
         assertEquals(expectedLoginPath(lScopedOidc), registered.getLoginPath());
         assertTrue(
                 "login path must end with the scoped registration id",
@@ -127,15 +119,16 @@ public class OAuth2LoginButtonManagerTest {
         assertEquals("openidconnect.login.button.title", registered.getTitleKey());
         assertEquals("OAuth2LoginAuthProviderPanel.oidcDescription", registered.getDescriptionKey());
 
-        // and: the internal registry mirrors the registration
-        assertNotNull(sut.getRegisteredButtons().get(lScopedOidc));
+        // and: ExtensionProvider exposes it under LoginFormInfo
+        assertEquals(LoginFormInfo.class, sut.getExtensionPoint());
+        assertEquals(1, sut.getExtensions(LoginFormInfo.class).size());
 
         // when: disable fires for the same filter
         sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
 
-        // then: the singleton is destroyed and the registry is empty
-        verify(beanFactory).destroySingleton(lBeanName);
+        // then: the registry is empty and the ExtensionProvider returns nothing
         assertNull(sut.getRegisteredButtons().get(lScopedOidc));
+        assertTrue(sut.getExtensions(LoginFormInfo.class).isEmpty());
     }
 
     @Test
@@ -149,9 +142,7 @@ public class OAuth2LoginButtonManagerTest {
         sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScoped1));
         sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScoped2));
 
-        // then: two distinct singletons are registered, each with its own scoped login path
-        verify(beanFactory).registerSingleton(eq(expectedBeanName(lScoped1)), any(LoginFormInfo.class));
-        verify(beanFactory).registerSingleton(eq(expectedBeanName(lScoped2)), any(LoginFormInfo.class));
+        // then: two distinct entries are tracked, each with its own scoped login path
         assertEquals(
                 expectedLoginPath(lScoped1),
                 sut.getRegisteredButtons().get(lScoped1).getLoginPath());
@@ -163,15 +154,16 @@ public class OAuth2LoginButtonManagerTest {
                 sut.getRegisteredButtons().get(lScoped1).getLoginPath().endsWith("/" + lFilter1 + "__" + REG_ID_OIDC));
         assertTrue(
                 sut.getRegisteredButtons().get(lScoped2).getLoginPath().endsWith("/" + lFilter2 + "__" + REG_ID_OIDC));
+        // ExtensionProvider returns both as a snapshot — the path GeoServerBasePage uses.
+        assertEquals(2, sut.getExtensions(LoginFormInfo.class).size());
 
         // when: only the first filter disables
         sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScoped1));
 
-        // then: only the first singleton is destroyed; the second one survives untouched
-        verify(beanFactory).destroySingleton(expectedBeanName(lScoped1));
-        verify(beanFactory, never()).destroySingleton(expectedBeanName(lScoped2));
+        // then: only the first entry is removed; the second one survives untouched
         assertNull(sut.getRegisteredButtons().get(lScoped1));
         assertNotNull(sut.getRegisteredButtons().get(lScoped2));
+        assertEquals(1, sut.getExtensions(LoginFormInfo.class).size());
     }
 
     @Test
@@ -185,11 +177,9 @@ public class OAuth2LoginButtonManagerTest {
             sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, scopedRegId(filterName, REG_ID_OIDC)));
         }
 
-        // Three independent singletons registered, each keyed by its own bean name.
+        // Three independent entries tracked, each with its own scoped login path.
         for (String filterName : filterNames) {
             String scopedId = scopedRegId(filterName, REG_ID_OIDC);
-            verify(beanFactory).registerSingleton(eq(expectedBeanName(scopedId)), any(LoginFormInfo.class));
-
             LoginFormInfo info = sut.getRegisteredButtons().get(scopedId);
             assertNotNull("expected a LoginFormInfo for " + scopedId, info);
             assertEquals(expectedLoginPath(scopedId), info.getLoginPath());
@@ -198,6 +188,7 @@ public class OAuth2LoginButtonManagerTest {
                     info.getLoginPath().endsWith("/" + filterName + "__" + REG_ID_OIDC));
             assertEquals("openid.png", info.getIcon());
         }
+        assertEquals(filterNames.length, sut.getExtensions(LoginFormInfo.class).size());
 
         // Login paths are pairwise distinct — no two filters share a login URL.
         java.util.Set<String> loginPaths = new java.util.HashSet<>();
@@ -208,7 +199,7 @@ public class OAuth2LoginButtonManagerTest {
         }
         assertEquals("each filter must have a unique login path", filterNames.length, loginPaths.size());
 
-        // Bean names are pairwise distinct too.
+        // Bean ids are pairwise distinct too.
         java.util.Set<String> beanIds = new java.util.HashSet<>();
         for (String filterName : filterNames) {
             beanIds.add(sut.getRegisteredButtons()
@@ -220,7 +211,6 @@ public class OAuth2LoginButtonManagerTest {
         // Disabling the middle filter must leave the other two intact.
         String middle = scopedRegId("auth0-staging", REG_ID_OIDC);
         sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, middle));
-        verify(beanFactory).destroySingleton(expectedBeanName(middle));
         assertNull(sut.getRegisteredButtons().get(middle));
         assertNotNull(sut.getRegisteredButtons().get(scopedRegId("keycloak-prod", REG_ID_OIDC)));
         assertNotNull(sut.getRegisteredButtons().get(scopedRegId("entra-tenant", REG_ID_OIDC)));
@@ -253,15 +243,19 @@ public class OAuth2LoginButtonManagerTest {
     }
 
     @Test
-    public void repeatedEnable_isIdempotent_doesNotReregister() {
+    public void repeatedEnable_isIdempotent_keepsExistingEntry() {
         String lScopedOidc = scopedRegId("my-filter", REG_ID_OIDC);
 
         // when: enable fires twice in a row (e.g. two consecutive filter rebuilds)
         sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
+        LoginFormInfo first = sut.getRegisteredButtons().get(lScopedOidc);
         sut.enablementChanged(enableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
+        LoginFormInfo second = sut.getRegisteredButtons().get(lScopedOidc);
 
-        // then: only one singleton registration happened
-        verify(beanFactory, times(1)).registerSingleton(eq(expectedBeanName(lScopedOidc)), any(LoginFormInfo.class));
+        // then: the entry is identical — bean identity stays stable for any consumer holding a reference, and
+        // the ExtensionProvider snapshot returns one and only one button for this scoped id.
+        assertSame(first, second);
+        assertEquals(1, sut.getExtensions(LoginFormInfo.class).size());
     }
 
     @Test
@@ -271,9 +265,9 @@ public class OAuth2LoginButtonManagerTest {
         // when: a disable event arrives for a scoped ID we never saw enabled
         sut.enablementChanged(disableButtonEvent(this, REG_ID_OIDC, lScopedOidc));
 
-        // then: no destroy call to the bean factory; registry stays empty
-        verify(beanFactory, never()).destroySingleton(anyString());
+        // then: registry stays empty (and unregisterButton short-circuits when there is nothing to remove)
         assertNull(sut.getRegisteredButtons().get(lScopedOidc));
+        assertTrue(sut.getExtensions(LoginFormInfo.class).isEmpty());
     }
 
     @Test
@@ -310,7 +304,9 @@ public class OAuth2LoginButtonManagerTest {
         OAuth2LoginButtonEnablementEvent nullScoped =
                 new OAuth2LoginButtonEnablementEvent(this, true, REG_ID_OIDC, null);
         sut.enablementChanged(nullScoped);
-        verify(beanFactory, never()).registerSingleton(anyString(), any());
+        assertTrue(
+                "null scopedRegId must not produce a registered button",
+                sut.getRegisteredButtons().isEmpty());
     }
 
     @Test
@@ -346,7 +342,7 @@ public class OAuth2LoginButtonManagerTest {
         stubInChainFilterNames(securityManager, "keycloak-prod", "auth0-staging");
 
         ContextRefreshedEvent event = new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class));
-        sut.onContextRefreshed(event);
+        sut.onApplicationEvent(event);
 
         // The manager must register itself as a SecurityManagerListener so that subsequent
         // saves (via GeoServerSecurityManager#saveSecurityConfig) call back into handlePostChanged.
@@ -369,7 +365,7 @@ public class OAuth2LoginButtonManagerTest {
         // Only keycloak-prod is in the chain; orphan-filter is not — its button must NOT register.
         stubInChainFilterNames(securityManager, "keycloak-prod");
 
-        sut.onContextRefreshed(new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class)));
+        sut.onApplicationEvent(new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class)));
 
         verify(securityManager).loadFilter("keycloak-prod");
         verify(securityManager, never()).loadFilter("orphan-filter");
@@ -385,9 +381,9 @@ public class OAuth2LoginButtonManagerTest {
 
         ContextRefreshedEvent event = new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class));
 
-        sut.onContextRefreshed(event);
-        sut.onContextRefreshed(event);
-        sut.onContextRefreshed(event);
+        sut.onApplicationEvent(event);
+        sut.onApplicationEvent(event);
+        sut.onApplicationEvent(event);
 
         // A re-refresh of the context (which can happen in test harnesses or after parent-context
         // shuffling) must not re-register the listener — otherwise GeoServerSecurityManager would
@@ -397,14 +393,14 @@ public class OAuth2LoginButtonManagerTest {
 
     @Test
     public void handlePostChanged_sweepsAllOAuth2FiltersThroughLoadFilter() throws Exception {
-        // Pre-condition: simulate that the listener is already wired up via onContextRefreshed.
+        // Pre-condition: simulate that the listener is already wired up via onApplicationEvent.
         GeoServerSecurityManager securityManager = org.mockito.Mockito.mock(GeoServerSecurityManager.class);
         when(securityManager.listFilters(GeoServerOAuth2LoginAuthenticationFilter.class))
                 .thenReturn(new TreeSet<>()); // initial sweep finds nothing
         when(beanFactory.getBean(GeoServerSecurityManager.class)).thenReturn(securityManager);
         stubInChainFilterNames(securityManager); // empty chain at boot
 
-        sut.onContextRefreshed(new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class)));
+        sut.onApplicationEvent(new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class)));
 
         // Now simulate an admin saving two new filters AND adding them to the chain — handlePostChanged
         // is the call that runs once GeoServerSecurityManager#saveSecurityConfig calls fireChanged().
@@ -437,7 +433,7 @@ public class OAuth2LoginButtonManagerTest {
         // First call throws — second must still happen.
         when(securityManager.loadFilter("broken-filter")).thenThrow(new RuntimeException("simulated bad config"));
 
-        sut.onContextRefreshed(new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class)));
+        sut.onApplicationEvent(new ContextRefreshedEvent(org.mockito.Mockito.mock(ApplicationContext.class)));
 
         // Defence-in-depth: a single bad filter (e.g. half-saved config) must not block the
         // remaining OIDC filters from getting their buttons registered.

--- a/src/theme/src/main/resources/css/geoserver.css
+++ b/src/theme/src/main/resources/css/geoserver.css
@@ -1914,6 +1914,32 @@ form a.collapsed {
   margin-bottom: 0.5em;
   padding: 0.25em;
 }
+/* External login buttons (OIDC / OAuth2 / CAS / ...).
+ *
+ * The Wicket template repeats the wrapper element per registered LoginFormInfo, so several configured filters produce
+ * sibling .gs-login-external-links divs. Layout goals:
+ *   1. multiple buttons sit side-by-side (not stacked vertically);
+ *   2. the group is centered horizontally;
+ *   3. no impact on other dropdown items when no OIDC button is present (rules opt-in via :has()).
+ *
+ * Scoping: every rule is anchored at .gs-user-dropdown-panel so nothing leaks outside the user dropdown. The
+ * parent <ul> rule fires only when at least one .gs-login-external-links wrapper is present (the :has() guard);
+ * with no OIDC buttons configured the existing dropdown layout is untouched. */
+.gs-user-dropdown-panel .gs-user-dropdown-info ul:has(> .gs-login-external-links) {
+  text-align: center;
+}
+.gs-user-dropdown-panel .gs-login-external-links {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0.25em 0.375em;
+  vertical-align: middle;
+}
+.gs-user-dropdown-panel .gs-login-external-links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
 .gs-user-dropdown-panel input[type="text"],
 .gs-user-dropdown-panel input[type="password"] {
   height: 2em;


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

This PR fixes a cluster of issues that surfaced once an administrator
configured more than one OIDC filter against the same GeoServer 3 / Spring
Security 7 deployment. The login dropdown now shows one button per filter,
each button works end-to-end, and the registry stays in sync with the
security configuration without requiring a container restart.

## What was broken

### 1. Dynamic button visibility (critical)

`OAuth2LoginButtonManager` used to register each login button as a Spring
singleton via `BeanFactory.registerSingleton`. `GeoServer­Extensions` caches
bean-names-by-type on the first lookup and never invalidates that cache,
so dynamically-registered singletons stayed invisible to
`GeoServerBasePage` indefinitely. Symptom: a freshly-saved OIDC filter's
button only appeared after a JVM restart; deleting a filter left a stale
button in the UI.

**Fix:** `OAuth2LoginButtonManager` now implements
`ExtensionProvider<LoginFormInfo>` and serves its live map of buttons.
`GeoServerExtensions` queries `ExtensionProvider`s on every call (no
caching), so chain edits propagate to the rendered HTML on the next page
load. Side cleanup: the redundant `registerSingleton` / `destroySingleton`
calls are gone, removing the duplicate-button artefact that appeared while
both lookup paths returned the same entry.

Listener wiring also moved to `ApplicationListener<ContextRefreshedEvent>`.
The earlier `setBeanFactory` / `afterPropertiesSet` / `@PostConstruct`
attempts all ran during this bean's own initialization, and looking up
`GeoServerSecurityManager` at that moment triggered
`BeanCurrentlyInCreationException` via `authenticationManager`.
`ApplicationListener` is Spring-auto-detected (no
`<context:annotation-config/>` required, which oidc-web doesn't declare)
and fires once the entire application context is up.

### 2. Per-filter scope separation

Each `GeoServerOAuth2LoginAuthenticationFilter` used to build its own
private `InMemoryClientRegistrationRepository` containing only its own
registration ID. Under Spring Security 7,
`DefaultOAuth2AuthorizationRequestResolver.resolve` throws
`InvalidClientRegistrationIdException` instead of silently falling through,
which meant clicking the button for filter B with filter A's sub-chain in
front returned HTTP 500.

**Fix:** A new application-wide `GeoServerOAuth2ClientRegistrationRegistry`
(implements `ClientRegistrationRepository` + `Iterable<ClientRegistration>`)
collects every active OAuth2 filter's contributions, keyed by GeoServer
filter name. Every filter's Spring sub-chain shares this same repository,
so any redirect filter can resolve any sibling's scoped registration ID
without throwing. Lifecycle: contributions are atomically replaced on
filter rebuild and pruned on the `OAuth2LoginButtonManager` sweep when a
filter leaves every chain.

This is enabled by a related change: registration IDs are now scoped per
filter as `<filterName>__<provider>` (e.g. `keycloak-prod__oidc`,
`auth0-staging__oidc`). Callback URLs the IdP must whitelist follow the
same form: `/web/login/oauth2/code/<filterName>__<provider>`.

### 3. Multi-button layout

<img width="217" height="255" alt="image" src="https://github.com/user-attachments/assets/5c055d58-42c3-45fb-920d-0f875801ec75" />

CSS in `theme/css/geoserver.css` now lays multiple
`.gs-login-external-links` siblings horizontally and centers them as a
group. The rule is scoped behind `:has(> .gs-login-external-links)` so
dropdowns without any OIDC filter configured are untouched.

## Also in this PR

- **Failure-redirect UX fix.** Spring's default failure handler redirected
  to `/login?error`, which has no servlet mapping in the GeoServer webapp;
  Tomcat served the path back as an unhandled resource and browsers
  downloaded an empty file named `login`. The OAuth2 builder now sets
  `failureUrl("/web/")` and `loginProcessingUrl("/web/login/oauth2/code/*")`
  so authentication failures land on the standard login form.
- **No more `community/jwt-headers` dependency.** The OIDC plugin will be
  promoted to extension and can't depend on a community module. Replaced
  the borrowed `JwtConfiguration` / `RoleConverter` / `JwtHeader­UserName­Extractor`
  / `asStringList` with two self-contained helpers in oidc-core
  (`OAuth2ClaimsHelpers`, `OAuth2RoleConverter`) and dropped the dependency
  from `oidc-core/pom.xml` and `oidc-assembly/{pom,assembly}.xml`.
- **Docs:** redirect-URI examples updated to the scoped form across
  `configuring.md`, `advanced.md`, and the per-provider guides
  (`generic.md`, `keycloak.md`, `google.md`, `github.md`, `azure.md`).
  Added a "Multiple OIDC filters" section in `configuring.md`.
- **Tests:** new `GeoServerOAuth2ClientRegistrationRegistryTest`;
  expanded `OAuth2LoginButtonManagerTest` (multi-filter, sweep, listener
  wiring, ExtensionProvider semantics);
  `OpenIdConnectLoginButtonTest` covers multi-filter render + CSS wrapper
  shape + auto-enablement + failure-redirect;
  `KeyCloakMultiFilterIntegrationTest` runs a Keycloak Testcontainers
  scenario covering scoped redirect URIs and per-filter button rendering.

## Migration note

Existing single-filter deployments need their IdP "Valid Redirect URIs"
updated to the new scoped form
`<base>/web/login/oauth2/code/<filterName>__<provider>`, or use a wildcard
(`<base>/web/login/oauth2/code/*`). The change is highlighted in
`configuring.md`.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.