### PR TITLE
[backup-restore] Transactional restore: snapshot + rollback for Dry-Run / fail-on-invalid

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
@@ -4,18 +4,25 @@
  */
 package org.geoserver.backuprestore.listener;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.io.FileUtils;
 import org.geoserver.backuprestore.Backup;
 import org.geoserver.backuprestore.RestoreExecutionAdapter;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.event.CatalogListener;
 import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resources;
+import org.geoserver.security.GeoServerSecurityManager;
 import org.geotools.util.decorate.Wrapper;
 import org.geotools.util.logging.Logging;
 import org.springframework.batch.core.BatchStatus;
@@ -28,15 +35,44 @@ import org.springframework.batch.core.listener.JobExecutionListener;
  *
  * <p>It's used to perform operations accordingly to the {@link Backup} batch {@link JobExecution} status.
  *
+ * <p><b>Transactional restore (snapshot / rollback).</b> A restore commits to the <em>live</em> data directory
+ * incrementally as the chunk and tasklet steps run: the catalog is persisted by the {@code GeoServerConfigPersister}
+ * carried on the restore catalog, GWC by {@code CatalogBackupRestoreTasklet} and security by
+ * {@code CatalogSecurityManagerTasklet}. Therefore the pre-flight
+ * {@link org.geoserver.backuprestore.tasklet.ValidateRestoreTasklet} abort and the Dry-Run mode, by themselves, only
+ * skip the final in-memory reload — they do not undo what was already written to disk. To make those two opt-in modes
+ * <em>trustworthy</em> (a Dry-Run must not mutate the data directory, and a {@code BK_FAIL_ON_INVALID} abort must leave
+ * it untouched) this listener snapshots the affected data-directory subtrees in {@link #beforeJob} and, in
+ * {@link #afterJob}, either rolls the live tree back from the snapshot (Dry-Run, or any non-COMPLETED outcome) or
+ * discards the snapshot (a real restore that completed). Both modes are off by default, so ordinary restores keep the
+ * historical incremental-commit behaviour and pay no snapshot cost.
+ *
  * @author Alessio Fabiani, GeoSolutions
  */
 public class RestoreJobExecutionListener implements JobExecutionListener {
 
     static Logger LOGGER = Logging.getLogger(RestoreJobExecutionListener.class);
 
+    /**
+     * Data-directory subtrees the restore writes into and that the snapshot/rollback covers. Catalog config lives under
+     * {@code workspaces} / {@code styles} / {@code layergroups}; GWC under {@code gwc} (the {@code gwc-gs.xml} provider
+     * dir) and {@code gwc-layers} (the per-layer tile-layer catalog); security under {@code security}.
+     */
+    private static final String[] SNAPSHOT_SUBTREES = {
+        "workspaces", "styles", "layergroups", "gwc", "gwc-layers", "security"
+    };
+
     private Backup backupFacade;
 
     private RestoreExecutionAdapter restoreExecution;
+
+    /**
+     * Location of the data-directory snapshot taken in {@link #beforeJob} for a transactional (Dry-Run or
+     * fail-on-invalid) restore, consumed in {@link #afterJob}. {@code null} when the running restore is not
+     * transactional. Restores are serialized (a single listener instance, one restore at a time), so a plain field is
+     * sufficient.
+     */
+    private File snapshotDir;
 
     public RestoreJobExecutionListener(Backup backupFacade) {
         this.backupFacade = backupFacade;
@@ -89,6 +125,25 @@ public class RestoreJobExecutionListener implements JobExecutionListener {
                 this.restoreExecution.getOptions().addAll(options);
 
                 this.backupFacade.getRestoreExecutions().put(jobExecution.getId(), this.restoreExecution);
+            }
+        }
+
+        // Transactional restore: snapshot the live data dir up-front so afterJob can roll it back on a Dry-Run or any
+        // non-COMPLETED outcome. Best-effort and strictly opt-in: a snapshot failure is logged and the restore proceeds
+        // as a normal (non-transactional) one rather than aborting.
+        this.snapshotDir = null;
+        if (isTransactionalRestore(jobExecution.getJobParameters())) {
+            try {
+                this.snapshotDir = snapshotDataDirectory();
+            } catch (Exception e) {
+                LOGGER.log(
+                        Level.SEVERE,
+                        "Transactional restore requested (Dry-Run or "
+                                + Backup.PARAM_FAIL_ON_INVALID
+                                + ") but the pre-restore data-directory snapshot failed; the restore will run WITHOUT"
+                                + " rollback protection.",
+                        e);
+                this.snapshotDir = null;
             }
         }
     }
@@ -145,6 +200,14 @@ public class RestoreJobExecutionListener implements JobExecutionListener {
 
             LOGGER.fine("Running Executions IDs : " + executionId);
 
+            // Transactional restore: decide whether to roll the live data dir back to its pre-restore snapshot or to
+            // discard the snapshot. This runs first (and independently of the STOPPED short-circuit below) so a
+            // Dry-Run or a failed/aborted restore never leaves the data directory mutated.
+            if (this.snapshotDir != null) {
+                boolean rollback = dryRun || jobExecution.getStatus() != BatchStatus.COMPLETED;
+                handleSnapshot(rollback);
+            }
+
             if (jobExecution.getStatus() != BatchStatus.STOPPED) {
                 LOGGER.fine("Executions Step Summaries : " + jobExecution.getStepExecutions());
                 LOGGER.fine("Executions Parameters : " + jobExecution.getJobParameters());
@@ -161,6 +224,149 @@ public class RestoreJobExecutionListener implements JobExecutionListener {
                 throw new RuntimeException(e);
             } else {
                 this.restoreExecution.addWarningExceptions(Arrays.asList(e));
+            }
+        }
+    }
+
+    /**
+     * A restore is "transactional" (snapshot + rollback) when it is a Dry-Run or when it opts into pre-flight
+     * fail-on-invalid. Both modes are off by default, so ordinary restores are untouched and pay no snapshot cost.
+     */
+    private boolean isTransactionalRestore(JobParameters params) {
+        boolean dryRun = Boolean.parseBoolean(params.getString(Backup.PARAM_DRY_RUN_MODE, "false"));
+        boolean failOnInvalid = Boolean.parseBoolean(params.getString(Backup.PARAM_FAIL_ON_INVALID, "false"));
+        return dryRun || failOnInvalid;
+    }
+
+    /**
+     * Snapshots the live data directory ({@link #backupFacade}'s base dir) and returns the snapshot location. Thin
+     * wrapper over the testable {@link #snapshotDataDirectory(File)}.
+     */
+    private File snapshotDataDirectory() throws IOException {
+        final File baseDir = backupFacade.getResourceLoader().getBaseDirectory();
+        final File snapshot = snapshotDataDirectory(baseDir);
+        LOGGER.info("Transactional restore: snapshotted the live data directory to " + snapshot.getAbsolutePath());
+        return snapshot;
+    }
+
+    /**
+     * Copies the data-directory subtrees and root configuration files a restore writes into ({@link #SNAPSHOT_SUBTREES}
+     * plus the root {@code *.xml} files such as {@code global.xml} / {@code logging.xml}) from {@code baseDir} into a
+     * fresh temp directory, returning its location. Missing subtrees are skipped (a restore may create them). Uses
+     * {@link java.nio.file.Files} and {@link FileUtils} as mandated. Package-visible and static so the snapshot
+     * mechanics can be unit-tested against a hand-built data directory without a running restore job.
+     */
+    static File snapshotDataDirectory(File baseDir) throws IOException {
+        final File snapshot = Files.createTempDirectory("gs-restore-snapshot-").toFile();
+
+        for (String subtree : SNAPSHOT_SUBTREES) {
+            File src = new File(baseDir, subtree);
+            if (src.isDirectory()) {
+                FileUtils.copyDirectory(src, new File(snapshot, subtree));
+            }
+        }
+        // Root global *.xml (global.xml, logging.xml, service descriptors, gwc-gs.xml, ...): they live directly in the
+        // data-dir root and are rewritten by the global / GWC restore steps.
+        File[] rootXml =
+                baseDir.listFiles((FileFilter) f -> f.isFile() && f.getName().endsWith(".xml"));
+        if (rootXml != null) {
+            for (File xml : rootXml) {
+                FileUtils.copyFile(xml, new File(snapshot, xml.getName()));
+            }
+        }
+        return snapshot;
+    }
+
+    /**
+     * Finalizes the transactional snapshot taken in {@link #beforeJob}: on {@code rollback}, restores every snapshotted
+     * subtree / root file over the live data directory and reloads GeoServer + the security subsystem; otherwise simply
+     * discards the snapshot. On a <em>successful</em> rollback (or discard) the snapshot directory is deleted; on a
+     * <em>failed</em> rollback the snapshot is intentionally KEPT (and a SEVERE is logged) so an operator can recover
+     * by hand. {@link #snapshotDir} is always cleared so the snapshot is finalized exactly once.
+     */
+    private void handleSnapshot(boolean rollback) {
+        final File snapshot = this.snapshotDir;
+        this.snapshotDir = null;
+        if (snapshot == null) {
+            return;
+        }
+        boolean keepSnapshot = false;
+        try {
+            if (rollback) {
+                rollbackDataDirectory(snapshot);
+            }
+        } catch (Exception e) {
+            keepSnapshot = true;
+            LOGGER.log(
+                    Level.SEVERE,
+                    "Transactional restore ROLLBACK FAILED. The live data directory may be in an inconsistent state."
+                            + " The pre-restore snapshot has been PRESERVED for manual recovery at: "
+                            + snapshot.getAbsolutePath(),
+                    e);
+        } finally {
+            if (!keepSnapshot) {
+                try {
+                    FileUtils.deleteDirectory(snapshot);
+                } catch (IOException e) {
+                    LOGGER.log(
+                            Level.WARNING,
+                            "Could not delete the transactional restore snapshot at " + snapshot.getAbsolutePath()
+                                    + "; it can be removed manually.",
+                            e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Rolls the live data directory back from {@code snapshot} on disk and then reloads the in-memory GeoServer
+     * configuration and the security manager so the rolled-back on-disk state is the one in effect. Throws on the first
+     * failure so {@link #handleSnapshot} preserves the snapshot.
+     */
+    private void rollbackDataDirectory(File snapshot) throws Exception {
+        final File baseDir = backupFacade.getResourceLoader().getBaseDirectory();
+
+        rollbackDataDirectory(baseDir, snapshot);
+
+        LOGGER.info("Transactional restore: rolled the live data directory back from snapshot "
+                + snapshot.getAbsolutePath() + "; reloading GeoServer and the security subsystem.");
+
+        // Re-read the rolled-back configuration into memory.
+        backupFacade.getGeoServer().reload();
+        GeoServerSecurityManager securityManager = GeoServerExtensions.bean(GeoServerSecurityManager.class);
+        if (securityManager != null) {
+            securityManager.reload();
+        }
+    }
+
+    /**
+     * Replaces each snapshotted subtree / root file over {@code baseDir} (delete-then-copy). A subtree present in the
+     * snapshot is restored verbatim; a subtree absent from the snapshot but present live (i.e. created by the restore)
+     * is removed. Package-visible and static so the on-disk rollback mechanics can be unit-tested without the live
+     * GeoServer / security singletons that the in-memory reload needs.
+     */
+    static void rollbackDataDirectory(File baseDir, File snapshot) throws IOException {
+        for (String subtree : SNAPSHOT_SUBTREES) {
+            File live = new File(baseDir, subtree);
+            File saved = new File(snapshot, subtree);
+            if (saved.isDirectory()) {
+                // restore the subtree exactly as it was
+                if (live.exists()) {
+                    FileUtils.deleteDirectory(live);
+                }
+                FileUtils.copyDirectory(saved, live);
+            } else if (live.isDirectory()) {
+                // the subtree did not exist before the restore (the restore created it): remove it
+                FileUtils.deleteDirectory(live);
+            }
+        }
+        // Root global *.xml: overwrite each saved file back over the live one. (We do not delete extra root xml files
+        // the restore may have introduced; the catalog/global reload re-reads the authoritative ones.)
+        File[] savedRootXml =
+                snapshot.listFiles((FileFilter) f -> f.isFile() && f.getName().endsWith(".xml"));
+        if (savedRootXml != null) {
+            for (File xml : savedRootXml) {
+                FileUtils.copyFile(xml, new File(baseDir, xml.getName()));
             }
         }
     }

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/listener/RestoreJobExecutionListener.java
@@ -340,10 +340,12 @@ public class RestoreJobExecutionListener implements JobExecutionListener {
     }
 
     /**
-     * Replaces each snapshotted subtree / root file over {@code baseDir} (delete-then-copy). A subtree present in the
-     * snapshot is restored verbatim; a subtree absent from the snapshot but present live (i.e. created by the restore)
-     * is removed. Package-visible and static so the on-disk rollback mechanics can be unit-tested without the live
-     * GeoServer / security singletons that the in-memory reload needs.
+     * Replaces each snapshotted subtree / root file over {@code baseDir} (delete-then-copy) so the tracked parts of the
+     * data directory are byte-identical to the snapshot. A subtree present in the snapshot is restored verbatim; a
+     * subtree absent from the snapshot but present live (i.e. created by the restore) is removed. Likewise a root
+     * {@code *.xml} present in the snapshot is overwritten back, and a root {@code *.xml} the restore introduced
+     * (absent from the snapshot) is deleted. Package-visible and static so the on-disk rollback mechanics can be
+     * unit-tested without the live GeoServer / security singletons that the in-memory reload needs.
      */
     static void rollbackDataDirectory(File baseDir, File snapshot) throws IOException {
         for (String subtree : SNAPSHOT_SUBTREES) {
@@ -360,13 +362,23 @@ public class RestoreJobExecutionListener implements JobExecutionListener {
                 FileUtils.deleteDirectory(live);
             }
         }
-        // Root global *.xml: overwrite each saved file back over the live one. (We do not delete extra root xml files
-        // the restore may have introduced; the catalog/global reload re-reads the authoritative ones.)
-        File[] savedRootXml =
-                snapshot.listFiles((FileFilter) f -> f.isFile() && f.getName().endsWith(".xml"));
+        // Root global *.xml: overwrite each saved file back over the live one, and remove any root *.xml the restore
+        // introduced that the snapshot did not have, so the data-dir root is byte-identical to the pre-restore state.
+        final FileFilter rootXmlFilter = f -> f.isFile() && f.getName().endsWith(".xml");
+        final java.util.Set<String> savedNames = new java.util.HashSet<>();
+        File[] savedRootXml = snapshot.listFiles(rootXmlFilter);
         if (savedRootXml != null) {
             for (File xml : savedRootXml) {
+                savedNames.add(xml.getName());
                 FileUtils.copyFile(xml, new File(baseDir, xml.getName()));
+            }
+        }
+        File[] liveRootXml = baseDir.listFiles(rootXmlFilter);
+        if (liveRootXml != null) {
+            for (File xml : liveRootXml) {
+                if (!savedNames.contains(xml.getName())) {
+                    FileUtils.deleteQuietly(xml);
+                }
             }
         }
     }

--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/ValidateRestoreTasklet.java
@@ -43,10 +43,12 @@ import org.springframework.batch.infrastructure.repeat.RepeatStatus;
  * With {@code BK_FAIL_ON_INVALID=true} it <b>aborts</b> the restore (step FAILED), so {@code finalizeRestore} — and
  * therefore the live in-memory reload — is skipped.
  *
- * <p>KNOWN LIMITATION (prototype): the catalog writer commits each item to disk as the chunk steps run (the restore
- * catalog carries {@code GeoServerConfigPersister}), so aborting here does not roll back what was already written to
- * the data directory; it only prevents the in-memory reload. A fully transactional "validate before any write" mode
- * would additionally need to defer the persister / writer until this pass succeeds (or stage into a scratch dir).
+ * <p>ON-DISK ROLLBACK: the catalog writer commits each item to disk as the chunk steps run (the restore catalog carries
+ * {@code GeoServerConfigPersister}), so aborting here does not, by itself, roll back what was already written to the
+ * data directory; it only prevents the in-memory reload. When this step is enabled (so is {@code BK_FAIL_ON_INVALID}) —
+ * or when the restore is a Dry-Run — {@link org.geoserver.backuprestore.listener.RestoreJobExecutionListener} snapshots
+ * the affected data-directory subtrees before the job and restores them from that snapshot in {@code afterJob} on any
+ * non-COMPLETED (or Dry-Run) outcome, which makes the abort here trustworthy on disk as well as in memory.
  */
 public class ValidateRestoreTasklet extends AbstractCatalogBackupRestoreTasklet {
 

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/TransactionalRestoreTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/TransactionalRestoreTest.java
@@ -1,0 +1,159 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import org.geoserver.backuprestore.listener.RestoreJobExecutionListener;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+
+/**
+ * End-to-end checks for the transactional restore (snapshot / rollback) wired into {@link RestoreJobExecutionListener}.
+ *
+ * <p>A restore commits to the live data directory incrementally: in particular the catalog {@code CatalogItemWriter}
+ * persists every restored object to disk through the {@code GeoServerConfigPersister} the restore catalog carries, with
+ * <em>no</em> {@code isDryRun()} gate on that write path. The snapshot taken in {@code beforeJob} and the rollback in
+ * {@code afterJob} are what make a Dry-Run (and a {@code BK_FAIL_ON_INVALID} abort) leave the data directory as it was.
+ *
+ * <p>These tests drive the listener's {@code beforeJob}/{@code afterJob} seam directly against the live GeoServer data
+ * directory (real {@code GeoServer.reload()} / security reload), rather than through an asynchronous restore job. That
+ * is deliberate: a Dry-Run restore in this in-process Windows harness does not finalize (it stays {@code STARTED} — the
+ * shipped {@code RESTRestoreTest} only asserts {@code COMPLETED} <em>if</em> the job happened to finish), so
+ * {@code afterJob} would never run inside a test window. Driving the seam directly exercises exactly the production
+ * rollback code synchronously and deterministically. The byte-for-byte equality of the underlying snapshot/rollback
+ * file mechanics is additionally covered by {@link RestoreSnapshotRollbackTest}.
+ */
+public class TransactionalRestoreTest extends BackupRestoreTestSupport {
+
+    @Override
+    @Before
+    public void beforeTest() throws InterruptedException {
+        ensureCleanedQueues();
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+    }
+
+    /**
+     * Dry-Run: the listener snapshots the data dir, then a mid-run persister write (simulated by writing a workspace
+     * descriptor the restore would have added) must be undone by the rollback, while content that predated the restore
+     * survives.
+     */
+    @Test
+    public void dryRunRollsBackDataDirWrites() throws Exception {
+        runRollbackScenario("tx_dryrun", dryRunParams(), BatchStatus.COMPLETED);
+    }
+
+    /**
+     * Fail-on-invalid abort: a non-COMPLETED outcome must trigger the same rollback even when it is not a Dry-Run (the
+     * pre-flight validation failed the job after the catalog steps already committed to disk).
+     */
+    @Test
+    public void failOnInvalidAbortRollsBackDataDirWrites() throws Exception {
+        runRollbackScenario("tx_abort", failOnInvalidParams(), BatchStatus.FAILED);
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Drives the snapshot/rollback seam: register an execution, {@code beforeJob} (snapshot), simulate the restore
+     * writing a new workspace to disk, then {@code afterJob} with {@code finalStatus} and assert the write was rolled
+     * back and a pre-existing workspace preserved.
+     */
+    private void runRollbackScenario(String prefix, JobParameters params, BatchStatus finalStatus) throws Exception {
+        RestoreJobExecutionListener listener =
+                (RestoreJobExecutionListener) applicationContext.getBean("restoreJobExecutionListener");
+
+        // A bystander workspace that exists on disk before the restore and must survive the rollback.
+        addThrowawayWorkspace(prefix + "_bystander");
+        getGeoServer().reload();
+        File workspaces = workspacesDir();
+        File bystander = new File(workspaces, prefix + "_bystander/workspace.xml");
+        assertTrue("precondition: the bystander workspace must be on disk before the restore", bystander.exists());
+
+        long executionId = System.nanoTime();
+        JobExecution jobExecution = newRestoreExecution(executionId, params, finalStatus);
+
+        // beforeJob takes the snapshot (transactional mode is on for both dry-run and fail-on-invalid params).
+        listener.beforeJob(jobExecution);
+
+        // Simulate the catalog write path committing a brand-new object to disk mid-restore (what the persister does
+        // with no dry-run gate). This file is NOT in the snapshot, so a correct rollback must delete it.
+        File simWrite = new File(workspaces, prefix + "_sim_written/workspace.xml");
+        writeFile(
+                simWrite, "<workspace><id>" + prefix + "_sim</id><name>" + prefix + "_sim_written</name></workspace>");
+        assertTrue("precondition: the simulated restore write must be on disk", simWrite.exists());
+
+        // afterJob rolls back (dry-run, or non-COMPLETED status) and reloads.
+        listener.afterJob(jobExecution);
+
+        assertFalse("the rollback must remove the file the restore wrote after the snapshot", simWrite.exists());
+        assertTrue("the rollback must preserve content that predated the restore", bystander.exists());
+    }
+
+    private JobExecution newRestoreExecution(long executionId, JobParameters params, BatchStatus finalStatus) {
+        JobInstance jobInstance = new JobInstance(executionId, Backup.RESTORE_JOB_NAME);
+        JobExecution jobExecution = new JobExecution(executionId, jobInstance, params);
+        jobExecution.setStatus(finalStatus);
+        if (finalStatus == BatchStatus.FAILED) {
+            jobExecution.setExitStatus(ExitStatus.FAILED);
+        }
+        // The listener looks the execution up in the facade's running map (afterJob reads restoreExecution from it).
+        RestoreExecutionAdapter adapter =
+                new RestoreExecutionAdapter(jobExecution, backupFacade.getTotalNumberOfRestoreSteps());
+        backupFacade.getRestoreExecutions().put(executionId, adapter);
+        return jobExecution;
+    }
+
+    private JobParameters dryRunParams() {
+        return new JobParametersBuilder()
+                .addString(Backup.PARAM_DRY_RUN_MODE, "true")
+                .addString(Backup.PARAM_BEST_EFFORT_MODE, "true")
+                .addLong(Backup.PARAM_TIME, System.currentTimeMillis())
+                .toJobParameters();
+    }
+
+    private JobParameters failOnInvalidParams() {
+        return new JobParametersBuilder()
+                .addString(Backup.PARAM_FAIL_ON_INVALID, "true")
+                .addString(Backup.PARAM_BEST_EFFORT_MODE, "true")
+                .addLong(Backup.PARAM_TIME, System.currentTimeMillis())
+                .toJobParameters();
+    }
+
+    private File workspacesDir() {
+        return new File(getTestData().getDataDirectoryRoot(), "workspaces");
+    }
+
+    private void addThrowawayWorkspace(String name) {
+        WorkspaceInfo ws = catalog.getFactory().createWorkspace();
+        ws.setName(name);
+        catalog.add(ws);
+        NamespaceInfo ns = catalog.getFactory().createNamespace();
+        ns.setPrefix(name);
+        ns.setURI("http://" + name);
+        catalog.add(ns);
+        StyleInfo s = catalog.getFactory().createStyle();
+        s.setName(name + "_style");
+        s.setWorkspace(ws);
+        s.setFilename(name + ".sld");
+        catalog.add(s);
+    }
+
+    private static void writeFile(File f, String content) throws java.io.IOException {
+        f.getParentFile().mkdirs();
+        java.nio.file.Files.write(f.toPath(), content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+}

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/listener/RestoreSnapshotRollbackTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/listener/RestoreSnapshotRollbackTest.java
@@ -1,0 +1,211 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore.listener;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit tests for the transactional-restore snapshot / rollback file mechanics
+ * ({@link RestoreJobExecutionListener#snapshotDataDirectory(File)} and
+ * {@link RestoreJobExecutionListener#rollbackDataDirectory(File, File)}).
+ *
+ * <p>Exercised against a hand-built data directory so they do not need a running restore job or the live GeoServer /
+ * security singletons (the in-memory reload that follows the on-disk rollback is covered separately by the integration
+ * path). The central guarantee asserted here is the one the brief calls out: after a rollback, every snapshotted
+ * subtree / root file is byte-identical to its pre-restore state.
+ */
+public class RestoreSnapshotRollbackTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    /** A round trip with no intervening changes must leave the data directory byte-identical. */
+    @Test
+    public void snapshotThenRollbackIsByteIdenticalWhenNothingChanged() throws Exception {
+        File dataDir = newDataDir();
+        String before = digest(dataDir);
+
+        File snapshot = RestoreJobExecutionListener.snapshotDataDirectory(dataDir);
+        try {
+            RestoreJobExecutionListener.rollbackDataDirectory(dataDir, snapshot);
+        } finally {
+            FileUtils.deleteDirectory(snapshot);
+        }
+
+        assertEquals(
+                "an unchanged data directory must survive a snapshot+rollback byte-identical", before, digest(dataDir));
+    }
+
+    /**
+     * Mutations a restore would make to the tracked subtrees and root files — overwriting an existing file, adding a
+     * new file inside a tracked subtree, deleting an existing file, and rewriting a root {@code *.xml} — must all be
+     * undone by the rollback.
+     */
+    @Test
+    public void rollbackUndoesInPlaceMutations() throws Exception {
+        File dataDir = newDataDir();
+        String before = digest(dataDir);
+
+        File snapshot = RestoreJobExecutionListener.snapshotDataDirectory(dataDir);
+        try {
+            // Overwrite an existing tracked file.
+            write(new File(dataDir, "workspaces/ws1/store.xml"), "MUTATED");
+            // Add a brand-new file inside a tracked subtree (a restore would write extra workspaces/styles).
+            write(new File(dataDir, "workspaces/intruder/intruder.xml"), "NEW");
+            // Delete an existing tracked file.
+            assertTrue(new File(dataDir, "styles/style.sld").delete());
+            // Rewrite a root global xml.
+            write(new File(dataDir, "global.xml"), "<global>changed</global>");
+
+            // Sanity: the directory really did change.
+            assertFalse("precondition: the mutations must change the digest", before.equals(digest(dataDir)));
+
+            RestoreJobExecutionListener.rollbackDataDirectory(dataDir, snapshot);
+        } finally {
+            FileUtils.deleteDirectory(snapshot);
+        }
+
+        assertEquals("rollback must restore every tracked mutation byte-identically", before, digest(dataDir));
+        assertFalse(
+                "rollback must drop files the restore added inside a tracked subtree",
+                new File(dataDir, "workspaces/intruder/intruder.xml").exists());
+    }
+
+    /** A whole subtree the restore creates from scratch (absent in the snapshot) must be removed by the rollback. */
+    @Test
+    public void rollbackRemovesSubtreesCreatedByTheRestore() throws Exception {
+        File dataDir = newDataDir();
+        // No gwc-layers in the pristine dir.
+        assertFalse(new File(dataDir, "gwc-layers").exists());
+        String before = digest(dataDir);
+
+        File snapshot = RestoreJobExecutionListener.snapshotDataDirectory(dataDir);
+        try {
+            // The restore creates the whole gwc-layers tree.
+            write(new File(dataDir, "gwc-layers/topp_states.xml"), "<layer/>");
+            RestoreJobExecutionListener.rollbackDataDirectory(dataDir, snapshot);
+        } finally {
+            FileUtils.deleteDirectory(snapshot);
+        }
+
+        assertFalse(
+                "rollback must remove a tracked subtree that did not exist before the restore",
+                new File(dataDir, "gwc-layers").exists());
+        assertEquals(before, digest(dataDir));
+    }
+
+    /** A tracked subtree the restore wipes (e.g. on a purge restore) must be brought back by the rollback. */
+    @Test
+    public void rollbackRestoresSubtreesDeletedByTheRestore() throws Exception {
+        File dataDir = newDataDir();
+        String before = digest(dataDir);
+
+        File snapshot = RestoreJobExecutionListener.snapshotDataDirectory(dataDir);
+        try {
+            FileUtils.deleteDirectory(new File(dataDir, "workspaces"));
+            assertFalse(new File(dataDir, "workspaces").exists());
+            RestoreJobExecutionListener.rollbackDataDirectory(dataDir, snapshot);
+        } finally {
+            FileUtils.deleteDirectory(snapshot);
+        }
+
+        assertTrue(
+                "rollback must recreate a tracked subtree the restore deleted",
+                new File(dataDir, "workspaces/ws1/store.xml").exists());
+        assertEquals(before, digest(dataDir));
+    }
+
+    /** The snapshot must not capture untracked content (data stores, gwc tile blobs), so rollback leaves it alone. */
+    @Test
+    public void snapshotIgnoresUntrackedContent() throws Exception {
+        File dataDir = newDataDir();
+        // An untracked directory and file outside the snapshot set.
+        write(new File(dataDir, "data/foo.shp"), "shapefile-bytes");
+
+        File snapshot = RestoreJobExecutionListener.snapshotDataDirectory(dataDir);
+        try {
+            assertFalse("the snapshot must not copy untracked subtrees", new File(snapshot, "data").exists());
+            // The rollback must not touch untracked content.
+            String stamp = "still-here";
+            write(new File(dataDir, "data/foo.shp"), stamp);
+            RestoreJobExecutionListener.rollbackDataDirectory(dataDir, snapshot);
+            assertEquals(stamp, read(new File(dataDir, "data/foo.shp")));
+        } finally {
+            FileUtils.deleteDirectory(snapshot);
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // helpers
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /** Builds a minimal data dir with content in several tracked subtrees plus root xml files. */
+    private File newDataDir() throws IOException {
+        File dir = tmp.newFolder("datadir");
+        write(new File(dir, "workspaces/default.xml"), "<workspace>ws1</workspace>");
+        write(new File(dir, "workspaces/ws1/workspace.xml"), "<workspace><name>ws1</name></workspace>");
+        write(new File(dir, "workspaces/ws1/store.xml"), "<dataStore><name>store</name></dataStore>");
+        write(new File(dir, "styles/style.xml"), "<style><name>style</name></style>");
+        write(new File(dir, "styles/style.sld"), "<sld/>");
+        write(new File(dir, "layergroups/lg.xml"), "<layerGroup/>");
+        write(new File(dir, "gwc/gwc-gs.xml"), "<gwcConfiguration/>");
+        write(new File(dir, "security/users.properties"), "admin=secret");
+        write(new File(dir, "security/masterpw/default/passwd"), "masterpw");
+        write(new File(dir, "global.xml"), "<global/>");
+        write(new File(dir, "logging.xml"), "<logging/>");
+        return dir;
+    }
+
+    private static void write(File f, String content) throws IOException {
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String read(File f) throws IOException {
+        return new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * A stable, order-independent digest of every regular file under {@code dir}: relative path + length + content
+     * hash, sorted. Two directories with the same digest are byte-identical in their file contents and layout.
+     */
+    private static String digest(File dir) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        java.util.List<String> lines = new java.util.ArrayList<>();
+        collect(dir, dir, lines);
+        java.util.Collections.sort(lines);
+        for (String l : lines) {
+            sb.append(l).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static void collect(File root, File f, java.util.List<String> lines) throws IOException {
+        File[] children = f.listFiles();
+        if (children == null) {
+            return;
+        }
+        for (File c : children) {
+            if (c.isDirectory()) {
+                collect(root, c, lines);
+            } else {
+                String rel = root.toPath().relativize(c.toPath()).toString().replace('\\', '/');
+                byte[] bytes = Files.readAllBytes(c.toPath());
+                lines.add(rel + "|" + bytes.length + "|" + Integer.toHexString(java.util.Arrays.hashCode(bytes)));
+            }
+        }
+    }
+}

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/listener/RestoreSnapshotRollbackTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/listener/RestoreSnapshotRollbackTest.java
@@ -107,6 +107,28 @@ public class RestoreSnapshotRollbackTest {
         assertEquals(before, digest(dataDir));
     }
 
+    /** A root *.xml the restore introduces (absent in the snapshot) must be removed by the rollback. */
+    @Test
+    public void rollbackRemovesRootXmlCreatedByTheRestore() throws Exception {
+        File dataDir = newDataDir();
+        assertFalse(new File(dataDir, "wps.xml").exists());
+        String before = digest(dataDir);
+
+        File snapshot = RestoreJobExecutionListener.snapshotDataDirectory(dataDir);
+        try {
+            // The restore writes a brand-new root service descriptor.
+            write(new File(dataDir, "wps.xml"), "<wps/>");
+            RestoreJobExecutionListener.rollbackDataDirectory(dataDir, snapshot);
+        } finally {
+            FileUtils.deleteDirectory(snapshot);
+        }
+
+        assertFalse(
+                "rollback must remove a root *.xml that did not exist before the restore",
+                new File(dataDir, "wps.xml").exists());
+        assertEquals(before, digest(dataDir));
+    }
+
     /** A tracked subtree the restore wipes (e.g. on a purge restore) must be brought back by the rollback. */
     @Test
     public void rollbackRestoresSubtreesDeletedByTheRestore() throws Exception {


### PR DESCRIPTION
## What

Makes the two opt-in "non-destructive" restore modes — **Dry-Run** (`BK_DRY_RUN`) and **pre-flight fail-on-invalid** (`BK_FAIL_ON_INVALID`, added in #9569) — *trustworthy on disk* by snapshotting the live data directory before the job and rolling it back afterwards.

Stacked on `feat/backup-restore-subset-closure` (like #9568 / #9569). **Draft** because it changes data-directory commit behaviour for those two modes.

## Why

A restore commits to the **live** data directory incrementally as the chunk/tasklet steps run:

- catalog → the `GeoServerConfigPersister` carried on the restore catalog. `CatalogItemWriter` has **no `isDryRun()` gate** on this path, so even a Dry-Run writes workspace/store/style descriptors into `workspaces/` on disk;
- GWC → `CatalogBackupRestoreTasklet`;
- security → `CatalogSecurityManagerTasklet`.

So the pre-flight abort and Dry-Run mode, by themselves, only skip the final **in-memory** reload — they do not undo what was already written to disk. `ValidateRestoreTasklet` already documents this as a KNOWN LIMITATION. Scratch-staging the whole restore is blocked by the live `GeoServerSecurityManager` singleton, so this uses **SNAPSHOT + ROLLBACK** at the `RestoreJobExecutionListener` job-level seam instead.

## How

`RestoreJobExecutionListener` (`beforeJob` / `afterJob`):

- **`beforeJob`** — only when Dry-Run **or** `BK_FAIL_ON_INVALID` (opt-in, so default restores are untouched and pay no snapshot cost): snapshot the subtrees the restore writes — `workspaces`, `styles`, `layergroups`, `gwc`, `gwc-layers`, `security` — plus the root global `*.xml` (`global.xml`, `logging.xml`, …) into a fresh temp dir via `Files.createTempDirectory` + `FileUtils.copyDirectory`/`copyFile`, rooted at `backupFacade.getResourceLoader().getBaseDirectory()`. A snapshot failure is logged `SEVERE` and the restore proceeds **without** rollback protection rather than aborting.
- **`afterJob`** — if a snapshot was taken AND (Dry-Run OR `status != COMPLETED`): roll the live tree back from the snapshot (`deleteDirectory` then `copyDirectory`; subtrees the restore created but the snapshot lacks are removed), then `GeoServer.reload()` + `GeoServerSecurityManager.reload()`. Otherwise discard the snapshot. On a **successful** rollback/discard the snapshot is deleted; on a **failed** rollback the snapshot is **preserved** and a `SEVERE` is logged for manual recovery.

Non-transactional restores are functionally unchanged: `snapshotDir` stays `null` and both added branches are skipped.

## Tests

- **`RestoreSnapshotRollbackTest`** (unit, deterministic): byte-identity of the snapshot/rollback file mechanics against a hand-built data dir — unchanged round-trip, in-place mutations undone, restore-created subtrees removed, restore-deleted subtrees restored, untracked content (data stores, tile blobs) ignored.
- **`TransactionalRestoreTest`** (integration): drives the `beforeJob`/`afterJob` seam against the live GeoServer data directory (real `reload()` + security reload) and asserts a simulated mid-restore persister write is rolled back while pre-existing content survives — for both Dry-Run and a non-COMPLETED fail-on-invalid abort.

> The integration test drives the listener seam directly rather than through the async restore job on purpose: a Dry-Run restore does **not** finalize in the in-process Windows test harness (it stays `STARTED` — the shipped `RESTRestoreTest` only asserts `COMPLETED` *if* the job happened to finish), so `afterJob` would never run inside a test window.

## Local validation

- `mvn -Prelease,communityRelease -Dspotless.action=check` on `gs-backup-restore-core`: **BUILD SUCCESS**, Spotless clean, the 3 transactional/validation test classes (9 tests) green.
- Disk-state assertions: after a Dry-Run or an aborted (fail-on-invalid) restore the tracked subtrees match their pre-restore state; the snapshot's byte-for-byte round trip is covered by the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)