### PR TITLE
[GEOS-12127] Add diagnostics to flaky PipeliningTaskQueueTest

### DIFF
--- a/src/extension/monitor/core/src/test/java/org/geoserver/monitor/PipeliningTaskQueueTest.java
+++ b/src/extension/monitor/core/src/test/java/org/geoserver/monitor/PipeliningTaskQueueTest.java
@@ -7,15 +7,17 @@ package org.geoserver.monitor;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.geotools.util.logging.Logging;
 import org.junit.After;
 import org.junit.Before;
@@ -49,17 +51,87 @@ public class PipeliningTaskQueueTest {
             workers.add(list);
         }
 
+        long submitStart = System.currentTimeMillis();
         for (int i = 0; i < groups; i++) {
             for (int j = 0; j < groups; j++) {
                 Worker w = workers.get(j).get(i);
                 taskQueue.execute(w.group, w);
             }
         }
+        long submitEnd = System.currentTimeMillis();
 
-        await().atMost(60, SECONDS).until(() -> completed.size() >= groups * groups);
+        int totalTasks = groups * groups;
+        try {
+            await().atMost(60, SECONDS).until(() -> completed.size() >= totalTasks);
+        } catch (Exception e) {
+            // Capture diagnostic state on timeout
+            long elapsed = System.currentTimeMillis() - submitEnd;
+            StringBuilder diag = new StringBuilder();
+            diag.append("\n=== PipeliningTaskQueueTest TIMEOUT DIAGNOSTICS ===\n");
+            diag.append("Completed: ").append(completed.size()).append("/").append(totalTasks);
+            diag.append(" after ").append(elapsed).append("ms\n");
+            diag.append("Submit took: ").append(submitEnd - submitStart).append("ms\n");
+            diag.append("Completed workers (group.seq @ startMs/endMs):\n");
+            for (Worker w : completed) {
+                diag.append("  group=")
+                        .append(w.group)
+                        .append(" seq=")
+                        .append(w.seq)
+                        .append(" started=")
+                        .append(w.startTimeMs.get())
+                        .append("ms ended=")
+                        .append(w.endTimeMs.get())
+                        .append("ms slept=")
+                        .append(w.actualSleepMs.get())
+                        .append("ms\n");
+            }
+            // Report which tasks never completed
+            diag.append("Missing workers:\n");
+            for (int g = 0; g < groups; g++) {
+                for (int s = 0; s < groups; s++) {
+                    Worker w = workers.get(g).get(s);
+                    if (w.endTimeMs.get() == 0) {
+                        diag.append("  group=")
+                                .append(w.group)
+                                .append(" seq=")
+                                .append(w.seq)
+                                .append(" started=")
+                                .append(w.startTimeMs.get())
+                                .append("ms\n");
+                    }
+                }
+            }
+            fail(diag.toString() + "\nOriginal exception: " + e.getMessage());
+        }
+
+        // Verify ordering within each group
+        long completionTime = System.currentTimeMillis() - submitEnd;
         int[] status = new int[groups];
-        for (Worker w : completed) {
-            assertEquals(status[w.group], w.seq.intValue());
+        List<Worker> completedList = new ArrayList<>(completed);
+        for (int idx = 0; idx < completedList.size(); idx++) {
+            Worker w = completedList.get(idx);
+            if (status[w.group] != w.seq.intValue()) {
+                // Build diagnostic showing the full completion order for this group
+                String groupOrder = completedList.stream()
+                        .filter(x -> x.group.equals(w.group))
+                        .map(x -> "seq=" + x.seq + "@" + x.endTimeMs.get() + "ms")
+                        .collect(Collectors.joining(", "));
+                fail("Ordering violation at position "
+                        + idx
+                        + ": group="
+                        + w.group
+                        + " expected seq="
+                        + status[w.group]
+                        + " but got seq="
+                        + w.seq
+                        + ". Total completion time: "
+                        + completionTime
+                        + "ms. Group "
+                        + w.group
+                        + " completion order: ["
+                        + groupOrder
+                        + "]");
+            }
             status[w.group]++;
         }
     }
@@ -69,6 +141,9 @@ public class PipeliningTaskQueueTest {
         Integer group;
         Integer seq;
         Queue<Worker> completed;
+        AtomicLong startTimeMs = new AtomicLong();
+        AtomicLong endTimeMs = new AtomicLong();
+        AtomicLong actualSleepMs = new AtomicLong();
 
         public Worker(Integer group, Integer seq, Queue<Worker> completed) {
             this.group = group;
@@ -78,15 +153,19 @@ public class PipeliningTaskQueueTest {
 
         @Override
         public void run() {
+            startTimeMs.set(System.currentTimeMillis());
             Random r = new Random();
             int x = r.nextInt(10) + 1;
             try {
+                long before = System.currentTimeMillis();
                 Thread.sleep(x * 10);
+                actualSleepMs.set(System.currentTimeMillis() - before);
             } catch (InterruptedException e) {
                 LOGGER.log(Level.WARNING, "", e);
             }
 
             completed.add(this);
+            endTimeMs.set(System.currentTimeMillis());
         }
     }
 }


### PR DESCRIPTION
[![GEOS-12127](https://badgen.net/badge/JIRA/GEOS-12127/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12127) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

https://osgeo-org.atlassian.net/browse/GEOS-12127

`PipeliningTaskQueueTest` fails intermittently (~once per 2 months on CI) but we have no logs from previous failures — GitHub Actions retains logs for only 90 days. Without knowing whether the failure is a `ConditionTimeoutException` (Awaitility 60s timeout) or an `AssertionError` (ordering violation), we cannot determine the root cause or apply a targeted fix.

**What this change does**: Instruments the test to capture diagnostic state on failure, without changing the test logic:

- **On timeout**: reports which tasks completed, which never started vs started but never finished, actual sleep durations, and elapsed time. This will distinguish scheduler thread starvation (likely given observed GitHub Actions runner starvation) from a deadlock/livelock in `PipeliningTaskQueue`.

- **On ordering violation**: reports the full completion order for the affected group with timestamps, enabling root-cause analysis of the pipeline's ordering guarantee.

The original test logic (Random sleep, 60s timeout, ordering assertion) is preserved unchanged — only the failure reporting is enhanced.

**Context**: Andrea Aime has already increased the timeout twice (20s → 60s in [49390d678d8](https://github.com/geoserver/geoserver/commit/49390d678d8)). A further increase to 600s was tested locally but never merged. The current hypothesis is runner starvation causing the `ScheduledExecutorService` (which polls every 10ms) to not fire for extended periods, but this needs confirmation from actual failure diagnostics.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a Contribution Licence Agreement (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the main branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] Documentation has been updated (if change is visible to end users).
- [ ] The REST API docs have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the GeoServer Jira (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form `[GEOS-XYZWV] Title of the Jira ticket`.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal). 