### PR TITLE
[GEOS-12129]: WPSLongitudinalProfile, fixing altitudePositive handling

### DIFF
--- a/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcess.java
+++ b/src/community/wps-longitudinal-profile/src/main/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcess.java
@@ -289,6 +289,7 @@ public class LongitudinalProfileProcess implements GeoServerProcess, DisposableB
         double positiveAltitude = 0;
         double negativeAltitude = 0;
         double previousAltitude = 0;
+        boolean hasPreviousAltitude = false;
         double totalDistance = 0;
         for (ProfileVertice v : result) {
             // check for cancellation
@@ -297,14 +298,17 @@ public class LongitudinalProfileProcess implements GeoServerProcess, DisposableB
             if (v.getDistancePrevious() != ProfileVertice.UNSET) totalDistance += v.getDistancePrevious();
             ProfileInfo currentInfo =
                     new ProfileInfo(totalDistance, coordinate.getX(), coordinate.getY(), v.getAltitude(), v.getSlope());
-            double profileAltitude = v.getAltitude() - previousAltitude;
-            if (profileAltitude >= 0) {
-                positiveAltitude += profileAltitude;
-            } else {
-                negativeAltitude += profileAltitude;
+            if (hasPreviousAltitude) {
+                double profileAltitude = v.getAltitude() - previousAltitude;
+                if (profileAltitude >= 0) {
+                    positiveAltitude += profileAltitude;
+                } else {
+                    negativeAltitude += profileAltitude;
+                }
             }
 
             previousAltitude = v.getAltitude();
+            hasPreviousAltitude = true;
 
             profileInfos.add(currentInfo);
         }

--- a/src/community/wps-longitudinal-profile/src/test/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcessTest.java
+++ b/src/community/wps-longitudinal-profile/src/test/java/org/geoserver/wps/longitudinal/LongitudinalProfileProcessTest.java
@@ -11,11 +11,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -27,7 +30,11 @@ import org.geoserver.data.test.SystemTestData;
 import org.geoserver.wps.WPSTestSupport;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.data.util.DefaultProgressListener;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
 import org.junit.Test;
 import org.kordamp.json.JSONArray;
 import org.kordamp.json.JSONNull;
@@ -147,18 +154,18 @@ public class LongitudinalProfileProcessTest extends WPSTestSupport {
         checkBasicProfile(requestXml, null);
     }
 
-    private void checkBasicProfile(String requestXml, String expctedLayer) throws Exception {
+    private void checkBasicProfile(String requestXml, String expectedLayer) throws Exception {
         JSONObject response = (JSONObject) postAsJSON(root(), requestXml, "application/xml");
         JSONObject infos = response.getJSONObject("infos");
-        assertEquals(214.94, infos.get("altitudePositive"));
+        assertEquals(37.03, infos.get("altitudePositive"));
         assertEquals(-64.28, infos.get("altitudeNegative"));
         assertEquals(1746.0248, infos.get("totalDistance"));
         assertEquals(843478.25, infos.get("firstPointX"));
         assertEquals(6420349.0, infos.get("firstPointY"));
         assertEquals(844102.7, infos.get("lastPointX"));
         assertEquals(6420614.0, infos.get("lastPointY"));
-        if (expctedLayer != null) {
-            assertEquals(expctedLayer, infos.get("layer"));
+        if (expectedLayer != null) {
+            assertEquals(expectedLayer, infos.get("layer"));
         } else {
             assertEquals(JSONNull.getInstance(), infos.get("layer"));
         }
@@ -204,7 +211,7 @@ public class LongitudinalProfileProcessTest extends WPSTestSupport {
 
         JSONObject response = (JSONObject) postAsJSON(root(), requestXml, "application/xml");
         JSONObject infos = response.getJSONObject("infos");
-        assertEquals(214.94, infos.get("altitudePositive"));
+        assertEquals(37.03, infos.get("altitudePositive"));
         assertEquals(-64.28, infos.get("altitudeNegative"));
         assertEquals(2463.6123, infos.get("totalDistance"));
         assertEquals(536188.94, infos.get("firstPointX"));
@@ -290,7 +297,7 @@ public class LongitudinalProfileProcessTest extends WPSTestSupport {
 
         JSONObject response = (JSONObject) postAsJSON(root(), requestXml, "application/xml");
         JSONObject infos = response.getJSONObject("infos");
-        assertEquals(195.69, infos.get("altitudePositive"));
+        assertEquals(39.78, infos.get("altitudePositive"));
         assertEquals(-67.03, infos.get("altitudeNegative"));
         // check it's a meaningful distance in meters, not some random number in degrees
         assertEquals(1746.9653, infos.get("totalDistance"));
@@ -337,7 +344,7 @@ public class LongitudinalProfileProcessTest extends WPSTestSupport {
         JSONObject infos = response.getJSONObject("infos");
 
         // Dataset is ~ 4m in resolution. Diagonal resolution is ~5.65
-        assertEquals(258.0, infos.get("altitudePositive"));
+        assertEquals(80.09, infos.get("altitudePositive"));
         assertEquals(-107.34, infos.get("altitudeNegative"));
         assertEquals(1746.0248, infos.get("totalDistance"));
         assertEquals(843478.25, infos.get("firstPointX"));
@@ -382,7 +389,7 @@ public class LongitudinalProfileProcessTest extends WPSTestSupport {
         JSONObject response = (JSONObject) postAsJSON(root(), requestXml, "application/xml");
         JSONObject infos = response.getJSONObject("infos");
 
-        assertEquals(256.9, infos.get("altitudePositive"));
+        assertEquals(78.99, infos.get("altitudePositive"));
         assertEquals(-106.03, infos.get("altitudeNegative"));
         assertEquals(1746.9653, infos.get("totalDistance"));
         assertEquals(4.8166676, infos.get("firstPointX"));
@@ -414,6 +421,39 @@ public class LongitudinalProfileProcessTest extends WPSTestSupport {
         assertEquals(22.130537, profile7.get("slope"));
         assertEquals(4.8170360, profile7.get("x"));
         assertEquals(44.86718, profile7.get("y"));
+    }
+
+    @Test
+    public void testTwoPointProfileAltitudeIncrement() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:3857", true);
+        GridCoverage2D coverage = createTwoByTwoCoverage(crs);
+        Geometry geometry = new WKTReader().read("LINESTRING(0.5 1.5, 1.5 1.5)");
+        geometry.setUserData(crs);
+
+        LongitudinalProfileProcess process = new LongitudinalProfileProcess(getGeoServer());
+        LongitudinalProfileProcess.LongitudinalProfileProcessResult result =
+                process.execute(null, coverage, null, geometry, 10d, null, 0, null, null);
+
+        OperationInfo info = result.getOperationInfo();
+        assertEquals(25.0, info.getAltitudePositive(), 0);
+        assertEquals(0.0, info.getAltitudeNegative(), 0);
+
+        List<ProfileInfo> profile = result.getProfileInfoList();
+        assertEquals(2, profile.size());
+        assertEquals(200.0, profile.get(0).getAltitude(), 0);
+        assertEquals(225.0, profile.get(1).getAltitude(), 0);
+    }
+
+    private GridCoverage2D createTwoByTwoCoverage(CoordinateReferenceSystem crs) {
+        BufferedImage image = new BufferedImage(2, 2, BufferedImage.TYPE_BYTE_GRAY);
+        WritableRaster raster = image.getRaster();
+        raster.setSample(0, 0, 0, 200);
+        raster.setSample(1, 0, 0, 225);
+        raster.setSample(0, 1, 0, 230);
+        raster.setSample(1, 1, 0, 240);
+
+        ReferencedEnvelope envelope = new ReferencedEnvelope(0, 2, 0, 2, crs);
+        return new GridCoverageFactory().create("two-by-two", image, envelope);
     }
 
     @Test


### PR DESCRIPTION
[![GEOS-12129](https://badgen.net/badge/JIRA/GEOS-12129/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12129) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->
Fixing WPSLongitudinalProfile, using the previous point as first elevation for altitudePositive computation rather than starting from zero.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 