### PR TITLE
[GEOS-12127] Fix flaky metadata extension tests

### DIFF
--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractWicketMetadataTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractWicketMetadataTest.java
@@ -1,9 +1,12 @@
 package org.geoserver.metadata;
 
 import static org.geoserver.web.GeoServerApplication.GEOSERVER_CSRF_DISABLED;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Locale;
 import org.apache.wicket.Component;
+import org.apache.wicket.extensions.markup.html.tabs.ITab;
+import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.apache.wicket.util.tester.WicketTester;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.wicket.WicketHierarchyPrinter;
@@ -41,6 +44,46 @@ public abstract class AbstractWicketMetadataTest extends AbstractMetadataTest {
     @After
     public void stop() throws Exception {
         tester.destroy();
+    }
+
+    /**
+     * Navigates to the Metadata tab on the ResourceConfigurationPage by finding it dynamically based on its title. This
+     * avoids hardcoding the tab index which varies depending on which extensions are loaded in the test context.
+     */
+    protected void navigateToMetadataTab() {
+        TabbedPanel<?> tabbedPanel = (TabbedPanel<?>) tester.getComponentFromLastRenderedPage("publishedinfo:tabs");
+        int metadataTabIndex = findMetadataTabIndex(tabbedPanel);
+        tabbedPanel.setSelectedTab(metadataTabIndex);
+        tester.submitForm("publishedinfo");
+        // verify we actually landed on the metadata tab — the panel contains either a TabbedPanel
+        // (when metadata-tabs.yaml is configured) or directly a MetadataPanel (when no sub-tabs)
+        org.apache.wicket.Component metadataComponent =
+                tester.getComponentFromLastRenderedPage("publishedinfo:tabs:panel:metadataPanel");
+        assertNotNull("Metadata panel not found after navigating to Metadata tab", metadataComponent);
+    }
+
+    /**
+     * Finds the index of the metadata tab by matching the tab title. The title is resolved from the resource key
+     * "MetadataTabPanelInfo.title" which defaults to "Metadata".
+     */
+    private int findMetadataTabIndex(TabbedPanel<?> tabbedPanel) {
+        java.util.List<? extends ITab> tabs = tabbedPanel.getTabs();
+        for (int i = 0; i < tabs.size(); i++) {
+            String title = tabs.get(i).getTitle().getObject();
+            if ("Metadata".equals(title)) {
+                return i;
+            }
+        }
+        // provide a helpful error message listing available tabs
+        StringBuilder available = new StringBuilder();
+        for (int i = 0; i < tabs.size(); i++) {
+            available
+                    .append(i)
+                    .append(": ")
+                    .append(tabs.get(i).getTitle().getObject())
+                    .append(", ");
+        }
+        throw new AssertionError("Could not find 'Metadata' tab. Available tabs: " + available);
     }
 
     /**

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/ConditionTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/ConditionTest.java
@@ -5,14 +5,11 @@
 package org.geoserver.metadata.web;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 
 import org.apache.wicket.MarkupContainer;
-import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.data.test.MockData;
 import org.geoserver.metadata.AbstractWicketMetadataTest;
-import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.web.data.resource.ResourceConfigurationPage;
 import org.junit.After;
 import org.junit.Test;
@@ -34,18 +31,15 @@ public class ConditionTest extends AbstractWicketMetadataTest {
 
     @Test
     public void testNoFeatureCatalogueForRasters() {
-        // this test does not run reliably on GitHub actions, cause unclear
-        assumeFalse(GeoServerSystemTestSupport.isGitHubAction());
 
         login();
         LayerInfo raster = geoServer.getCatalog().getLayerByName(MockData.USA_WORLDIMG.getLocalPart());
         ResourceConfigurationPage page = new ResourceConfigurationPage(raster, false);
         tester.startPage(page);
-        ((TabbedPanel<?>) tester.getComponentFromLastRenderedPage("publishedinfo:tabs")).setSelectedTab(4);
+        navigateToMetadataTab();
 
         MarkupContainer c = (MarkupContainer) tester.getComponentFromLastRenderedPage(
                 "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items");
-        tester.submitForm("publishedinfo");
         assertEquals(14, c.size());
         logout();
     }

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/ExternalResourceLoaderTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/ExternalResourceLoaderTest.java
@@ -9,12 +9,10 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.util.Locale;
 import org.apache.wicket.Session;
-import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.util.file.File;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.metadata.AbstractWicketMetadataTest;
-import org.geoserver.metadata.web.panel.MetadataPanel;
 import org.geoserver.metadata.web.resource.WicketResourceResourceLoader;
 import org.geoserver.platform.resource.Files;
 import org.geoserver.web.data.resource.ResourceConfigurationPage;
@@ -87,9 +85,7 @@ public class ExternalResourceLoaderTest extends AbstractWicketMetadataTest {
         LayerInfo layer = geoServer.getCatalog().getLayerByName("mylayer");
         ResourceConfigurationPage page = new ResourceConfigurationPage(layer, false);
         tester.startPage(page);
-        ((TabbedPanel<?>) tester.getComponentFromLastRenderedPage("publishedinfo:tabs")).setSelectedTab(4);
-        tester.submitForm("publishedinfo");
-        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel", MetadataPanel.class);
+        navigateToMetadataTab();
 
         tester.assertLabel(
                 "publishedinfo:tabs:panel:metadataPanel:attributesPanel:attributesTablePanel:listContainer:items:2:itemProperties:0:component",

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/LayerMetadataTabTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/LayerMetadataTabTest.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
-import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.DropDownChoice;
@@ -59,9 +58,7 @@ public class LayerMetadataTabTest extends AbstractWicketMetadataTest {
         assertNotNull(layer);
         ResourceConfigurationPage page = new ResourceConfigurationPage(layer, false);
         tester.startPage(page);
-        ((TabbedPanel<?>) tester.getComponentFromLastRenderedPage("publishedinfo:tabs")).setSelectedTab(4);
-        tester.submitForm("publishedinfo");
-        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel", MetadataPanel.class);
+        navigateToMetadataTab();
     }
 
     @After

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/web/TabsTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/web/TabsTest.java
@@ -2,11 +2,9 @@ package org.geoserver.metadata.web;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeFalse;
 
 import java.io.IOException;
 import java.util.Map;
-import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.apache.wicket.util.file.File;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.catalog.LayerInfo;
@@ -14,7 +12,6 @@ import org.geoserver.metadata.AbstractMetadataTest;
 import org.geoserver.metadata.AbstractWicketMetadataTest;
 import org.geoserver.metadata.data.dto.AttributeConfiguration;
 import org.geoserver.metadata.web.panel.MetadataPanel;
-import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.util.IOUtils;
 import org.geoserver.web.data.resource.ResourceConfigurationPage;
 import org.geoserver.web.wicket.GeoServerTablePanel;
@@ -47,10 +44,7 @@ public class TabsTest extends AbstractWicketMetadataTest {
         assertNotNull(layer);
         ResourceConfigurationPage page = new ResourceConfigurationPage(layer, false);
         tester.startPage(page);
-        ((TabbedPanel<?>) tester.getComponentFromLastRenderedPage("publishedinfo:tabs")).setSelectedTab(4);
-        tester.submitForm("publishedinfo");
-        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel", TabbedPanel.class);
-        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel:panel", MetadataPanel.class);
+        navigateToMetadataTab();
 
         GeoServerTablePanel<AttributeConfiguration> attPanel =
                 (GeoServerTablePanel<AttributeConfiguration>) tester.getComponentFromLastRenderedPage(
@@ -75,18 +69,13 @@ public class TabsTest extends AbstractWicketMetadataTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testSave() throws IOException {
-        // this test does not run reliably on GitHub actions, cause unclear
-        assumeFalse(GeoServerSystemTestSupport.isGitHubAction());
 
         login();
         layer = geoServer.getCatalog().getLayerByName("mylayer");
         assertNotNull(layer);
         ResourceConfigurationPage page = new ResourceConfigurationPage(layer, false);
         tester.startPage(page);
-        ((TabbedPanel<?>) tester.getComponentFromLastRenderedPage("publishedinfo:tabs")).setSelectedTab(4);
-        tester.submitForm("publishedinfo");
-        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel", TabbedPanel.class);
-        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel:panel", MetadataPanel.class);
+        navigateToMetadataTab();
 
         FormTester formTester = tester.newFormTester("publishedinfo");
         formTester.setValue(
@@ -113,10 +102,7 @@ public class TabsTest extends AbstractWicketMetadataTest {
         assertNotNull(layer);
         ResourceConfigurationPage page = new ResourceConfigurationPage(layer, false);
         tester.startPage(page);
-        ((TabbedPanel<?>) tester.getComponentFromLastRenderedPage("publishedinfo:tabs")).setSelectedTab(4);
-        tester.submitForm("publishedinfo");
-        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel", TabbedPanel.class);
-        tester.assertComponent("publishedinfo:tabs:panel:metadataPanel:panel", MetadataPanel.class);
+        navigateToMetadataTab();
 
         assertEquals(
                 "extra-text",


### PR DESCRIPTION
[![GEOS-12127](https://badgen.net/badge/JIRA/GEOS-12127/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12127) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

https://osgeo-org.atlassian.net/browse/GEOS-12127

The metadata extension tests (`TabsTest`, `LayerMetadataTabTest`, `ExternalResourceLoaderTest`, `ConditionTest`) were the #1 source of flaky CI failures — 11 occurrences of `TabsTest` alone in a 2-month analysis period.

**Root cause**: All these tests used a hardcoded `setSelectedTab(4)` assuming the Metadata tab is always at index 4 on `ResourceConfigurationPage`. This index varies depending on which extensions contribute tabs via `PublishedEditTabPanelInfo`, and differs between local builds and CI environments.

**Fix**: Replace the hardcoded index with a dynamic lookup that finds the Metadata tab by its title. A shared `navigateToMetadataTab()` helper in `AbstractWicketMetadataTest` iterates the TabbedPanel's tabs and matches on the title "Metadata".

**Additional cleanup**: Removed `assumeFalse(isGitHubAction())` workarounds from `TabsTest.testSave()` and `ConditionTest.testNoFeatureCatalogueForRasters()` since the root cause is now fixed.

All 74 tests in the metadata module pass locally including spotbugs verification.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal). 