### PR TITLE
[GEOS-12127] Fix flaky GWCIntegrationTest cache assertion

### DIFF
--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -640,6 +640,10 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
 
         final TileLayer tileLayer = gwc.getTileLayerByName(qualifiedName);
         assertNotNull(tileLayer);
+
+        // Ensure clean cache state regardless of test execution order
+        gwc.truncate(qualifiedName);
+
         boolean directWMSIntegrationEndpoint = true;
         String request = TEST_WORKSPACE_NAME
                 + "/"


### PR DESCRIPTION
[![GEOS-12127](https://badgen.net/badge/JIRA/GEOS-12127/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12127) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

https://osgeo-org.atlassian.net/browse/GEOS-12127

`testDirectWMSIntegrationWithVirtualServicesAndWorkspacedStyle` fails intermittently because it asserts `MISS` on the first tile request, but the GWC in-memory blob store retains cached tiles across test methods within the same class. The `@Before` method wipes data directory files but does not reset the in-memory cache.

On CI this manifests as either:
- `expected:<[image/png]> but was:<[application/vnd.ogc.se_xml]>` (workspace state corruption from previous test)
- `Expected: "MISS" but was: "HIT"` (tiles cached by previous test method)

**Fix**: Call `gwc.truncate(qualifiedName)` before issuing requests to ensure the test always starts with a clean cache state, regardless of test execution order. The original MISS assertion is preserved.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal). 