### PR TITLE
[GEOS-12093] Fix publish_release.sh: version-gate GS3+ merge workflow

### DIFF
--- a/build/publish_release.sh
+++ b/build/publish_release.sh
@@ -39,6 +39,9 @@ fi
 
 pushd .. > /dev/null
 
+# Determine major version to select branch-specific behaviour
+major_version=$(echo "$tag" | cut -d. -f1)
+
 # init_git $git_user $git_email
 
 # fetch single tag
@@ -50,23 +53,26 @@ if [ `git tag --list $tag | wc -l` == 0 ]; then
   exit 1
 fi
 
-# check to see if a release branch already exists
-if [ `git branch --list $tag.x | wc -l` == 1 ]; then
-  echo "branch $tag.x exists, checking out"
-  git checkout $tag.x
-else
-  echo `release branch $tag.x not available, run build_release.sh first`
-fi
+if [ "$major_version" -ge 3 ]; then
+  # GeoServer 3.x+ uses persistent release branch $tag.x
+  if [ `git branch --list $tag.x | wc -l` == 1 ]; then
+    echo "branch $tag.x exists, checking out"
+    git checkout $tag.x
+  else
+    echo "release branch $tag.x not available, run build_release.sh first"
+    exit 1
+  fi
 
-# ensure the tagged revision actually on this branch
-set +e
-git log | grep $tag
-if [ $? != 0 ]; then
-   echo "Tag $tag not a on branch $tag.x"
-   echo "(Perhaps $tag.x is from a prior failed attempt and can be removed)"
-   exit -1
+  # ensure the tagged revision is actually on this branch (ancestry check)
+  if ! git merge-base --is-ancestor $tag HEAD; then
+     echo "Tag $tag is not an ancestor of branch $tag.x"
+     echo "(Perhaps $tag.x is from a prior failed attempt and can be removed)"
+     exit 1
+  fi
+else
+  # GeoServer 2.x uses tag directly
+  git checkout $tag
 fi
-set -e
 
 # deploy the release to maven repo
 pushd src > /dev/null
@@ -112,10 +118,13 @@ fi
 
 popd > /dev/null
 
-# release done, revert branch to snapshot, and supply a merge commit for commit history
-git revert $tag
-git push $tag.x
+# GeoServer 3.x+: revert release commit on branch, merge back to development branch
+if [ "$major_version" -ge 3 ]; then
+  git revert --no-edit $tag
+  git push origin $tag.x
 
-git checkout $branch
-git merge --no-ff $tag.x -m "Release $tag completed"
+  git checkout $branch
+  git merge --no-ff $tag.x -m "Release $tag completed"
+  git push origin $branch
+fi
 


### PR DESCRIPTION
[![GEOS-12093](https://badgen.net/badge/JIRA/GEOS-12093/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12093) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Summary

The GSIP 226 commit (eb3f3e1346) introduced a merge-commit-based release workflow in `publish_release.sh`, but it runs unconditionally for all versions. This causes the 2.28.x publish job to fail with merge conflicts when it tries to merge the release branch back into the development branch.

### Root cause

The script's post-publish steps (`git revert`, `git merge --no-ff`) attempt to merge the release branch (which touched now-deleted Sphinx `conf.py` files via `build_release.sh`'s `find doc -name conf.py` sed commands) back into a branch where those files no longer exist, resulting in modify/delete conflicts.

Specific conflicts observed in the [2.28.4 publish job](https://build.geoserver.org/view/release/job/geoserver-release-publish-jdk17/17/console):
- `doc/en/developer/programming-guide/ows-services/hello/pom.xml`
- `doc/en/developer/source/conf.py` (modify/delete)
- `doc/en/docguide/source/conf.py` (modify/delete)
- `doc/en/pom.xml`
- `doc/en/user/source/conf.py` (modify/delete)

### Fix

Apply the same version-gating pattern used in `build_release.sh` (commit 6f4c21f59b):

1. **Version check added**: `major_version=$(echo "$tag" | cut -d. -f1)` — the GS3+ merge workflow only runs when major version >= 3. For 2.x releases, the script simply checks out the tag (original behaviour).

2. **Exit on missing branch**: Previously the script printed a message when `$tag.x` didn't exist but continued executing on the wrong branch. Now it exits immediately.

3. **Proper ancestry check**: Replaced weak `git log | grep $tag` (which could match commit messages, not refs) with `git merge-base --is-ancestor $tag HEAD`.

4. **Fixed `git push`**: `git push $tag.x` was treating the branch name as the remote name. Changed to `git push origin $tag.x`.

5. **Push merged result**: Added `git push origin $branch` after the merge commit (previously the merge was never pushed).

6. **Non-interactive revert**: Added `--no-edit` to `git revert` to prevent an interactive editor from blocking CI.

### Testing

- For 2.28.x releases: the new code path simply does `git checkout $tag` then proceeds to deploy/upload — no branch manipulation, no merge, no conflicts.
- For 3.x+ releases: the full GSIP 226 merge-commit workflow runs with the bug fixes above.

cc @jodygarnett for review — this touches the GSIP 226 release process changes. 

----



- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 