### PR TITLE
Remove duplicate dependency and plugin declarations from POMs

### DIFF
--- a/src/community/features-templating/features-templating-ogcapi/pom.xml
+++ b/src/community/features-templating/features-templating-ogcapi/pom.xml
@@ -94,17 +94,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-app-schema</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-app-schema</artifactId>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.community</groupId>
       <artifactId>gs-features-templating-core</artifactId>
       <version>${project.version}</version>

--- a/src/community/jms-cluster/jms-geoserver/pom.xml
+++ b/src/community/jms-cluster/jms-geoserver/pom.xml
@@ -228,11 +228,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
       <classifier>tests</classifier>

--- a/src/community/ncwms/pom.xml
+++ b/src/community/ncwms/pom.xml
@@ -107,11 +107,5 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.geoserver</groupId>
-      <artifactId>gs-wfs-core</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/src/extension/app-schema/app-schema-test/pom.xml
+++ b/src/extension/app-schema/app-schema-test/pom.xml
@@ -48,12 +48,6 @@
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
-      <artifactId>gs-main</artifactId>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs-core</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>

--- a/src/extension/dxf/core/pom.xml
+++ b/src/extension/dxf/core/pom.xml
@@ -36,12 +36,6 @@
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.geoserver</groupId>
-      <artifactId>gs-wfs1_x</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/extension/dxf/wps/pom.xml
+++ b/src/extension/dxf/wps/pom.xml
@@ -37,12 +37,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.geoserver</groupId>
-      <artifactId>gs-wfs1_x</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-wps-core</artifactId>
       <version>${project.version}</version>

--- a/src/release/pom.xml
+++ b/src/release/pom.xml
@@ -149,7 +149,7 @@
         <executions>
           <execution>
             <id>extract-slf4j-version-from-jarname</id>
-            <phase>validate</phase>
+            <phase>test</phase>
             <goals>
               <goal>run</goal>
             </goals>
@@ -187,6 +187,21 @@
                 </pathconvert>
 
                 <echo>Using SLF4J version: ${slf4j.version}</echo>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>remove-dependencies</id>
+            <phase>install</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <!-- remove some unwanted dependencies that get pulled over -->
+              <target>
+                <delete>
+                  <fileset dir="${project.build.directory}/dependency" includes="servlet-api-*.jar,core*.jar"></fileset>
+                </delete>
               </target>
             </configuration>
           </execution>
@@ -252,69 +267,6 @@
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>remove-dependencies</id>
-            <phase>install</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <!-- remove some unwanted dependencies that get pulled over -->
-              <target>
-                <delete>
-                  <fileset dir="${project.build.directory}/dependency" includes="servlet-api-*.jar,core*.jar"></fileset>
-                </delete>
-              </target>
-            </configuration>
-          </execution>
-          <execution>
-            <id>extract-slf4j-version-from-jarname</id>
-            <phase>test</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <exportAntProperties>true</exportAntProperties>
-              <target name="extract-slf4j-version">
-
-                <!-- Find all slf4j-api-*.jar in target/dependency -->
-                <pathconvert pathsep="," property="slf4j.matches">
-                  <fileset dir="${project.build.directory}/dependency">
-                    <include name="slf4j-api-*.jar"></include>
-                  </fileset>
-                </pathconvert>
-
-                <!-- Fail fast if none found -->
-                <fail message="No slf4j-api-*.jar found under ${project.build.directory}/dependency">
-                  <condition>
-                    <equals arg1="${slf4j.matches}" arg2=""></equals>
-                  </condition>
-                </fail>
-
-                <!-- Fail if multiple (avoid ambiguity) -->
-                <fail message="Multiple slf4j-api jars found: ${slf4j.matches}. Keep only one.">
-                  <condition>
-                    <contains string="${slf4j.matches}" substring=","></contains>
-                  </condition>
-                </fail>
-
-                <!-- Extract the version from the single match -->
-                <pathconvert property="slf4j.version">
-                  <path>
-                    <pathelement location="${slf4j.matches}"></pathelement>
-                  </path>
-                  <mapper from="^.*[/\\]slf4j-api-(.*)\.jar$" to="\1" type="regexp"></mapper>
-                </pathconvert>
-
-                <echo>Using SLF4J version: ${slf4j.version}</echo>
-              </target>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Maven warns about duplicate dependency/plugin declarations on every build. This removes 9 duplicates across 8 POM files. No functional change - Maven was already deduplicating these silently. This eliminates the warnings and prepares for future Maven versions that will reject malformed POMs.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html).
- [x] First PR targets the main branch.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective.