### PR TITLE
[GEOS-12121] Fix Resource Browser OOM with lazy tree rendering

### DIFF
--- a/src/extension/web-resource/src/main/java/org/geoserver/web/treeview/TreeView.java
+++ b/src/extension/web-resource/src/main/java/org/geoserver/web/treeview/TreeView.java
@@ -492,9 +492,11 @@ public class TreeView<T> extends Panel {
                         if (newSelectedNodes.size()
                                 != selectedNodeModel.getObject().size()) {
                             setSelectedNodesInternal(newSelectedNodes, target);
-                            target.add(TreeExpandableNodeView.this);
                         }
                     }
+                    // Always refresh this node so children are rendered/cleared
+                    // when expand state changes (lazy rendering)
+                    target.add(TreeExpandableNodeView.this);
                 }
             };
             add(cbExpand);
@@ -509,8 +511,14 @@ public class TreeView<T> extends Panel {
             super.onBeforeRender();
             final RepeatingView children = (RepeatingView) get("children");
             children.removeAll();
-            for (TreeNode<T> child : getNode().getChildren()) {
-                children.add(createTreeNodeView(child.getUniqueId(), new Model<>(child)));
+            // Only render children if the node is expanded (lazy rendering).
+            // Previously all children were rendered unconditionally, causing
+            // OutOfMemoryError when large directory trees (e.g. tile cache
+            // blob stores) were present in the resource store.
+            if (Boolean.TRUE.equals(getNode().getExpanded().getObject())) {
+                for (TreeNode<T> child : getNode().getChildren()) {
+                    children.add(createTreeNodeView(child.getUniqueId(), new Model<>(child)));
+                }
             }
         }
 

--- a/src/extension/web-resource/src/test/java/org/geoserver/web/resources/PageResourceBrowserTest.java
+++ b/src/extension/web-resource/src/test/java/org/geoserver/web/resources/PageResourceBrowserTest.java
@@ -72,6 +72,16 @@ public class PageResourceBrowserTest extends GeoServerWicketTestSupport {
             }
         }
 
+        // Expand the test directories so their children are rendered (lazy rendering)
+        resourceBrowser
+                .expandedStates
+                .getResourceExpandedState(store.get("temp"))
+                .setObject(true);
+        resourceBrowser
+                .expandedStates
+                .getResourceExpandedState(store.get("temp/dir"))
+                .setObject(true);
+
         tester.startPage(resourceBrowser);
     }
 

