### PR TITLE
[backup-restore] Docs: align with 3.0 behaviour + 2.x->3.x migration page

### DIFF
--- a/doc/en/user/community/backuprestore/index.md
+++ b/doc/en/user/community/backuprestore/index.md
@@ -9,5 +9,6 @@ This section describes the GeoServer Backup and Restore plugin functionality and
 - [Usage Via GeoServer's REST API](usagerest.md)
 - [Backup and Restore Extension for the management of ImageMosaic indexers](extensions.md)
 - [Use Cases](usecases.md)
+- [What changed between 2.x and 3.x](migration.md)
 
 </div>

--- a/doc/en/user/community/backuprestore/migration.md
+++ b/doc/en/user/community/backuprestore/migration.md
@@ -1,0 +1,143 @@
+# What changed between 2.x and 3.x
+
+The Backup and Restore module was substantially reworked for GeoServer 3.x. The REST API, the
+archive layout and the on-disk format remain compatible, so existing automation and existing
+archives keep working. Most of the changes are reliability fixes and new options; there is **one
+default behaviour change** — `BK_PRESERVE_IDS` — that you should be aware of before upgrading
+scripted backups.
+
+## At a glance
+
+| Area | 2.x | 3.x |
+|----|----|----|
+| Batch engine | Spring Batch 4 / Spring 5, jobs wired in XML | Spring Batch 6 / Spring 7, jobs wired in Java |
+| Default archive | name-based (ids regenerated on restore) | **id-preserving** (`BK_PRESERVE_IDS=true` by default) |
+| Filtered (subset) backups | could be incomplete (dangling references) | self-contained via dependency closure |
+| Merge / partial restore + GWC | wiped the target's tile layers | keeps the target's tile layers |
+| Restore validation | could false-fail name-based restores | null-id guards + trustworthy pre-flight pass |
+| Security restore | verbatim copy, single-instance only | merge mode + keystore re-encryption for cross-instance migration |
+| Dry-run / fail-on-invalid | wrote to disk incrementally (only the reload was skipped) | snapshot + rollback leave the data directory untouched |
+
+## `BK_PRESERVE_IDS` now defaults to `true` — the one to watch
+
+This is the only change that alters the default outcome of a backup.
+
+In 3.x a backup keeps each catalog object's internal id and writes cross-references **by id**, so the
+archive is a portable **migration artifact**: restoring it into another, already-populated GeoServer
+preserves the original identities, which lets cross-references and GeoWebCache tile-layer links
+re-link correctly, and lets a re-restore into the *same* instance skip objects that already exist
+(by id) instead of duplicating or clashing on name.
+
+If you rely on the classic **name-based** archive — ids stripped and regenerated on restore, which is
+the right choice when restoring into a fresh, empty data directory — set the option explicitly:
+
+```text
+BK_PRESERVE_IDS=false
+```
+
+!!! note
+    `BK_PRESERVE_IDS` is a **backup-side** option only. The restore adapts automatically to whatever
+    the archive contains (it reads whichever of `<id>`/`<name>` each reference carries), so no matching
+    option is required on the restore command. See
+    [Migrating a catalog to another GeoServer instance](usecases.md#migrating-a-catalog-to-another-geoserver-instance).
+
+## Filtered (subset) backups are now self-contained
+
+A workspace-filtered backup in 2.x captured only the objects directly inside the selected
+workspaces. If one of those layers used a **global** (workspace-less) style, or a **layer group**
+referenced members in another workspace, the archive carried dangling references and could fail to
+restore into an empty target.
+
+In 3.x a filtered backup computes a **dependency closure** before writing: global styles,
+cross-workspace layer-group members and the namespaces they need are pulled into the archive
+automatically. A subset backup is therefore self-contained and restores cleanly into an empty
+instance.
+
+## GeoWebCache tile layers survive a merge restore
+
+In 2.x a restore wiped the target's `gwc-layers` directory whenever the restore was filtered,
+destroying tile-layer configuration for layers that had nothing to do with the archive.
+
+In 3.x the GeoWebCache directory is wiped **only on a full purge restore**
+(`BK_PURGE_RESOURCES=true` with no workspace filter). A **merge** restore
+(`BK_PURGE_RESOURCES=false`) or a **filtered** restore keeps the target's existing tile layers and
+merges the archive's tile layers on top. This makes incremental, per-workspace restores safe on a
+server that already serves tiles.
+
+## Stronger, trustworthy restore validation
+
+Two fixes make restore validation both less noisy and more dependable:
+
+- **No more false failures on name-based restores** (GEOS-10877). A name-based archive carries
+  objects with no ids; in 2.x feeding those to the catalog validator could raise spurious errors.
+  In 3.x per-item validation is skipped for null-id objects, so a name-based restore no longer
+  false-fails.
+- **A pre-flight validation pass.** After the restore catalog has been fully assembled, a dedicated
+  step validates the *whole* catalog and reports any problems. By default it logs them and records
+  them as execution warnings. Set `BK_FAIL_ON_INVALID=true` to make the restore **abort** on the
+  first invalid object — the job is marked `FAILED`, the live configuration reload is skipped, and the
+  data directory is rolled back (see [Transactional Dry-Run and fail-on-invalid](#transactional-dry-run-and-fail-on-invalid)
+  below). Combine it with `BK_DRY_RUN=true` to validate an archive non-destructively before committing.
+
+## Migration-safe security restore
+
+Restoring security across two different instances used to be impossible: 2.x copied the `security`
+folder verbatim, so a keystore encrypted with the source's master password could not be read on a
+target with a different one, and the copy overwrote the target's whole security configuration.
+
+3.x adds the pieces needed for cross-instance security migration:
+
+- **`BK_MERGE_SECURITY`** — an *add-only* merge of the archive's users, groups and roles into the
+  target's existing security services. The target keeps its own configuration, keystore and master
+  password; only principals that are not already present (by name) are added. Works even when the
+  source and target master passwords differ.
+- **Automatic service bootstrap** — if the target is missing a user/group or role service that the
+  merge needs, an empty one is created for it.
+- **Keystore re-encryption** — on a security *replace* restore, supply
+  `BK_SOURCE_MASTER_PASSWORD` and `BK_TARGET_MASTER_PASSWORD` together and the archive's keystore is
+  re-encrypted from the source master password to the target's, so it becomes readable on the target.
+
+See [`BK_MERGE_SECURITY` and the master-password options](usagerest.md) for the REST parameters.
+
+!!! warning
+    Security is still **excluded by default** (`BK_SKIP_SECURITY=true`). The options above only take
+    effect when you opt security in with `BK_SKIP_SECURITY=false`.
+
+## Transactional Dry-Run and fail-on-invalid
+
+A restore commits to the data directory **incrementally** as its steps run — the restore catalog
+persists each item through `GeoServerConfigPersister`, and GeoWebCache and security are written by
+their tasklets. In earlier versions a **Dry-Run** therefore only skipped the final in-memory reload:
+it still wrote the catalog to disk along the way, so it was not truly non-destructive, and a
+`BK_FAIL_ON_INVALID` abort could leave a partial write behind.
+
+3.x makes both opt-in modes trustworthy on disk by snapshotting and rolling back at the job level:
+
+- **Before the job**, when the restore is a Dry-Run (`BK_DRY_RUN=true`) or opts into
+  `BK_FAIL_ON_INVALID=true`, the affected data-directory subtrees (`workspaces`, `styles`,
+  `layergroups`, `gwc`, `gwc-layers`, `security`) and the root global `*.xml` files are copied into a
+  temporary snapshot. This is **strictly opt-in**, so an ordinary restore keeps the historical
+  incremental-commit behaviour and pays no snapshot cost.
+- **After the job**, if the restore was a Dry-Run or ended in any non-`COMPLETED` state, the live
+  tree is rolled back from the snapshot (subtrees the restore created are removed; modified or deleted
+  ones are restored) and the configuration and security are reloaded. The snapshot is then deleted; if
+  a rollback ever fails it is **preserved** and logged for manual recovery.
+
+The practical effect: a `BK_DRY_RUN=true` restore now leaves the data directory exactly as it was —
+making it a safe way to validate an archive — and a failed or `BK_FAIL_ON_INVALID`-aborted restore no
+longer leaves the target half-written.
+
+## REST API and archive compatibility
+
+The REST endpoints (`/rest/br/backup`, `/rest/br/restore`) and the JSON/XML response shape are
+unchanged from 2.x, so existing clients and scripts continue to work without modification. Archives
+written by 3.x restore into 3.x; the practical difference from a 2.x archive is the id-preserving
+default described above.
+
+## For developers and extension authors
+
+- The engine now runs on **Spring Batch 6.0.3 / Spring 7** (GeoServer 3's JDK 17 baseline applies).
+- The backup and restore **job graphs are defined in Java `@Configuration`**
+  (`BackupJobConfiguration`, `RestoreJobConfiguration`, `BatchInfrastructureConfiguration`) instead
+  of the old `applicationContext.xml` `<batch:job>` definitions. Custom steps, tasklets, readers,
+  processors and writers contributed by extensions should be wired the same way.

--- a/doc/en/user/community/backuprestore/usagegui.md
+++ b/doc/en/user/community/backuprestore/usagegui.md
@@ -21,7 +21,7 @@ Here you'll be able to specify various parameters for the Backup / Restore proce
     3.  `Clean-Up Temp Resources`: Delete the temporary working folder at the end of the execution
     4.  `Skip GeoWebCache`: Exclude the GWC catalog and tile-layer folders from the backup
     5.  `Parameterize Store Passwords`: Replace store passwords in the archive with parameterizable tokens instead of the encrypted values (see `BK_PARAM_PASSWORDS` under [Usage Via REST](usagerest.md))
-    6.  `Preserve Catalog IDs (for migration)`: Keep catalog object ids and write cross-references by id, producing an archive suited to migrating into another, already-populated instance. Off by default (the portable, name-based archive). See [Migrating a catalog to another GeoServer instance](usecases.md#migrating-a-catalog-to-another-geoserver-instance)
+    6.  `Preserve Catalog IDs (for migration to another instance)`: Keep catalog object ids and write cross-references by id, producing a portable migration archive that restores into another GeoServer with the original object identities — and their GWC tile-layer links — preserved. **On by default.** Turn it off only to produce a legacy name-based archive whose ids are regenerated on restore. See [Migrating a catalog to another GeoServer instance](usecases.md#migrating-a-catalog-to-another-geoserver-instance)
     7.  `Skip Security Settings`: Exclude the security configuration (users, groups, roles, services) from the backup. **Checked by default**, matching the `BK_SKIP_SECURITY` REST default. Uncheck to include security in the archive
     8.  `Skip Global Settings`: Exclude the global settings from the backup. **Checked by default**, matching the `BK_SKIP_SETTINGS` REST default
 
@@ -36,6 +36,7 @@ Here you'll be able to specify various parameters for the Backup / Restore proce
     5.  `Skip Security Settings`: Do not restore the security configuration. **Checked by default**, matching the `BK_SKIP_SECURITY` REST default. Uncheck only when the archive contains a security folder you intend to restore
     6.  `Skip Global Settings`: Do not restore the global settings. **Checked by default**, matching the `BK_SKIP_SETTINGS` REST default
     7.  `Purge Existing Resources`: Delete incoming resources where possible before restoring (e.g. drop existing workspaces). **Checked by default**, matching the `BK_PURGE_RESOURCES` REST default. Uncheck to merge into the existing catalog without deleting
+    8.  `Merge Security (cross-instance migration)`: Merge the archive's users, groups and roles into this instance's existing security services instead of replacing the whole security configuration. Keeps this instance's configuration, keystore and master password — use it to migrate users/roles from another GeoServer whose master password differs. **Unchecked by default** (replace mode). New users keep their archived (digest) passwords; reversible passwords must be reset afterwards. This option applies only when security is actually restored — that is, when `Skip Security Settings` is unchecked. See the REST option [`BK_MERGE_SECURITY`](usagerest.md)
 
 6.  `Restore Executions`: Report of running and previously run restore
 
@@ -43,7 +44,7 @@ Here you'll be able to specify various parameters for the Backup / Restore proce
     `Skip Security Settings` is checked by default for a reason: restoring security configuration replaces the target's users, groups, roles and authentication settings. Only uncheck it when you understand the archive's security content and intend to overwrite the target's security. See the [partial / cross-instance restore notes](usecases.md#partial-and-cross-instance-restores).
 
 !!! note
-    The remaining `BK_*` options (e.g. password-token substitution, `exclude.file.path`) are available only through the [REST API](usagerest.md), which exposes the full option set.
+    The remaining `BK_*` options — password-token substitution, `exclude.file.path`, the pre-flight validation gate (`BK_FAIL_ON_INVALID`) and security keystore re-encryption (`BK_SOURCE_MASTER_PASSWORD` / `BK_TARGET_MASTER_PASSWORD`) — are available only through the [REST API](usagerest.md), which exposes the full option set.
 
 ## Performing a full backup via UI
 

--- a/doc/en/user/community/backuprestore/usagerest.md
+++ b/doc/en/user/community/backuprestore/usagerest.md
@@ -44,7 +44,7 @@ Available options are:
 4.  `BK_SKIP_SETTINGS`: This will attempt to exclude global settings from the backup, as well as security settings. Default: `true`.
 5.  `BK_SKIP_GWC`: This option will avoid backup / restore the GWC catalog and folders. Default: `false`.
 6.  `BK_CLEANUP_TEMP`: This will attempt to delete temporary folder at the end of the execution. Default: `true`.
-7.  `BK_PRESERVE_IDS`: Keep every catalog object's internal id in the archive and write cross-references **by id** instead of by name. Default: `false`. By default the archive is *portable* — ids are stripped and objects reference each other by name — which is the right choice when restoring into a fresh, empty data directory. Set this to `true` when you intend to **migrate** the archive into another, already-populated GeoServer instance and need the original identities to be preserved (see [Migrating a catalog to another GeoServer instance](usecases.md#migrating-a-catalog-to-another-geoserver-instance)). The flag is a **backup-side** option only: the restore reads whichever of `<id>`/`<name>` each reference carries, so an id-based archive restores correctly with the default restore command — no matching option is required.
+7.  `BK_PRESERVE_IDS`: Keep every catalog object's internal id in the archive and write cross-references **by id** instead of by name. Default: `true`. By default the archive is a portable **migration artifact**: it preserves the original object identities, so it restores into another, already-populated GeoServer with cross-references and GWC tile-layer links intact (see [Migrating a catalog to another GeoServer instance](usecases.md#migrating-a-catalog-to-another-geoserver-instance)). Set this to `false` to produce the legacy *name-based* archive — ids are stripped and regenerated on restore — which is only needed when restoring into a fresh, empty data directory. The flag is a **backup-side** option only: the restore reads whichever of `<id>`/`<name>` each reference carries, so an archive restores correctly with the default restore command — no matching option is required. (Changed in 3.0 — see [What changed between 2.x and 3.x](migration.md).)
 8.  `exclude.file.path`: A `;` separated list of paths relative to the `GEOSERVER_DATA_DIR` (e.g.: 'exclude.file.path=/data/geonode;/monitoring;/geofence'). If exist, the backup / restore will skip the path listed. Default: `[]`. WARNING: `security` and `workspaces` are treated differently. This option should be used only for custom external resources located under the `GEOSERVER_DATA_DIR`.
 
 !!! note
@@ -186,7 +186,7 @@ In this case we did not specify any options in the restore configuration so defa
 
 Available Options are:
 
-1.  `BK_DRY_RUN`: Only test the archive do not persist the restored configuration. Default: `false`.
+1.  `BK_DRY_RUN`: Only test the archive, do not persist the restored configuration. Default: `false`. Since 3.x a dry-run **snapshots and rolls back** the affected data-directory subtrees, so it leaves the data directory untouched even though the restore otherwise writes incrementally (see [What changed](migration.md#transactional-dry-run-and-fail-on-invalid)).
 
 2.  `BK_BEST_EFFORT`: Skip any failing resources and proceed with the restore procedure. Default: `false`.
 
@@ -206,7 +206,13 @@ Available Options are:
 
 8.  `BK_CLEANUP_TEMP`: This will attempt to delete temporary folder at the end of the execution. Default: `true`.
 
-9.  `exclude.file.path`: A `;` separated list of paths relative to the `GEOSERVER_DATA_DIR` (e.g.: 'exclude.file.path=/data/geonode;/monitoring;/geofence'). If exist, the backup / restore will skip the path listed. Default: `[]`. WARNING: `security` and `workspaces` are treated differently. This option should be used only for custom external resources located under the `GEOSERVER_DATA_DIR`.
+9.  `BK_MERGE_SECURITY`: When `true`, **merge** the archive's users, groups and roles into the target's existing security services instead of replacing the whole `security` folder. The target keeps its own configuration, keystore and master password, so this works even when the source and target master passwords differ. New principals keep their archived (digest) passwords; reversible passwords must be reset on the target afterwards. Default: `false` (replace mode). Has effect only when security is actually restored, i.e. `BK_SKIP_SECURITY=false`. New in 3.0.
+
+10.  `BK_SOURCE_MASTER_PASSWORD` / `BK_TARGET_MASTER_PASSWORD`: Supplied together on a security **replace** restore (`BK_SKIP_SECURITY=false`, `BK_MERGE_SECURITY=false`) to re-encrypt the archive's keystore from the source's master password to the target's — without them a keystore encrypted under a different source master password cannot be read on the target. `BK_TARGET_MASTER_PASSWORD` must match the target instance's actual master password or the re-encryption is rejected. Both are **sensitive**: pass them as transient parameters, never store them in scripts or logs. New in 3.0.
+
+11.  `BK_FAIL_ON_INVALID`: When `true`, the restore runs a **pre-flight validation pass** over the fully-assembled restore catalog and **aborts** (the job is marked `FAILED`, the live configuration reload is skipped, and the data directory is rolled back to its pre-restore state) if any catalog object is invalid. Default: `false` — the pass still runs but only logs the problems and records them as execution warnings. Combine with `BK_DRY_RUN=true` to validate an archive non-destructively before committing to a real restore. New in 3.0.
+
+12.  `exclude.file.path`: A `;` separated list of paths relative to the `GEOSERVER_DATA_DIR` (e.g.: 'exclude.file.path=/data/geonode;/monitoring;/geofence'). If exist, the backup / restore will skip the path listed. Default: `[]`. WARNING: `security` and `workspaces` are treated differently. This option should be used only for custom external resources located under the `GEOSERVER_DATA_DIR`.
 
 !!! warning
     A restore is **destructive by default**: with the default options it drops pre-existing resources (`BK_PURGE_RESOURCES=true`) and does not restore security or global settings (`BK_SKIP_SECURITY` / `BK_SKIP_SETTINGS` = `true`). To **merge** an archive into the current catalog without deleting anything, pass `BK_PURGE_RESOURCES=false`. Always run a `BK_DRY_RUN=true` first. The GeoServer UI exposes all three as checkboxes (pre-checked to these defaults).

--- a/doc/en/user/community/backuprestore/usecases.md
+++ b/doc/en/user/community/backuprestore/usecases.md
@@ -47,14 +47,12 @@ The backup and restore extension should perform a double check once restored the
 
 ## Migrating a catalog to another GeoServer instance
 
-The default backup archive is **portable**: catalog object ids are stripped and objects reference each other by name. This is the right format when the archive is restored into a fresh, empty data directory — the restore re-creates everything and assigns new ids.
+Since GeoServer 3.0 the default backup archive is **migration-ready**: it keeps every catalog object's id and writes all cross-references by id (`BK_PRESERVE_IDS=true`, the default). This is what you want when the archive will be **merged** into another, already-populated instance — a migration, a consolidation of several servers, or a promotion from staging to production — because it preserves the original identities:
 
-When the goal is instead to **merge** the contents of one instance into another, already-populated instance (a migration, a consolidation of several servers, or a promotion from staging to production), the name-based format has two limitations:
+- A restore matches incoming objects **by id** first (then by name), so each object keeps its identity instead of being conflated with a target object that merely shares a name.
+- GeoWebCache keys its tile-layer configurations strictly by the **published id** of the layer/layer group (there is no name fallback), so preserving ids is what lets the cached tile layers re-link on the target.
 
-- A restore matches incoming objects against the target **by name**, so an object that happens to share a name with an existing one is treated as the same object.
-- GeoWebCache keys its tile-layer configurations strictly by the **published id** of the layer/layer group (there is no name fallback), so name-based archives cannot reliably re-link the cached tile layers.
-
-To preserve the original identities, take the backup with the `BK_PRESERVE_IDS` option (see [Backup options](usagerest.md)):
+Because this is the default, a migration backup needs no special option:
 
 ```json
 {
@@ -62,19 +60,32 @@ To preserve the original identities, take the backup with the `BK_PRESERVE_IDS` 
       "archiveFile":"/home/sg/BackupAndRestore/migration.zip",
       "overwrite":true,
       "options":{
-        "option": ["BK_PRESERVE_IDS=true"]
       }
    }
 }
 ```
 
-The resulting archive keeps every object's id and writes all cross-references by id. Restoring it requires **no special option** — the restore detects the ids and matches accordingly:
+Restoring it requires **no special option** either — the restore detects the ids and matches accordingly:
 
 - Restoring into the **same** instance is idempotent: objects whose id already exists are skipped instead of being duplicated or merged by name.
 - Restoring into a **different** instance preserves the original ids (their ids never collide with the target's, so each object is added keeping its preset id), which lets cross-references between objects and the GWC tile layers re-link correctly.
 
+If you instead want the legacy **portable, name-based** archive — catalog ids stripped and regenerated on restore, the right choice when restoring into a fresh, empty data directory — turn the option off with `BK_PRESERVE_IDS=false`:
+
+```json
+{
+   "backup":{
+      "archiveFile":"/home/sg/BackupAndRestore/portable.zip",
+      "overwrite":true,
+      "options":{
+        "option": ["BK_PRESERVE_IDS=false"]
+      }
+   }
+}
+```
+
 !!! note
-    `BK_PRESERVE_IDS` is currently a REST / programmatic option only; it is not exposed in the Web UI. The default (`false`) keeps the legacy portable, name-based archive format.
+    `BK_PRESERVE_IDS` is exposed in the Web UI as the **Preserve Catalog IDs (for migration to another instance)** backup checkbox (checked by default) as well as the `BK_PRESERVE_IDS` REST option. It is a backup-side option only; the restore adapts automatically to whatever the archive contains. See [What changed between 2.x and 3.x](migration.md).
 
 ## Partial and cross-instance restores
 
@@ -89,4 +100,4 @@ Restoring a workspace-filtered archive, or an archive produced on a different in
 - **Stale GWC tile layers are pruned.** After a (non-dry-run) restore, tile-layer configurations whose published id no longer resolves to a catalog layer or layer group are removed, cleaning up the dangling tile layers that accumulate when a partial restore does not wipe the `gwc-layers` directory.
 
 !!! note
-    As noted under [Saving/restoring only specific workspaces](usagegui.md), a backup archive that contains only a subset of workspaces cannot be used to restore the missing ones. To migrate or consolidate a full catalog, back up the whole catalog (optionally with `BK_PRESERVE_IDS=true`) and restore the workspaces you need.
+    As noted under [Saving/restoring only specific workspaces](usagegui.md), a backup archive that contains only a subset of workspaces cannot be used to restore the missing ones. To migrate or consolidate a full catalog, back up the whole catalog (the default archive already preserves ids for migration) and restore the workspaces you need.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -757,6 +757,7 @@ nav:
         - en/user/community/backuprestore/usagerest.md
         - en/user/community/backuprestore/extensions.md
         - en/user/community/backuprestore/usecases.md
+        - en/user/community/backuprestore/migration.md
       - COG (Cloud Optimized GeoTIFF) Documentation:
         - en/user/community/cog/index.md
         - en/user/community/cog/cog.md


### PR DESCRIPTION
Documentation-only PR aligning the Backup & Restore community module docs with the 3.0 refactor (PRs #9566–#9570) and adding a "What changed between 2.x and 3.x" migration page.

## Accuracy fixes to the existing pages
- `BK_PRESERVE_IDS` is now documented as **default `true`** (id-preserving migration archive) across `usagegui`, `usagerest` and `usecases` — the prior text said `false` / "off" / "not exposed in the Web UI", all now corrected to match the code and the GUI checkbox.
- Documented the **Merge Security** GUI checkbox and the REST-only options `BK_MERGE_SECURITY`, `BK_SOURCE_MASTER_PASSWORD`, `BK_TARGET_MASTER_PASSWORD`, `BK_FAIL_ON_INVALID`.

## New `migration.md` ("What changed between 2.x and 3.x")
Registered in `index.md` and the mkdocs `nav`, covering the merged work:
- Spring Batch 6.0.3 / Spring 7 engine, job wiring moved XML → Java `@Configuration`
- `BK_PRESERVE_IDS` default flip to `true` (the one behaviour change to watch)
- self-contained subset backups via dependency closure
- GWC merge/partial restores keep the target's tile layers
- restore validation hardening (GEOS-10877 null-id guards + pre-flight pass + `BK_FAIL_ON_INVALID`)
- migration-safe security (merge, service bootstrap, keystore re-encryption)
- transactional snapshot/rollback for Dry-Run / fail-on-invalid (#9570)

Markdown + mkdocs nav only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)