### PR TITLE
[GEOS-12127] Fix flaky TemplatePageTest by ensuring config is loaded

### DIFF
--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractWicketMetadataTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractWicketMetadataTest.java
@@ -8,6 +8,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.extensions.markup.html.tabs.ITab;
 import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.apache.wicket.util.tester.WicketTester;
+import org.geoserver.metadata.data.service.impl.ConfigurationServiceImpl;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.wicket.WicketHierarchyPrinter;
 import org.junit.After;
@@ -19,6 +20,9 @@ public abstract class AbstractWicketMetadataTest extends AbstractMetadataTest {
 
     @Autowired
     protected GeoServerApplication app;
+
+    @Autowired
+    private ConfigurationServiceImpl configService;
 
     protected WicketTester tester;
 
@@ -38,6 +42,13 @@ public abstract class AbstractWicketMetadataTest extends AbstractMetadataTest {
 
     @Before
     public void start() throws Exception {
+        // Defensive: ensure metadata configuration is loaded before creating the WicketTester.
+        // While JUnit 4 guarantees parent @Before (setupAndLoadDataDirectory) runs first,
+        // the config can still be null if readConfiguration() failed silently (YAML files
+        // not yet copied to the data directory, or parse errors logged at FINE level).
+        if (configService.getMetadataConfiguration() == null) {
+            configService.reload();
+        }
         tester = new WicketTester(app, true);
     }
 


### PR DESCRIPTION
[![GEOS-12127](https://badgen.net/badge/JIRA/GEOS-12127/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12127) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

https://osgeo-org.atlassian.net/browse/GEOS-12127

`TemplatePageTest.testPageNewSave` intermittently fails with:
```
NullPointerException: Cannot invoke "AttributeCollection.getAttributes()" because "attCollection" is null
    at ComplexMetadataServiceImpl.copy(ComplexMetadataServiceImpl.java:260)
    at MetadataTemplatePage.onInitialize(MetadataTemplatePage.java:100)
```

The page's `onInitialize()` calls `service.clean()` which requires the metadata configuration to be loaded. The config can be null if `readConfiguration()` failed silently (YAML files not yet present in the data directory, or parse errors logged at FINE level).

**Fix**: Add a defensive config-reload guard in `AbstractWicketMetadataTest.start()` — the parent class of ALL metadata Wicket tests. If the configuration is null when the WicketTester is about to be created, it explicitly reloads. This benefits `TemplatePageTest`, `TabsTest`, and all other metadata Wicket tests.

All 74 metadata tests pass locally.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal). 