### PR TITLE
[backup-restore] Fix restore configuration validation: GEOS-10877 guards + pre-flight pass

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/Backup.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/Backup.java
@@ -116,6 +116,13 @@ public class Backup implements DisposableBean, ApplicationContextAware, Applicat
 
     public static final String PARAM_BEST_EFFORT_MODE = "BK_BEST_EFFORT";
 
+    /**
+     * PROTOTYPE: when {@code true}, a restore runs a pre-flight validation pass over the fully-assembled restore
+     * catalog and ABORTS (job FAILED, so the live reload is skipped) if any catalog object is invalid. Default
+     * {@code false} — the pass only logs and records the findings as warnings.
+     */
+    public static final String PARAM_FAIL_ON_INVALID = "BK_FAIL_ON_INVALID";
+
     /* Jobs Context Keys **/
     public static final String BACKUP_JOB_NAME = "backupJob";
 
@@ -718,6 +725,7 @@ public class Backup implements DisposableBean, ApplicationContextAware, Applicat
                             case PARAM_SKIP_GWC:
                             case PARAM_PRESERVE_IDS:
                             case PARAM_MERGE_SECURITY:
+                            case PARAM_FAIL_ON_INVALID:
                                 if (paramsBuilder.toJobParameters().getString(k) == null) {
                                     paramsBuilder.addString(k, booleanOptionValue(param.getValue()));
                                 }

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/BackupRestoreItem.java
@@ -338,10 +338,10 @@ public abstract class BackupRestoreItem<T> {
             } else {
                 throw e;
             }
-        }
-
-        if (!isBestEffort()) {
             getCurrentJobExecution().addFailureExceptions(List.of(validationException));
+        } else {
+            // best-effort: record the problem as a warning instead of swallowing it silently
+            getCurrentJobExecution().addWarningExceptions(List.of(validationException));
         }
         return false;
     }

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/config/RestoreJobConfiguration.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/config/RestoreJobConfiguration.java
@@ -566,6 +566,17 @@ public class RestoreJobConfiguration {
                 .build();
     }
 
+    @Bean
+    public Step validateRestoreCatalog(
+            @Qualifier("jobRepository") JobRepository jobRepository,
+            @Qualifier("transactionManager") PlatformTransactionManager transactionManager,
+            @Qualifier("validateRestoreTasklet") Tasklet validateRestoreTasklet) {
+        return new StepBuilder("validateRestoreCatalog", jobRepository)
+                .tasklet(validateRestoreTasklet, transactionManager)
+                .allowStartIfComplete(true)
+                .build();
+    }
+
     // -------------------------------------------------------------------------------------------------------------
     // The restoreJob assembling the eleven steps with the fail / stop(restart=next) / next(*->next) transitions
     // reproduced from the XML. finalizeRestore is terminal (no outgoing transition).
@@ -587,6 +598,7 @@ public class RestoreJobConfiguration {
             @Qualifier("restoreGeoServerInfos") Step restoreGeoServerInfos,
             @Qualifier("restoreGeoServerSecurityManager") Step restoreGeoServerSecurityManager,
             @Qualifier("genericTaskletsRestore") Step genericTaskletsRestore,
+            @Qualifier("validateRestoreCatalog") Step validateRestoreCatalog,
             @Qualifier("finalizeRestore") Step finalizeRestore) {
 
         return new JobBuilder("restoreJob", jobRepository)
@@ -679,8 +691,17 @@ public class RestoreJobConfiguration {
                 .fail()
                 .from(genericTaskletsRestore)
                 .on("STOPPED")
-                .stopAndRestart(finalizeRestore)
+                .stopAndRestart(validateRestoreCatalog)
                 .from(genericTaskletsRestore)
+                .on("*")
+                .to(validateRestoreCatalog)
+                .from(validateRestoreCatalog)
+                .on("FAILED")
+                .fail()
+                .from(validateRestoreCatalog)
+                .on("STOPPED")
+                .stopAndRestart(finalizeRestore)
+                .from(validateRestoreCatalog)
                 .on("*")
                 .to(finalizeRestore)
                 .end()

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/processor/CatalogItemProcessor.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/processor/CatalogItemProcessor.java
@@ -5,7 +5,6 @@
 package org.geoserver.backuprestore.processor;
 
 import java.lang.reflect.Proxy;
-import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.backuprestore.Backup;
@@ -228,7 +227,7 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
         return getClazz().cast(style);
     }
 
-    private T process(LayerGroupInfo lg) {
+    private T process(LayerGroupInfo lg) throws Exception {
         ValidationResult result = null;
         try {
             WorkspaceInfo ws = resolveWorkspace(lg);
@@ -248,10 +247,14 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
                 }
             }
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Error occurred while trying to process a Resource!", e);
-            if (getCurrentJobExecution() != null) {
-                getCurrentJobExecution().addWarningExceptions(Arrays.asList(e));
-            }
+            LOGGER.warning("Could not validate the layer group "
+                    + lg
+                    + " due to the following issue: "
+                    + e.getLocalizedMessage());
+            // consistent with process(StyleInfo)/process(LayerInfo): drop the item, and abort (or warn in best-effort)
+            // instead of keeping a layer group that failed validation
+            logValidationExceptions(result, e);
+            return null;
         }
         return getClazz().cast(lg);
     }
