### PR TITLE
Improve GWC error logging

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -131,6 +131,7 @@ import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.grid.GridSubsetFactory;
+import org.geowebcache.grid.OutsideCoverageException;
 import org.geowebcache.grid.SRS;
 import org.geowebcache.io.ByteArrayResource;
 import org.geowebcache.io.Resource;
@@ -799,6 +800,10 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         ConveyorTile tileResp = null;
         try {
             tileResp = tileLayer.getTile(tileReq);
+        } catch (OutsideCoverageException e) {
+            final String msg = e.getMessage() != null ? e.getMessage() : "tile outside coverage";
+            requestMistmatchTarget.append(msg);
+            log.log(Level.FINE, msg);
         } catch (Exception e) {
             log.log(Level.INFO, "Error dispatching tile request to GeoServer", e);
         }

--- a/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
+++ b/src/main/src/main/java/org/geoserver/config/GeoServerLoader.java
@@ -1048,7 +1048,7 @@ public abstract class GeoServerLoader {
 
     protected void logStop(Stopwatch stoppedSw, final Catalog catalog) {
         Supplier<String> msg = () ->
-                "Read Catalog in %s: workspaces: %,d, namespaces: %,d, styles: %,d, stores: %,d, resources: %,d, layers: %,d, layer groups: %,d."
+                "Read Catalog in %s : workspaces: %,d, namespaces: %,d, styles: %,d, stores: %,d, resources: %,d, layers: %,d, layer groups: %,d."
                         .formatted(
                                 stoppedSw,
                                 catalog.count(WorkspaceInfo.class, Predicates.acceptAll()),


### PR DESCRIPTION
Improve GWC error logging:

- Log OutsideCoverageException at FINE level (message only, no stack trace) in GWC.dispatch(). This is a routine client error (requesting a tile outside coverage) and does not warrant a full stack trace at INFO level.
- Add space before colon in GeoServerLoader catalog timing log message to prevent the stopwatch output (e.g. '1.234s:') from being interpreted as a URI scheme by log viewers.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).