### PR TITLE
[GEOS-12136] IOTestUtils.createRandomDirectory() replacing mkdir call to more recent java.nio.files API

### DIFF
--- a/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaMockData.java
+++ b/src/extension/app-schema/app-schema-test/src/test/java/org/geoserver/test/AbstractAppSchemaMockData.java
@@ -149,7 +149,7 @@ public abstract class AbstractAppSchemaMockData extends SystemTestData implement
 
     static File newRandomDirectory() {
         try {
-            return IOUtils.createRandomDirectory("target", "app-schema-mock", "data");
+            return org.geoserver.test.IOUtils.createRandomDirectory("target", "app-schema-mock");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/extension/app-schema/sample-data-access-test/src/test/java/org/geoserver/test/SampleDataAccessMockData.java
+++ b/src/extension/app-schema/sample-data-access-test/src/test/java/org/geoserver/test/SampleDataAccessMockData.java
@@ -56,7 +56,7 @@ public class SampleDataAccessMockData extends SystemTestData {
 
     /** Constructor. Creates empty mock data directory. */
     public SampleDataAccessMockData() throws IOException {
-        data = IOUtils.createRandomDirectory("./target", "sample-data-access-mock", "data");
+        data = org.geoserver.test.IOUtils.createRandomDirectory("./target", "sample-data-access-mock");
         data.delete();
         data.mkdir();
 

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/Directory.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/Directory.java
@@ -12,6 +12,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -59,9 +61,9 @@ public class Directory extends FileData {
     }
 
     public static Directory createNew(File parent) throws IOException {
-        File directory = File.createTempFile("tmp", "", parent);
-        if (!directory.delete() || !directory.mkdir())
-            throw new IOException("Error creating temp directory at " + directory.getAbsolutePath());
+        Path tmpPath = Files.createTempDirectory(parent.toPath(), "tmp");
+        File directory = tmpPath.toFile();
+
         return new Directory(directory);
     }
 

--- a/src/extension/importer/core/src/main/java/org/geoserver/importer/transform/AbstractCommandLinePreTransform.java
+++ b/src/extension/importer/core/src/main/java/org/geoserver/importer/transform/AbstractCommandLinePreTransform.java
@@ -8,6 +8,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -172,13 +174,9 @@ public abstract class AbstractCommandLinePreTransform extends AbstractCommandLin
     protected File getOutputDirectory(ImportData data) throws IOException {
         File input = getInputFile(data);
         File parent = input.getParentFile();
-        File tempFile = File.createTempFile("tmp", null, parent);
-        tempFile.delete();
-        if (!tempFile.mkdir()) {
-            throw new IOException("Could not create work directory " + tempFile.getAbsolutePath());
-        }
+        Path tmpPath = Files.createTempDirectory(parent.toPath(), "tmp");
 
-        return tempFile;
+        return tmpPath.toFile();
     }
 
     /** Implementors must provide the executable to be run */

--- a/src/extension/kml/src/test/java/org/geoserver/kml/KMLReflectorTest.java
+++ b/src/extension/kml/src/test/java/org/geoserver/kml/KMLReflectorTest.java
@@ -488,7 +488,7 @@ public class KMLReflectorTest extends WMSTestSupport {
         assertEquals(KMZMapOutputFormat.MIME_TYPE, response.getContentType());
 
         // create the kmz
-        File tempDir = org.geoserver.util.IOUtils.createRandomDirectory("./target", "kmplacemark", "test");
+        File tempDir = org.geoserver.test.IOUtils.createRandomDirectory("./target", "kmplacemark");
         tempDir.deleteOnExit();
 
         File zip = new File(tempDir, "kmz.zip");

--- a/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
+++ b/src/extension/wps-download/src/test/java/org/geoserver/wps/gs/download/DownloadProcessTest.java
@@ -2980,8 +2980,8 @@ public class DownloadProcessTest extends WPSTestSupport {
      */
     private ShapefileDataStore decodeShape(InputStream input) throws Exception {
         // create the temp directory and register it as a temporary resource
-        File tempDir = IOUtils.createRandomDirectory(
-                IOUtils.createTempDirectory("shpziptemp").getAbsolutePath(), "download-process", "download-services");
+        File tempDir = org.geoserver.test.IOUtils.createRandomDirectory(
+                IOUtils.createTempDirectory("shpziptemp").getAbsolutePath(), "download-process");
 
         // unzip to the temporary directory
         File shapeFile = null;
@@ -3038,8 +3038,8 @@ public class DownloadProcessTest extends WPSTestSupport {
      */
     private GeoPackage decodeGeoPackage(InputStream input) throws Exception {
         // create the temp directory and register it as a temporary resource
-        File tempDir = IOUtils.createRandomDirectory(
-                IOUtils.createTempDirectory("gpkgziptemp").getAbsolutePath(), "download-process", "download-services");
+        File tempDir = org.geoserver.test.IOUtils.createRandomDirectory(
+                IOUtils.createTempDirectory("gpkgziptemp").getAbsolutePath(), "download-process");
 
         // unzip to the temporary directory
         File geopackage = null;

--- a/src/main/src/test/java/org/geoserver/data/test/LiveData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/LiveData.java
@@ -23,7 +23,7 @@ public class LiveData implements TestData {
      */
     @Override
     public void setUp() throws Exception {
-        data = IOUtils.createRandomDirectory("./target", "live", "data");
+        data = org.geoserver.test.IOUtils.createRandomDirectory("./target", "live");
         IOUtils.deepCopy(source, data);
     }
 

--- a/src/main/src/test/java/org/geoserver/data/test/LiveSystemTestData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/LiveSystemTestData.java
@@ -20,7 +20,7 @@ public class LiveSystemTestData extends SystemTestData {
 
     @Override
     public void setUp() throws Exception {
-        data = IOUtils.createRandomDirectory("./target", "live", "data");
+        data = org.geoserver.test.IOUtils.createRandomDirectory("./target", "live");
         IOUtils.deepCopy(source, data);
     }
 

--- a/src/main/src/test/java/org/geoserver/data/test/MockData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/MockData.java
@@ -315,7 +315,7 @@ public class MockData implements TestData {
 
     public MockData() throws IOException {
         // setup the root
-        data = IOUtils.createRandomDirectory("./target", "mock", "data");
+        data = org.geoserver.test.IOUtils.createRandomDirectory("./target", "mock");
         data.delete();
         data.mkdir();
 

--- a/src/main/src/test/java/org/geoserver/data/test/MockTestData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/MockTestData.java
@@ -12,7 +12,6 @@ import org.geoserver.catalog.Catalog;
 import org.geoserver.security.GeoServerSecurityManager;
 import org.geoserver.test.GeoServerMockTestSupport;
 import org.geoserver.test.GeoServerSystemTestSupport;
-import org.geoserver.util.IOUtils;
 
 /**
  * Test setup uses for GeoServer mock tests.
@@ -35,7 +34,7 @@ public class MockTestData extends CiteTestData {
 
     public MockTestData() throws IOException {
         // setup the root
-        data = IOUtils.createRandomDirectory("./target", "mock", "data");
+        data = org.geoserver.test.IOUtils.createRandomDirectory("./target", "mock");
         data.delete();
         data.mkdir();
 

--- a/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
+++ b/src/main/src/test/java/org/geoserver/data/test/SystemTestData.java
@@ -122,7 +122,7 @@ public class SystemTestData extends CiteTestData {
 
     public SystemTestData() throws IOException {
         // setup the root
-        data = IOUtils.createRandomDirectory("./target", "default", "data");
+        data = org.geoserver.test.IOUtils.createRandomDirectory("./target", "default");
         data.delete();
         data.mkdir();
     }

--- a/src/main/src/test/java/org/geoserver/test/GeoServerTestApplicationContext.java
+++ b/src/main/src/test/java/org/geoserver/test/GeoServerTestApplicationContext.java
@@ -9,7 +9,6 @@ import jakarta.servlet.ServletContext;
 import java.io.File;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
-import org.geoserver.util.IOUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -42,7 +41,7 @@ public class GeoServerTestApplicationContext extends ClassPathXmlApplicationCont
             throws BeansException {
         super(configLocation, false);
         try {
-            contextTmp = IOUtils.createRandomDirectory("./target", "mock", "tmp");
+            contextTmp = org.geoserver.test.IOUtils.createRandomDirectory("./target", "mock");
             servletContext.setAttribute("javax.servlet.context.tempdir", contextTmp);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/main/src/test/java/org/geoserver/test/IOUtils.java
+++ b/src/main/src/test/java/org/geoserver/test/IOUtils.java
@@ -1,0 +1,22 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class IOUtils {
+
+    /**
+     * Creates a directory as a child of baseDir. The directory name will be preceded by prefix and followed by suffix
+     */
+    public static File createRandomDirectory(String baseDir, String prefix) throws IOException {
+        Path tmpPath = java.nio.file.Files.createTempDirectory(Paths.get(baseDir), prefix);
+
+        return tmpPath.toFile();
+    }
+}

--- a/src/platform/src/main/java/org/geoserver/util/IOUtils.java
+++ b/src/platform/src/main/java/org/geoserver/util/IOUtils.java
@@ -20,10 +20,10 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
@@ -158,32 +158,14 @@ public class IOUtils {
     }
 
     /**
-     * Creates a directory as a child of baseDir. The directory name will be preceded by prefix and followed by suffix
-     */
-    public static File createRandomDirectory(String baseDir, String prefix, String suffix) throws IOException {
-        File tempDir = File.createTempFile(prefix, suffix, new File(baseDir));
-        tempDir.delete();
-        if (!tempDir.mkdir()) throw new IOException("Could not create the temp directory " + tempDir.getPath());
-        return tempDir;
-    }
-
-    /**
      * Creates a temporary directory whose name will start by prefix
      *
      * <p>Strategy is to leverage the system temp directory, then create a sub-directory.
      */
     public static File createTempDirectory(String prefix) throws IOException {
-        File dummyTemp = File.createTempFile("blah", null);
-        String sysTempDir = dummyTemp.getParentFile().getAbsolutePath();
-        dummyTemp.delete();
+        Path tmpPath = java.nio.file.Files.createTempDirectory(prefix);
 
-        File reqTempDir = new File(sysTempDir
-                + File.separator
-                + prefix
-                + ThreadLocalRandom.current().nextDouble());
-        reqTempDir.mkdir();
-
-        return reqTempDir;
+        return tmpPath.toFile();
     }
 
     /**

--- a/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/LiveDbmsDataSecurity.java
+++ b/src/security/jdbc/src/test/java/org/geoserver/security/jdbc/LiveDbmsDataSecurity.java
@@ -33,7 +33,7 @@ public class LiveDbmsDataSecurity extends LiveDbmsData {
 
     @Override
     public void setUp() throws Exception {
-        data = IOUtils.createRandomDirectory("./target", "live", "data");
+        data = org.geoserver.test.IOUtils.createRandomDirectory("./target", "live");
         IOUtils.deepCopy(source, data);
     }
 


### PR DESCRIPTION
[![GEOS-12136](https://badgen.net/badge/JIRA/GEOS-12136/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12136) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->

File.mkdir is known not to be thread-safe. Replacing the call by the `java.nio.files`  Java api which is more recent. The impact should be quite limited though, as grepping the codebase reveals that the method is only called in the testsuite.

Removing the suffix parameter from the `IOUtils` static method, as the `createTempDirectory` does not support passing a suffix.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 