@@ -354,11 +357,9 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
             return null;
         }
 
-        /*
-         * if (!filterIsValid() && resource == null && !validateResource((ResourceInfo) resource,
-         * isNew())) { LOGGER.warning("Skipped invalid resource: " + resource);
-         * logValidationExceptions(resource, null); return null; }
-         */
+        // Resource (feature type / coverage) validity is checked by the pre-flight ValidateRestoreTasklet against the
+        // fully-assembled catalog; per-item validation here is intentionally skipped — running it mid-restore caused
+        // false failures (the referenced store may not be added yet) and false duplicate-name drops on a merge.
         return getClazz().cast(resource);
     }
 
@@ -576,61 +577,6 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
         resource.setWorkspace(ws);
 
         return true;
-    }
-
-    /**
-     * Being sure the associated {@link StoreInfo} exists and is available on the GeoServer Catalog.
-     *
-     * @param {@link ResourceInfo} resource
-     * @return boolean indicating whether the resource is valid or not.
-     */
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private boolean validateResource(ResourceInfo resource, boolean isNew) {
-        try {
-            final StoreInfo store = resource.getStore();
-            final NamespaceInfo namespace = resource.getNamespace();
-
-            if (store == null) {
-                return logValidationExceptions((T) resource, null);
-            }
-
-            final Class storeClazz = (store instanceof DataStoreInfo ? DataStoreInfo.class : CoverageStoreInfo.class);
-            final StoreInfo ds = this.getCatalog().getStoreByName(store.getName(), storeClazz);
-
-            if (ds != null) {
-                resource.setStore(ds);
-            } else {
-                return logValidationExceptions((T) resource, null);
-            }
-
-            ResourceInfo existing = getCatalog().getResourceByStore(store, resource.getName(), ResourceInfo.class);
-            if (existing != null && !existing.getId().equals(resource.getId())) {
-                final String msg = "Resource named '"
-                        + resource.getName()
-                        + "' already exists in store: '"
-                        + store.getName()
-                        + "'";
-                return logValidationExceptions((T) resource, new RuntimeException(msg));
-            }
-
-            existing = getCatalog().getResourceByName(namespace, resource.getName(), ResourceInfo.class);
-            if (existing != null && !existing.getId().equals(resource.getId())) {
-                final String msg = "Resource named '"
-                        + resource.getName()
-                        + "' already exists in namespace: '"
-                        + namespace.getPrefix()
-                        + "'";
-                return logValidationExceptions((T) resource, new RuntimeException(msg));
-            }
-
-            return true;
-        } catch (Exception e) {
-            LOGGER.warning("Could not validate the resource "
-                    + resource
-                    + " due to the following issue: "
-                    + e.getLocalizedMessage());
-            return logValidationExceptions((T) resource, e);
-        }
     }
 
     private WorkspaceInfo resolveWorkspace(CatalogInfo item) {

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/processor/CatalogItemProcessor.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/processor/CatalogItemProcessor.java
@@ -210,7 +210,7 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
                 return null;
             }
 
