### PR TITLE
Skip KeycloakAdminApiIntegrationTest when the Keycloak container fails to start

### DIFF
--- a/src/extension/security/oidc-web/src/test/java/org/geoserver/web/security/oauth2/intgration/keycloak/KeycloakAdminApiIntegrationTest.java
+++ b/src/extension/security/oidc-web/src/test/java/org/geoserver/web/security/oauth2/intgration/keycloak/KeycloakAdminApiIntegrationTest.java
@@ -69,8 +69,16 @@ public class KeycloakAdminApiIntegrationTest {
         Assume.assumeTrue("Docker not available — skipping", dockerAvailable);
 
         // Start a vanilla Keycloak — no realm-import, no fixtures. dasniko's container sets admin/admin via env vars.
-        keycloak = new KeycloakContainer("quay.io/keycloak/keycloak:26.0").withCustomCommand("--log-level=INFO");
-        keycloak.start();
+        try {
+            keycloak = new KeycloakContainer("quay.io/keycloak/keycloak:26.0").withCustomCommand("--log-level=INFO");
+            keycloak.start();
+        } catch (Exception e) {
+            // Docker is present but the container could not START (e.g. the build agent CPU lacks x86-64-v2 for the
+            // Keycloak image, a blocked image pull, or resource limits). Skip rather than fail the build, matching
+            // KeyCloakIntegrationTestSupport; genuine provisioning regressions below are still reported.
+            Assume.assumeTrue("Skipping Keycloak Admin API test: container failed to start - " + e.getMessage(), false);
+            return; // unreachable: assumeTrue(false) throws AssumptionViolatedException
+        }
         serverUrl = keycloak.getAuthServerUrl();
 
         provisionRealmViaAdminAPI();


### PR DESCRIPTION
Fixes the `gs-sec-oidc-web` failure breaking `main` on the OSGeo build server (e.g. [geoserver-main #3108](https://build.geoserver.org/job/geoserver-main/3108/)).

**Root cause:** the build agent's CPU lacks `x86-64-v2`, so the Keycloak 26.x container images cannot start there:
```
Fatal glibc error: CPU does not support x86-64-v2
... Container startup failed for image quay.io/keycloak/keycloak:26.0
```
The module's tests only began running in CI now that OIDC is a supported extension (community modules build with `-DskipTests`), so this path was never exercised before.

`KeyCloakIntegrationTestSupport` (used by the other three Keycloak tests) already catches a container-launch failure and `Assume`-skips — those report `Tests run: 0`. `KeycloakAdminApiIntegrationTest` called `keycloak.start()` unguarded in `@BeforeClass`, so it **errored** instead of skipping → `BUILD FAILURE`.

**Fix:** wrap the container construction/start in a `try/catch` and `Assume`-skip on launch failure, matching the sibling tests. Realm provisioning stays outside the `try`, so genuine provisioning regressions are still reported. On an agent where the container starts (e.g. GitHub Actions PR CI, which has x86-64-v2) the test runs exactly as before.