### PR TITLE
[GEOS-12127] Fix flaky VectorTileMetatilingTest cache assertion

### DIFF
--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMetatilingTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMetatilingTest.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.wms.vector;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -124,8 +127,28 @@ public class VectorTileMetatilingTest extends GeoServerSystemTestSupport {
         int z = 9, x = 510, y = 254;
         VectorTileDecoder decoder = new VectorTileDecoder();
 
+        // Issue the first request — this triggers the metatile render which seeds sibling tiles.
+        MockHttpServletResponse firstResp = getTile(z, x, y);
+        assertEquals(200, firstResp.getStatus());
+        byte[] firstData = firstResp.getContentAsByteArray();
+        assertCacheResult(firstResp, cacheResults[0][0]);
+        assertTrue(firstData.length > 0);
+        assertFeature(decoder, firstData, 0, 0);
+
+        // When metatiling is enabled, sibling tiles are stored asynchronously after the first
+        // request completes. Wait for the cache to be populated before asserting HIT on them.
+        if (cacheResults[0][1] == CacheResult.HIT) {
+            await().atMost(5, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {
+                MockHttpServletResponse probe = getTile(z, x + 1, y);
+                assertEquals(200, probe.getStatus());
+                assertCacheResult(probe, CacheResult.HIT);
+            });
+        }
+
+        // Now assert the remaining tiles
         for (int j = 0; j < 2; j++) {
             for (int i = 0; i < 2; i++) {
+                if (j == 0 && i == 0) continue; // already asserted above
                 MockHttpServletResponse resp = getTile(z, x + i, y + j);
                 assertEquals(200, resp.getStatus());
                 byte[] data = resp.getContentAsByteArray();


### PR DESCRIPTION
[![GEOS-12127](https://badgen.net/badge/JIRA/GEOS-12127/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12127) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

https://osgeo-org.atlassian.net/browse/GEOS-12127

`testMetatilingEnabled` fails intermittently because it asserts HIT on sibling tiles immediately after the first metatile request, but the cache write for sibling tiles completes asynchronously. On slow CI runners the write has not finished by the time the next request arrives, producing MISS instead of the expected HIT.

**Fix**: Use Awaitility to poll for the expected HIT on the first sibling tile before asserting the remaining tiles. This tolerates the async nature of metatile cache population (up to 5 seconds) without watering down the assertions. The non-metatiling path (`testMetatilingDisabled`) is unaffected — it expects all MISS and does not wait.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a Contribution Licence Agreement (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the main branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] Documentation has been updated (if change is visible to end users).
- [ ] The REST API docs have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the GeoServer Jira (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form `[GEOS-XYZWV] Title of the Jira ticket`.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal). 