### PR TITLE
[docs - quickfix] app-schema/feature-chaining - properly escape example xml blocks

### DIFF
--- a/doc/en/user/data/app-schema/feature-chaining.md
+++ b/doc/en/user/data/app-schema/feature-chaining.md
@@ -324,6 +324,7 @@ For this example, we are nesting gsml:GeologicUnit in gsml:MappedFeature as gsml
 
 - Set up nesting on the container feature type mapping as usual:
 
+```xml
       <AttributeMapping>
         <targetAttribute>gsml:specification</targetAttribute>
         <sourceExpression>
@@ -332,9 +333,11 @@ For this example, we are nesting gsml:GeologicUnit in gsml:MappedFeature as gsml
           <linkField>gml:name[2]</linkField>
         </sourceExpression>
       </AttributeMapping>
+```
 
 - Set up xlink:href as client property on the other mapping file:
 
+```xml
       <AttributeMapping>
         <targetAttribute>gsml:occurrence</targetAttribute>      
         <sourceExpression>
@@ -348,6 +351,7 @@ For this example, we are nesting gsml:GeologicUnit in gsml:MappedFeature as gsml
            <value>strConcat('urn:cgi:feature:MappedFeature:', ID)</value>
         </ClientProperty>       
       </AttributeMapping>
+```
 
 As we are getting the client property value from a nested feature, we have to set it as if we are chaining the feature; but we also add the client property containing *xlink:href* in the attribute mapping. The code will detect the *xlink:href* setting, and will not proceed to build the nested feature's attributes, and we will end up with empty attributes with *xlink:href* client properties.
 


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  XML code wasn't properly escaped, this results in the document rendering improperly
<img width="728" height="277" alt="image" src="https://github.com/user-attachments/assets/b568eabb-1c20-4a69-9256-57ba8e6477f1" />

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [X] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.