--- a/src/extension/web-resource/src/test/java/org/geoserver/web/treeview/TreeViewLazyRenderTest.java
+++ b/src/extension/web-resource/src/test/java/org/geoserver/web/treeview/TreeViewLazyRenderTest.java
@@ -1,0 +1,225 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.web.treeview;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.repeater.RepeatingView;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.geoserver.web.GeoServerWicketTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests that TreeView uses lazy rendering: children of collapsed nodes are not rendered, and expanding a node via the
+ * checkbox causes children to be rendered via AJAX refresh.
+ */
+public class TreeViewLazyRenderTest extends GeoServerWicketTestSupport {
+
+    private static class MockNode implements TreeNode<Integer> {
+        private static final long serialVersionUID = 1012858609071186910L;
+
+        protected int data;
+        protected MockNode parent;
+        protected List<MockNode> children = new ArrayList<>();
+        protected IModel<Boolean> expanded = new Model<>(false);
+
+        public MockNode(int data, MockNode parent) {
+            this.data = data;
+            this.parent = parent;
+            if (parent != null) {
+                parent.children.add(this);
+            }
+        }
+
+        @Override
+        public Collection<? extends TreeNode<Integer>> getChildren() {
+            return children;
+        }
+
+        @Override
+        public TreeNode<Integer> getParent() {
+            return parent;
+        }
+
+        @Override
+        public Integer getObject() {
+            return data;
+        }
+
+        @Override
+        public IModel<Boolean> getExpanded() {
+            return expanded;
+        }
+
+        @Override
+        public String getUniqueId() {
+            return "" + data;
+        }
+
+        @Override
+        public boolean isLeaf() {
+            return children.isEmpty();
+        }
+    }
+
+    // Tree structure:
+    //   1 (root, expanded)
+    //   +-- 2 (directory, collapsed)
+    //   |   +-- 4 (leaf)
+    //   |   +-- 5 (leaf)
+    //   +-- 3 (directory, collapsed)
+    //   |   +-- 6 (leaf)
+    //   +-- 7 (leaf)
+    protected MockNode root;
+    protected MockNode dirA;
+    protected MockNode dirB;
+    protected MockNode leafInA1;
+    protected MockNode leafInA2;
+    protected MockNode leafInB;
+    protected MockNode leafInRoot;
+    protected TreeView<Integer> treeView;
+
+    @Before
+    public void initialize() {
+        root = new MockNode(1, null);
+        root.expanded.setObject(true);
+
+        dirA = new MockNode(2, root);
+        dirB = new MockNode(3, root);
+        leafInA1 = new MockNode(4, dirA);
+        leafInA2 = new MockNode(5, dirA);
+        leafInB = new MockNode(6, dirB);
+        leafInRoot = new MockNode(7, root);
+
+        treeView = new TreeView<>("treeView", root);
+    }
+
+    @Test
+    public void testCollapsedNodeChildrenNotRendered() {
+        // dirA and dirB are collapsed
+        assertFalse(dirA.expanded.getObject());
+        assertFalse(dirB.expanded.getObject());
+
+        tester.startComponentInPage(treeView);
+
+        // Root is expanded, so its direct children (dirA, dirB, leafInRoot) should be rendered
+        assertNotNull(tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2"));
+        assertNotNull(tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:3"));
+        assertNotNull(tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:7"));
+
+        // dirA is collapsed, so its children (4, 5) should NOT be rendered
+        Component dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertNotNull(dirAChildren);
+        assertTrue(dirAChildren instanceof RepeatingView);
+        assertEquals("Collapsed node should have no rendered children", 0, ((RepeatingView) dirAChildren).size());
+
+        // dirB is collapsed, so its child (6) should NOT be rendered
+        Component dirBChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:3:children");
+        assertNotNull(dirBChildren);
+        assertTrue(dirBChildren instanceof RepeatingView);
+        assertEquals("Collapsed node should have no rendered children", 0, ((RepeatingView) dirBChildren).size());
+    }
+
+    @Test
+    public void testExpandedNodeChildrenRendered() {
+        // Expand dirA before rendering
+        dirA.expanded.setObject(true);
+
+        tester.startComponentInPage(treeView);
+
+        // dirA is expanded, so its children (4, 5) should be rendered
+        Component dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertNotNull(dirAChildren);
+        assertTrue(dirAChildren instanceof RepeatingView);
+        assertEquals("Expanded node should have its children rendered", 2, ((RepeatingView) dirAChildren).size());
+
+        // Verify specific children exist
+        assertNotNull(tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children:4"));
+        assertNotNull(tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children:5"));
+
+        // dirB is still collapsed, so its child should NOT be rendered
+        Component dirBChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:3:children");
+        assertEquals(0, ((RepeatingView) dirBChildren).size());
+    }
+
+    @Test
+    public void testExpandViaCheckboxRendersChildren() {
+        // Start with everything collapsed except root
+        assertFalse(dirA.expanded.getObject());
+
+        tester.startComponentInPage(treeView);
+
+        // Verify dirA children are not rendered initially
+        Component dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertEquals(0, ((RepeatingView) dirAChildren).size());
+
+        // Programmatically expand dirA (simulates what the checkbox does)
+        dirA.expanded.setObject(true);
+        // Re-render the tree to trigger onBeforeRender with the new expanded state
+        tester.startComponentInPage(treeView);
+
+        // Children should now be rendered
+        dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertEquals("After expanding, children should be rendered", 2, ((RepeatingView) dirAChildren).size());
+        assertNotNull(tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children:4"));
+        assertNotNull(tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children:5"));
+    }
+
+    @Test
+    public void testCollapseRemovesChildren() {
+        // Start with dirA expanded
+        dirA.expanded.setObject(true);
+
+        tester.startComponentInPage(treeView);
+
+        // Verify children are rendered
+        Component dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertEquals(2, ((RepeatingView) dirAChildren).size());
+
+        // Collapse dirA
+        dirA.expanded.setObject(false);
+        tester.startComponentInPage(treeView);
+
+        // Children should no longer be rendered
+        dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertEquals("After collapsing, children should not be rendered", 0, ((RepeatingView) dirAChildren).size());
+    }
+
+    @Test
+    public void testExpandCollapseExpandCycle() {
+        tester.startComponentInPage(treeView);
+
+        // Initially collapsed - no children rendered
+        Component dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertEquals(0, ((RepeatingView) dirAChildren).size());
+
+        // Expand
+        dirA.expanded.setObject(true);
+        tester.startComponentInPage(treeView);
+        dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertEquals(2, ((RepeatingView) dirAChildren).size());
+
+        // Collapse
+        dirA.expanded.setObject(false);
+        tester.startComponentInPage(treeView);
+        dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertEquals(0, ((RepeatingView) dirAChildren).size());
+
+        // Expand again - children should reappear
+        dirA.expanded.setObject(true);
+        tester.startComponentInPage(treeView);
+        dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertEquals("Re-expanding should render children again", 2, ((RepeatingView) dirAChildren).size());
+    }
+}

--- a/src/extension/web-resource/src/test/java/org/geoserver/web/treeview/TreeViewLazyRenderTest.java
+++ b/src/extension/web-resource/src/test/java/org/geoserver/web/treeview/TreeViewLazyRenderTest.java
@@ -154,26 +154,30 @@ public class TreeViewLazyRenderTest extends GeoServerWicketTestSupport {
     }
 
     @Test
-    public void testExpandViaCheckboxRendersChildren() {
-        // Start with everything collapsed except root
-        assertFalse(dirA.expanded.getObject());
-
-        tester.startComponentInPage(treeView);
-
-        // Verify dirA children are not rendered initially
-        Component dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
-        assertEquals(0, ((RepeatingView) dirAChildren).size());
-
-        // Programmatically expand dirA (simulates what the checkbox does)
+    public void testCheckboxAjaxRefreshesNodeView() {
+        // Start with dirA expanded so the checkbox is checked
         dirA.expanded.setObject(true);
-        // Re-render the tree to trigger onBeforeRender with the new expanded state
+
         tester.startComponentInPage(treeView);
 
-        // Children should now be rendered
+        // Verify dirA children ARE rendered initially (expanded)
+        Component dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
+        assertEquals("Expanded node should have children rendered", 2, ((RepeatingView) dirAChildren).size());
+
+        // Collapse dirA via the checkbox (AJAX) - clicking a checked checkbox unchecks it.
+        // This exercises the real onUpdate() path and will fail if
+        // AjaxCheckBox.onUpdate() forgets to call target.add(...)
+        tester.executeAjaxEvent("treeView:rootView:1:children:2:cbExpand", "click");
+
+        // The checkbox should have toggled the expanded model to false
+        assertFalse("Checkbox click should have set expanded to false", dirA.expanded.getObject());
+
+        // Children should no longer be rendered (lazy rendering removes them)
         dirAChildren = tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children");
-        assertEquals("After expanding, children should be rendered", 2, ((RepeatingView) dirAChildren).size());
-        assertNotNull(tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children:4"));
-        assertNotNull(tester.getComponentFromLastRenderedPage("treeView:rootView:1:children:2:children:5"));
+        assertEquals(
+                "After collapsing via checkbox, children should not be rendered",
+                0,
+                ((RepeatingView) dirAChildren).size());
     }
 
     @Test

--- a/src/extension/web-resource/src/test/java/org/geoserver/web/treeview/TreeViewTest.java
+++ b/src/extension/web-resource/src/test/java/org/geoserver/web/treeview/TreeViewTest.java
@@ -78,6 +78,9 @@ public class TreeViewTest extends GeoServerWicketTestSupport {
 
     @Before
     public void initialize() {
+        // Expand root and directory nodes so children are rendered (lazy rendering)
+        one.expanded.setObject(true);
+        two.expanded.setObject(true);
         treeView = new TreeView<>("treeView", one);
     }
 
@@ -145,6 +148,11 @@ public class TreeViewTest extends GeoServerWicketTestSupport {
         assertFalse(one.getExpanded().getObject());
         assertTrue(treeView.getSelectedNodes().isEmpty());
         assertEquals(0, treeView.getSelectedViews().length);
+
+        // re-expand root for subsequent tests (programmatic expand + re-render)
+        one.expanded.setObject(true);
+        two.expanded.setObject(true);
+        tester.startComponentInPage(treeView);
 
         // multi-select toggle with ctrl
         tester.executeAjaxEvent("treeView:rootView:1:children:2:label:selectableLabel", "click");
@@ -223,6 +231,8 @@ public class TreeViewTest extends GeoServerWicketTestSupport {
         tester.startComponentInPage(treeView);
         MockNode five = new MockNode(5, four);
         assertEquals("4", treeView.getNearestView(five).getId());
+        // four must be expanded for its child (five) to be rendered
+        four.expanded.setObject(true);
         tester.startComponentInPage(treeView);
         assertEquals("5", treeView.getNearestView(five).getId());
     }


### PR DESCRIPTION
[![GEOS-12121](https://badgen.net/badge/JIRA/GEOS-12121/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12121) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Summary

The Resource Browser page (Utilities > Tools > Resource Browser) throws an `OutOfMemoryError` when the data directory contains a large directory tree such as a tile cache blob store.

<img width="832" height="297" alt="image" src="https://github.com/user-attachments/assets/d21f3908-af24-48c4-8f14-ba92130a9a74" />


## Root Cause

`TreeExpandableNodeView.onBeforeRender()` rendered children of **all** nodes unconditionally, regardless of expanded state. The expand/collapse was purely CSS-driven (checkbox + `display:none`). When a blob store with millions of tile cache directories was present, Wicket generated thousands of JavaScript snippets (one per `AjaxEventBehavior`) concatenated into a single `AppendingStringBuffer`, exceeding `Integer.MAX_VALUE`.

## Fix

- Only render children when the node's expanded model is `true` (lazy rendering)
- The `AjaxCheckBox.onUpdate()` now always refreshes the node view via `target.add()`, so children are populated via AJAX when expanding

## Testing

- New `TreeViewLazyRenderTest` with 5 tests covering lazy rendering behavior
- Updated existing tests to expand nodes before asserting on their children
- Full module test suite passes (19 tests, 0 failures) 


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.