### PR TITLE
[GEOS-11581] Set up leaner attribute transformations when attribute customization is enabled

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/TransformFeatureTypeCallback.java
+++ b/src/main/src/main/java/org/geoserver/catalog/TransformFeatureTypeCallback.java
@@ -18,10 +18,12 @@ import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.api.feature.Feature;
 import org.geotools.api.feature.type.FeatureType;
 import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.api.util.InternationalString;
 import org.geotools.data.transform.Definition;
 import org.geotools.data.transform.TransformFactory;
+import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.FeatureTypes;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
@@ -33,6 +35,8 @@ import org.geotools.util.SimpleInternationalString;
  * eventual {@link AttributeTypeInfo} list.
  */
 public class TransformFeatureTypeCallback {
+
+    static final FilterFactory FF = CommonFactoryFinder.getFilterFactory(null);
 
     public FeatureType retypeFeatureType(FeatureTypeInfo fti, FeatureType schema) throws IOException {
         List<AttributeTypeInfo> attributes = fti.getAttributes();
@@ -75,7 +79,12 @@ public class TransformFeatureTypeCallback {
     private Definition toDefinition(AttributeTypeInfo ati) {
         try {
             String name = ati.getName();
-            Expression source = ECQL.toExpression(ati.getSource());
+            Expression source;
+            if (ati.getRawSource() == null) {
+                source = FF.property(name);
+            } else {
+                source = ECQL.toExpression(ati.getSource());
+            }
             Class<?> binding = ati.getBinding();
             InternationalString descriptionInternational = createDescriptionInternationalString(ati);
             boolean nillable = ati.isNillable();


### PR DESCRIPTION
[![GEOS-11581](https://badgen.net/badge/JIRA/GEOS-11581/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-11581) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Needs https://github.com/geotools/geotools/pull/5647

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 