### PR TITLE
Fix escaping for reserved characters in configuration.md

### DIFF
--- a/doc/en/user/data/raster/imagemosaic/configuration.md
+++ b/doc/en/user/data/raster/imagemosaic/configuration.md
@@ -22,7 +22,7 @@ If you already have these files generated, GeoServer will respect them and not g
 Within each store there are multiple configuration files that determine how the mosaic is rendered.
 
 !!! note
-    The property file syntax uses a few reserved chars that need escaping in order to be used for keys or values. For example, the `#` character is used to comment out lines, in order to use it in values it needs to be escaped, like this: `\#`. The same applies to the `=` character, which is used to separate the property name from its value: it should be specified as `\=`. Finally, if there is a need to use the ` itself, it will have to be escaped as well: `.
+    The property file syntax uses a few reserved chars that need escaping in order to be used for keys or values. For example, the `#` character is used to comment out lines, in order to use it in values it needs to be escaped, like this: `\#`. The same applies to the `=` character, which is used to separate the property name from its value: it should be specified as `\=`. Finally, if there is a need to use the `` ` `` itself, it will have to be escaped as well: `` \` ``.
 
 ### Primary configuration file
 


### PR DESCRIPTION
Use double backticks plus space to enclose a single backtick

Preview seems to be correct now:

<img width="1289" height="130" alt="image" src="https://github.com/user-attachments/assets/71d5dc33-eddd-4cbe-aa4d-c1dc853c44cf" />


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.