### PR TITLE
Throw HttpErrorCodeException for unsupported tile format

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -116,6 +116,7 @@ import org.geowebcache.locks.LockProvider.Lock;
 import org.geowebcache.mime.FormatModifier;
 import org.geowebcache.mime.MimeException;
 import org.geowebcache.mime.MimeType;
+import org.geowebcache.service.HttpErrorCodeException;
 import org.geowebcache.storage.StorageBroker;
 import org.geowebcache.storage.TileObject;
 import org.geowebcache.util.GWCVars;
@@ -538,7 +539,7 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer, TileJSO
             mime = formats.get(0);
         } else {
             if (!formats.contains(mime)) {
-                throw new IllegalArgumentException(mime.getFormat() + " is not a supported format for " + getName());
+                throw new HttpErrorCodeException(400, mime.getFormat() + " is not a supported format for " + getName());
             }
         }
 

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -134,6 +134,7 @@ import org.geowebcache.locks.MemoryLockProvider;
 import org.geowebcache.mime.ApplicationMime;
 import org.geowebcache.mime.FormatModifier;
 import org.geowebcache.mime.MimeType;
+import org.geowebcache.service.HttpErrorCodeException;
 import org.geowebcache.storage.StorageBroker;
 import org.junit.After;
 import org.junit.Before;
@@ -819,7 +820,8 @@ public class GeoServerTileLayerTest {
         try {
             layerInfoTileLayer.getTile(tile);
             fail("Expected exception, requested mime is invalid for the layer");
-        } catch (IllegalArgumentException e) {
+        } catch (HttpErrorCodeException e) {
+            assertEquals(400, e.getErrorCode());
             assertTrue(e.getMessage().contains("is not a supported format"));
         }
 


### PR DESCRIPTION
When a client requests a tile in a format not supported by the layer (e.g. `image/gif` for a layer that only caches `image/png`), the code previously threw `IllegalArgumentException`. This was caught by the generic exception handler in `GeoWebCacheDispatcher` which logged at SEVERE with a full stack trace — excessive noise for a routine client error.

**Fix**: Change the single `throw` in `GeoServerTileLayer.getTile()` from `IllegalArgumentException` to `HttpErrorCodeException(400, message)`. The dispatcher already handles `HttpErrorCodeException` cleanly: returns 400 with the error message to the client, no stack trace logged.

This is a targeted fix at the source — only the specific "unsupported format" validation is changed. All other `IllegalArgumentException` throws elsewhere remain untouched.

**Tested**: Docker deployment confirms:
- WMTS path: client gets `400 text/plain` with message `image/gif is not a supported format for sf:archsites`, no server log entry
- WMS `tiled=true` path: format mismatch detected before `getTile()` is called, graceful fallback to standard WMS renderer

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).