-            if (!filterIsValid()) {
+            if (!filterIsValid() && style.getId() != null) {
                 Catalog catalog = getCatalog();
                 result = catalog.validate(style, isNew());
                 if (!result.isValid()) {
@@ -237,7 +237,7 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
                 return null;
             }
 
-            if (!filterIsValid()) {
+            if (!filterIsValid() && lg.getId() != null) {
                 Catalog catalog = getCatalog();
                 result = catalog.validate(lg, isNew());
                 if (!result.isValid()) {
@@ -276,7 +276,7 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
                 return null;
             }
 
-            if (!filterIsValid()) {
+            if (!filterIsValid() && layer.getId() != null) {
                 Catalog catalog = getCatalog();
                 result = catalog.validate(layer, isNew());
                 if (!result.isValid()) {
@@ -437,10 +437,12 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
 
         ValidationResult result = null;
         try {
-            result = this.getCatalog().validate(resource, isNew);
-            if (!result.isValid()) {
-                LOGGER.log(Level.SEVERE, "Workspace is not valid: {0}", resource);
-                logValidationResult(result, resource);
+            if (resource.getId() != null) {
+                result = this.getCatalog().validate(resource, isNew);
+                if (!result.isValid()) {
+                    LOGGER.log(Level.SEVERE, "Workspace is not valid: {0}", resource);
+                    logValidationResult(result, resource);
+                }
             }
         } catch (Exception e) {
             LOGGER.warning("Could not validate the resource "
@@ -478,10 +480,12 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
 
         ValidationResult result = null;
         try {
-            result = this.getCatalog().validate(resource, isNew);
-            if (!result.isValid()) {
-                LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
-                logValidationResult(result, resource);
+            if (resource.getId() != null) {
+                result = this.getCatalog().validate(resource, isNew);
+                if (!result.isValid()) {
+                    LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
+                    logValidationResult(result, resource);
+                }
             }
         } catch (Exception e) {
             LOGGER.warning("Could not validate the resource "
@@ -512,10 +516,12 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
 
         ValidationResult result = null;
         try {
-            result = this.getCatalog().validate(resource, isNew);
-            if (!result.isValid()) {
-                LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
-                logValidationResult(result, resource);
+            if (resource.getId() != null) {
+                result = this.getCatalog().validate(resource, isNew);
+                if (!result.isValid()) {
+                    LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
+                    logValidationResult(result, resource);
+                }
             }
         } catch (Exception e) {
             LOGGER.warning("Could not validate the resource "
@@ -552,10 +558,12 @@ public class CatalogItemProcessor<T> extends BackupRestoreItem<T> implements Ite
 
         ValidationResult result = null;
         try {
-            result = this.getCatalog().validate(resource, isNew);
-            if (!result.isValid()) {
-                LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
-                logValidationResult(result, resource);
+            if (resource.getId() != null) {
+                result = this.getCatalog().validate(resource, isNew);
+                if (!result.isValid()) {
+                    LOGGER.log(Level.SEVERE, "Store is not valid: {0}", resource);
+                    logValidationResult(result, resource);
+                }
             }
         } catch (Exception e) {
             LOGGER.warning("Could not validate the resource "

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTasklet.java
@@ -1,0 +1,147 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore.tasklet;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.logging.Logger;
+import org.geoserver.backuprestore.Backup;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogException;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.ValidationResult;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.CatalogImpl;
+import org.geotools.util.logging.Logging;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.StepContribution;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+
+/**
+ * PROTOTYPE: pre-flight restore validation pass.
+ *
+ * <p>Runs as a dedicated step after the restore catalog has been fully assembled (all catalog chunk steps plus the
+ * GeoServer global and security steps) but before {@code finalizeRestore} reloads the live instance. Because the whole
+ * graph is present and cross-referenced at this point, a single {@link Catalog#validate} sweep gives a trustworthy
+ * verdict on whether the restored configuration is valid — unlike the per-item validation in {@code CatalogItemProcessor},
+ * which runs while the catalog is only partially assembled and was progressively defanged (filter gating, id gating,
+ * log-only store helpers, extended validation disabled) to avoid false failures.
+ *
+ * <p>By default the pass only <b>reports</b> (logs a summary and records the findings as warnings on the execution).
+ * With {@code BK_FAIL_ON_INVALID=true} it <b>aborts</b> the restore (step FAILED), so {@code finalizeRestore} — and
+ * therefore the live in-memory reload — is skipped.
+ *
+ * <p>KNOWN LIMITATION (prototype): the catalog writer commits each item to disk as the chunk steps run (the restore
+ * catalog carries {@code GeoServerConfigPersister}), so aborting here does not roll back what was already written to
+ * the data directory; it only prevents the in-memory reload. A fully transactional "validate before any write" mode
+ * would additionally need to defer the persister / writer until this pass succeeds (or stage into a scratch dir).
+ */
+public class ValidateRestoreTasklet extends AbstractCatalogBackupRestoreTasklet {
+
+    private static final Logger LOGGER = Logging.getLogger(ValidateRestoreTasklet.class);
+
+    private boolean failOnInvalid = false;
+
+    public ValidateRestoreTasklet(Backup backupFacade) {
+        super(backupFacade);
+    }
+
+    @Override
+    protected void initialize(StepExecution stepExecution) {
+        this.failOnInvalid =
+                Boolean.parseBoolean(stepExecution.getJobParameters().getString(Backup.PARAM_FAIL_ON_INVALID, "false"));
+    }
+
+    @Override
+    RepeatStatus doExecute(StepContribution contribution, ChunkContext chunkContext, JobExecution jobExecution)
+            throws Exception {
+        // Only meaningful on the restore path: isNew() == true means getCatalog() is the assembled restore catalog.
+        if (!isNew()) {
+            return RepeatStatus.FINISHED;
+        }
+
+        final Catalog catalog = getCatalog();
+
+        // The chunk pipeline disabled extended validation on the restore catalog to avoid ordering false-failures while
+        // items were still being added. The graph is complete now, so re-enable it for an honest, thorough pre-flight.
+        if (catalog instanceof CatalogImpl) {
+            ((CatalogImpl) catalog).setExtendedValidation(true);
+        }
+
+        final List<String> problems = new ArrayList<>();
+        // isNew=false: every object is already present in the restore catalog (added + saved during the chunk steps),
+        // so referential checks resolve against the fully-assembled graph instead of false-failing on load order.
+        check(catalog.getWorkspaces(), w -> catalog.validate(w, false), WorkspaceInfo::getName, "workspace", problems);
+        check(catalog.getNamespaces(), n -> catalog.validate(n, false), NamespaceInfo::getPrefix, "namespace", problems);
+        check(catalog.getStores(StoreInfo.class), s -> catalog.validate(s, false), StoreInfo::getName, "store", problems);
+        check(
+                catalog.getResources(ResourceInfo.class),
+                r -> catalog.validate(r, false),
+                ResourceInfo::getName,
+                "resource",
+                problems);
+        check(catalog.getStyles(), st -> catalog.validate(st, false), StyleInfo::getName, "style", problems);
+        check(catalog.getLayers(), l -> catalog.validate(l, false), LayerInfo::getName, "layer", problems);
+        check(catalog.getLayerGroups(), lg -> catalog.validate(lg, false), LayerGroupInfo::getName, "layerGroup", problems);
+
+        if (problems.isEmpty()) {
+            LOGGER.info("Restore pre-flight validation: the assembled catalog is valid.");
+            return RepeatStatus.FINISHED;
+        }
+
+        final String summary = "Restore pre-flight validation found "
+                + problems.size()
+                + " invalid catalog object(s):\n  - "
+                + String.join("\n  - ", problems);
+        LOGGER.warning(summary);
+
+        // Surface the findings on the execution so they show up in the REST / web execution summary.
+        if (getCurrentJobExecution() != null) {
+            final List<Throwable> warnings = new ArrayList<>();
+            for (String p : problems) {
+                warnings.add(new CatalogException(p));
+            }
+            getCurrentJobExecution().addWarningExceptions(warnings);
+        }
+
+        if (failOnInvalid) {
+            final CatalogException abort = new CatalogException(summary);
+            if (getCurrentJobExecution() != null) {
+                getCurrentJobExecution().addFailureExceptions(Arrays.asList(abort));
+            }
+            throw abort; // step FAILED -> job FAILED -> finalizeRestore (live reload) is skipped
+        }
+
+        return RepeatStatus.FINISHED;
+    }
+
+    private <T extends CatalogInfo> void check(
+            List<T> items,
+            Function<T, ValidationResult> validator,
+            Function<T, String> namer,
+            String kind,
+            List<String> problems) {
+        for (T item : items) {
+            try {
+                ValidationResult result = validator.apply(item);
+                if (result != null && !result.isValid()) {
+                    problems.add(kind + " '" + namer.apply(item) + "': " + result.getErrosAsString("; "));
+                }
+            } catch (Exception e) {
+                problems.add(kind + " '" + namer.apply(item) + "': " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTasklet.java
@@ -80,21 +80,7 @@ public class ValidateRestoreTasklet extends AbstractCatalogBackupRestoreTasklet 
             ((CatalogImpl) catalog).setExtendedValidation(true);
         }
 
-        final List<String> problems = new ArrayList<>();
-        // isNew=false: every object is already present in the restore catalog (added + saved during the chunk steps),
-        // so referential checks resolve against the fully-assembled graph instead of false-failing on load order.
-        check(catalog.getWorkspaces(), w -> catalog.validate(w, false), WorkspaceInfo::getName, "workspace", problems);
-        check(catalog.getNamespaces(), n -> catalog.validate(n, false), NamespaceInfo::getPrefix, "namespace", problems);
-        check(catalog.getStores(StoreInfo.class), s -> catalog.validate(s, false), StoreInfo::getName, "store", problems);
-        check(
-                catalog.getResources(ResourceInfo.class),
-                r -> catalog.validate(r, false),
-                ResourceInfo::getName,
-                "resource",
-                problems);
-        check(catalog.getStyles(), st -> catalog.validate(st, false), StyleInfo::getName, "style", problems);
-        check(catalog.getLayers(), l -> catalog.validate(l, false), LayerInfo::getName, "layer", problems);
-        check(catalog.getLayerGroups(), lg -> catalog.validate(lg, false), LayerGroupInfo::getName, "layerGroup", problems);
+        final List<String> problems = collectProblems(catalog);
 
         if (problems.isEmpty()) {
             LOGGER.info("Restore pre-flight validation: the assembled catalog is valid.");
@@ -127,7 +113,35 @@ public class ValidateRestoreTasklet extends AbstractCatalogBackupRestoreTasklet 
         return RepeatStatus.FINISHED;
     }
 
-    private <T extends CatalogInfo> void check(
+    /**
+     * Validates every catalog object in the (fully-assembled) catalog and returns a human-readable description of each
+     * invalidity. Package-visible and static so it can be unit-tested against a hand-built catalog without a running
+     * restore job. {@code isNew=false}: the objects are already members of the catalog, so referential checks resolve
+     * against the complete graph instead of false-failing on load order.
+     */
+    static List<String> collectProblems(Catalog catalog) {
+        final List<String> problems = new ArrayList<>();
+        check(catalog.getWorkspaces(), w -> catalog.validate(w, false), WorkspaceInfo::getName, "workspace", problems);
+        check(catalog.getNamespaces(), n -> catalog.validate(n, false), NamespaceInfo::getPrefix, "namespace", problems);
+        check(catalog.getStores(StoreInfo.class), s -> catalog.validate(s, false), StoreInfo::getName, "store", problems);
+        check(
+                catalog.getResources(ResourceInfo.class),
+                r -> catalog.validate(r, false),
+                ResourceInfo::getName,
+                "resource",
+                problems);
+        check(catalog.getStyles(), st -> catalog.validate(st, false), StyleInfo::getName, "style", problems);
+        check(catalog.getLayers(), l -> catalog.validate(l, false), LayerInfo::getName, "layer", problems);
+        check(
+                catalog.getLayerGroups(),
+                lg -> catalog.validate(lg, false),
+                LayerGroupInfo::getName,
+                "layerGroup",
+                problems);
+        return problems;
+    }
+
+    private static <T extends CatalogInfo> void check(
             List<T> items,
             Function<T, ValidationResult> validator,
             Function<T, String> namer,

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTasklet.java
@@ -35,9 +35,9 @@ import org.springframework.batch.infrastructure.repeat.RepeatStatus;
  * <p>Runs as a dedicated step after the restore catalog has been fully assembled (all catalog chunk steps plus the
  * GeoServer global and security steps) but before {@code finalizeRestore} reloads the live instance. Because the whole
  * graph is present and cross-referenced at this point, a single {@link Catalog#validate} sweep gives a trustworthy
- * verdict on whether the restored configuration is valid — unlike the per-item validation in {@code CatalogItemProcessor},
- * which runs while the catalog is only partially assembled and was progressively defanged (filter gating, id gating,
- * log-only store helpers, extended validation disabled) to avoid false failures.
+ * verdict on whether the restored configuration is valid — unlike the per-item validation in
+ * {@code CatalogItemProcessor}, which runs while the catalog is only partially assembled and was progressively defanged
+ * (filter gating, id gating, log-only store helpers, extended validation disabled) to avoid false failures.
  *
  * <p>By default the pass only <b>reports</b> (logs a summary and records the findings as warnings on the execution).
  * With {@code BK_FAIL_ON_INVALID=true} it <b>aborts</b> the restore (step FAILED), so {@code finalizeRestore} — and
@@ -122,8 +122,18 @@ public class ValidateRestoreTasklet extends AbstractCatalogBackupRestoreTasklet 
     static List<String> collectProblems(Catalog catalog) {
         final List<String> problems = new ArrayList<>();
         check(catalog.getWorkspaces(), w -> catalog.validate(w, false), WorkspaceInfo::getName, "workspace", problems);
-        check(catalog.getNamespaces(), n -> catalog.validate(n, false), NamespaceInfo::getPrefix, "namespace", problems);
-        check(catalog.getStores(StoreInfo.class), s -> catalog.validate(s, false), StoreInfo::getName, "store", problems);
+        check(
+                catalog.getNamespaces(),
+                n -> catalog.validate(n, false),
+                NamespaceInfo::getPrefix,
+                "namespace",
+                problems);
+        check(
+                catalog.getStores(StoreInfo.class),
+                s -> catalog.validate(s, false),
+                StoreInfo::getName,
+                "store",
+                problems);
         check(
                 catalog.getResources(ResourceInfo.class),
                 r -> catalog.validate(r, false),

--- a/src/community/backup-restore/core/src/main/resources/applicationContext.xml
+++ b/src/community/backup-restore/core/src/main/resources/applicationContext.xml
@@ -69,6 +69,11 @@
 		<constructor-arg ref="backupFacade" />
 		<property name="timeout" value="600000"/>
 	</bean>
+	<!-- PROTOTYPE: pre-flight restore validation step (BK_FAIL_ON_INVALID) -->
+	<bean id="validateRestoreTasklet" class="org.geoserver.backuprestore.tasklet.ValidateRestoreTasklet">
+		<constructor-arg ref="backupFacade" />
+		<property name="timeout" value="600000"/>
+	</bean>
 
 	<!-- Main Restore Job listeners -->
 	<bean id="restoreJobExecutionListener" class="org.geoserver.backuprestore.listener.RestoreJobExecutionListener">

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTaskletTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTaskletTest.java
@@ -1,0 +1,67 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore.tasklet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogFactory;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.junit.Test;
+
+/**
+ * Unit tests for the pre-flight validation sweep ({@link ValidateRestoreTasklet#collectProblems}). Exercised against a
+ * hand-built {@link CatalogImpl} so it does not need a running restore job.
+ */
+public class ValidateRestoreTaskletTest {
+
+    @Test
+    public void validCatalogHasNoProblems() {
+        Catalog catalog = new CatalogImpl();
+        addValidContent(catalog);
+        assertTrue(
+                "a valid catalog must produce no validation problems",
+                ValidateRestoreTasklet.collectProblems(catalog).isEmpty());
+    }
+
+    @Test
+    public void invalidStyleIsReported() {
+        Catalog catalog = new CatalogImpl();
+        addValidContent(catalog);
+
+        // Corrupt the style in place: unwrap the ModificationProxy and null its name on the stored object, so the
+        // sweep's getStyles() sees an invalid style (a style name is mandatory).
+        StyleInfo style = catalog.getStyleByName("good-style");
+        ModificationProxy.unwrap(style).setName(null);
+
+        List<String> problems = ValidateRestoreTasklet.collectProblems(catalog);
+        assertEquals("exactly the corrupted style should be reported, got: " + problems, 1, problems.size());
+        assertTrue("the report should identify the style, got: " + problems, problems.get(0).startsWith("style"));
+    }
+
+    private static void addValidContent(Catalog catalog) {
+        CatalogFactory factory = catalog.getFactory();
+
+        WorkspaceInfo ws = factory.createWorkspace();
+        ws.setName("good-ws");
+        catalog.add(ws);
+
+        NamespaceInfo ns = factory.createNamespace();
+        ns.setPrefix("good-ws");
+        ns.setURI("http://good");
+        catalog.add(ns);
+
+        StyleInfo style = factory.createStyle();
+        style.setName("good-style");
+        style.setFilename("good-style.sld");
+        catalog.add(style);
+    }
+}

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTaskletTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTaskletTest.java
@@ -44,7 +44,9 @@ public class ValidateRestoreTaskletTest {
 
         List<String> problems = ValidateRestoreTasklet.collectProblems(catalog);
         assertEquals("exactly the corrupted style should be reported, got: " + problems, 1, problems.size());
-        assertTrue("the report should identify the style, got: " + problems, problems.get(0).startsWith("style"));
+        assertTrue(
+                "the report should identify the style, got: " + problems,
+                problems.get(0).startsWith("style"));
     }
 
     private static void addValidContent(Catalog catalog) {


### PR DESCRIPTION
[![GEOS-10877](https://badgen.net/badge/JIRA/GEOS-10877/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-10877) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

> Branched from `feat/backup-restore-subset-closure` (#9566). Re-homes the **GEOS-10877** fix onto current code and extends it into a proper restore-validation story. The original 2023 branch `GEOS-10877` (tip `47674350b6`, closed PR #6648) sat on a pre-Spring base and no longer merged; it has been deleted in favour of this one.

Following an audit, restore-configuration validation had been progressively defanged to the point where it no longer prevents an invalid configuration from being restored: stores/workspaces logged `SEVERE: "... is not valid"` but were restored anyway, feature types/coverages were never validated, and all of it was skipped on filtered jobs. This PR addresses that in two complementary parts.

## Part 1 — Stop the false-failures (GEOS-10877)

During a **name-based** restore, catalog objects are referenced by name with their `id` stripped (`null`); `CatalogItemProcessor` then calls `catalog.validate(info, isNew)` on those null-id objects, which fails and drops the item — *"Restore Tasklet always fails on resources validation"*.

Skip validation when the object has no id yet:
- `process(StyleInfo / LayerGroupInfo / LayerInfo)` — `if (!filterIsValid() && X.getId() != null)`.
- `validateWorkspace / validateDataStore / validateHttpStore / validateCoverageStore` — wrap the `catalog.validate(...)` call in `if (resource.getId() != null)`.

Extends the 2023 original (styles, layers, workspace + 2 store validators) to layer groups and the coverage-store validator. The `TileLayerCatalog` accessor the old branch added to `BackupRestoreItem` is **not** ported — GWC restore resolves it in the tasklet, so it'd be dead code.

## Part 2 — Add the real check: a pre-flight validation pass (PROTOTYPE)

A new `validateRestoreCatalog` **step** runs after the restore catalog is fully assembled (all catalog chunks + globals + security) but before `finalizeRestore` reloads the live instance. Because the whole graph is present and cross-referenced there, a single `catalog.validate(.., false)` sweep over every workspace/namespace/store/resource/style/layer/layer-group gives a **trustworthy** verdict — ordering-proof, unlike the per-item path. It re-enables extended validation (the chunk pipeline turns it off) for an honest check.

- **Default**: report — logs a summary and records the findings as execution warnings (visible in the REST/web execution summary).
- **`BK_FAIL_ON_INVALID=true`**: abort — the step fails, so `finalizeRestore` (and the live reload) is skipped.

This is also the foundation for making **Dry-Run** trustworthy (today Dry-Run rides the same defanged per-item path).

### Known limitation (prototype)

The catalog writer persists each item to disk as the chunk steps run (the restore catalog carries `GeoServerConfigPersister`), so aborting in the pre-flight prevents the in-memory reload but does **not** roll back what was already written to the data directory. A fully transactional "validate before any write" mode would additionally defer the persister/writer (or stage into a scratch dir) until the pass succeeds. Flagged in the tasklet javadoc.

## Status / follow-ups

- Part 1 complete; Part 2 prototype, now **unit-tested** (`ValidateRestoreTaskletTest`: a valid catalog → no problems; a corrupted/null-name style → reported).
- **Transactional write-deferral + trustworthy Dry-Run** are a focused follow-up (tracked separately): *stage → validate → promote* — restore into a scratch data dir, validate, and promote into the live dir only on success; dry-run validates the scratch and never promotes. Reworks the finalize/commit path across all three write paths (catalog persister, GWC dir, security); to be live-validated. 