### PR TITLE
XMLUtils italian locale followup

### DIFF
--- a/src/wfs1_x/src/test/java/org/geoserver/wfs/ExternalEntitiesTest.java
+++ b/src/wfs1_x/src/test/java/org/geoserver/wfs/ExternalEntitiesTest.java
@@ -71,50 +71,58 @@ public class ExternalEntitiesTest extends WFSTestSupport {
 
     @Test
     public void testWfs1_0() throws Exception {
-        String output;
-        // enable entity parsing
+        Document dom;
         System.setProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED, "true");
         try {
-            output = string(post("wfs", WFS_1_0_0_REQUEST));
-            // the server tried to read a file on local file system
+            // enable entity parsing: server tries to read file on local file system
+            dom = postAsDOM("wfs", WFS_1_0_0_REQUEST);
             assertTrue(
                     "SAXException",
-                    output.indexOf("xml request is most probably not compliant to GetFeature element") > -1);
+                    checkLegacyException(dom, null, null)
+                            .contains("xml request is most probably not compliant to GetFeature element"));
 
-            // disable entity parsing
+            // disable entity parsing: DOCTYPE must be rejected
             System.setProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED, "false");
-            output = string(post("wfs", WFS_1_0_0_REQUEST));
-            assertTrue("DOCTYPE is disallowed", output.contains("DOCTYPE"));
+            dom = postAsDOM("wfs", WFS_1_0_0_REQUEST);
+            assertTrue(checkLegacyException(dom, null, null).contains("DOCTYPE"));
         } finally {
-            // set default (entity parsing disabled);
             System.clearProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED);
         }
-        output = string(post("wfs", WFS_1_0_0_REQUEST));
-        assertTrue("DOCTYPE is disallowed", output.contains("DOCTYPE"));
+        // default (entity parsing disabled): DOCTYPE must be rejected
+        dom = postAsDOM("wfs", WFS_1_0_0_REQUEST);
+        assertTrue(checkLegacyException(dom, null, null).contains("DOCTYPE"));
     }
 
     @Test
     public void testWfs1_1() throws Exception {
-        // enable entity parsing
-        String output;
+        Document dom;
+        System.setProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED, "true");
         try {
-            System.setProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED, "true");
-            output = string(post("wfs", WFS_1_1_0_REQUEST));
-            // the server tried to read a file on local file system
+            // enable entity parsing: server tries to read file on local file system
+            dom = postAsDOM("wfs", WFS_1_1_0_REQUEST);
             assertTrue(
                     "SAXException",
-                    output.indexOf("xml request is most probably not compliant to GetFeature element") > -1);
+                    dom.getElementsByTagName("ows:ExceptionText")
+                            .item(0)
+                            .getTextContent()
+                            .contains("xml request is most probably not compliant to GetFeature element"));
 
-            // disable entity parsing
+            // disable entity parsing: DOCTYPE must be rejected
             System.setProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED, "false");
-            output = string(post("wfs", WFS_1_1_0_REQUEST));
-            assertTrue("DDCTYPE is disallowed", output.contains("DOCTYPE"));
+            dom = postAsDOM("wfs", WFS_1_1_0_REQUEST);
+            assertTrue(dom.getElementsByTagName("ows:ExceptionText")
+                    .item(0)
+                    .getTextContent()
+                    .contains("DOCTYPE"));
         } finally {
-            // set default (entity parsing disabled);
             System.clearProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED);
         }
-        output = string(post("wfs", WFS_1_1_0_REQUEST));
-        assertTrue("DOCTYPE is disallowed", output.contains("DOCTYPE"));
+        // default (entity parsing disabled): DOCTYPE must be rejected
+        dom = postAsDOM("wfs", WFS_1_1_0_REQUEST);
+        assertTrue(dom.getElementsByTagName("ows:ExceptionText")
+                .item(0)
+                .getTextContent()
+                .contains("DOCTYPE"));
     }
 
     @Test

--- a/src/wfs2_x/src/test/java/org/geoserver/wfs/ExternalEntitiesTest.java
+++ b/src/wfs2_x/src/test/java/org/geoserver/wfs/ExternalEntitiesTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.geoserver.util.EntityResolverProvider;
 import org.junit.Test;
+import org.w3c.dom.Document;
 
 public class ExternalEntitiesTest extends WFSTestSupport {
 
@@ -45,24 +46,28 @@ public class ExternalEntitiesTest extends WFSTestSupport {
 
     @Test
     public void testWfs2_0() throws Exception {
-        // enable entity parsing
+        Document dom;
+        String message;
         System.setProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED, "true");
-        String output = string(post("wfs", WFS_2_0_0_REQUEST));
-        // the server tried to read a file on local file system
-        assertTrue(
-                "not compliant to GetFeature element",
-                output.indexOf("xml request is most probably not compliant to GetFeature element") > -1);
+        try {
+            // enable entity parsing: server tries to read file on local file system
+            dom = postAsDOM("wfs", WFS_2_0_0_REQUEST);
+            message = checkOws11Exception(dom, "2.0.0", null, null);
+            assertTrue(
+                    "not compliant to GetFeature element",
+                    message.contains("xml request is most probably not compliant to GetFeature element"));
 
-        // disable entity parsing
-        System.setProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED, "false");
-        output = string(post("wfs", WFS_2_0_0_REQUEST));
-        // just searching for DOCTYPE keyword as SAXException message is Locale dependent
-        assertTrue("DOCTYPE is disallowed", output.contains("DOCTYPE"));
-
-        // set default (entity parsing disabled);
-        System.clearProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED);
-        output = string(post("wfs", WFS_2_0_0_REQUEST));
-        // just searching for DOCTYPE keyword as SAXException message is Locale dependent
-        assertTrue("DOCTYPE is disallowed", output.contains("DOCTYPE"));
+            // disable entity parsing: DOCTYPE must be rejected
+            System.setProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED, "false");
+            dom = postAsDOM("wfs", WFS_2_0_0_REQUEST);
+            message = checkOws11Exception(dom, "2.0.0", null, null);
+            assertTrue(message.contains("DOCTYPE"));
+        } finally {
+            System.clearProperty(EntityResolverProvider.ENTITY_RESOLUTION_UNRESTRICTED);
+        }
+        // default (entity parsing disabled): DOCTYPE must be rejected
+        dom = postAsDOM("wfs", WFS_2_0_0_REQUEST);
+        message = checkOws11Exception(dom, "2.0.0", null, null);
+        assertTrue(message.contains("DOCTYPE"));
     }
 }

--- a/src/wfs2_x/src/test/java/org/geoserver/wfs/v2_0/GetFeatureTest.java
+++ b/src/wfs2_x/src/test/java/org/geoserver/wfs/v2_0/GetFeatureTest.java
@@ -1387,7 +1387,7 @@ public class GetFeatureTest extends WFS20TestSupport {
         MockHttpServletResponse resp = postAsServletResponse("wfs", xml, "application/soap+xml");
         assertEquals("application/soap+xml", resp.getContentType());
         String message = resp.getContentAsString();
-        assertThat(message, containsString("DOCTYPE is disallowed"));
+        assertThat(message, containsString("DOCTYPE"));
     }
 
     @Test

--- a/src/wfs2_x/src/test/java/org/geoserver/wfs/v2_0/StoredQueryTest.java
+++ b/src/wfs2_x/src/test/java/org/geoserver/wfs/v2_0/StoredQueryTest.java
@@ -571,7 +571,7 @@ public class StoredQueryTest extends WFS20TestSupport {
                 + "</wfs:CreateStoredQuery>";
         Document dom = postAsDOM("wfs", xml);
         String message = checkOws11Exception(dom, "2.0.0", "OperationProcessingFailed", "CreateStoredQuery");
-        assertThat(message, containsString("DOCTYPE is disallowed"));
+        assertThat(message, containsString("DOCTYPE"));
     }
 
     @Test

--- a/src/wms1_1/src/test/java/org/geoserver/sld/SLDXmlRequestReaderTest.java
+++ b/src/wms1_1/src/test/java/org/geoserver/sld/SLDXmlRequestReaderTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -18,6 +19,7 @@ import org.geoserver.wms.WMSTestSupport;
 import org.geotools.util.logging.Logging;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.w3c.dom.Document;
 
 /** Test suite for {@link SLDXmlRequestReader} */
 public class SLDXmlRequestReaderTest extends WMSTestSupport {
@@ -67,6 +69,7 @@ public class SLDXmlRequestReaderTest extends WMSTestSupport {
         MockHttpServletResponse response = super.postAsServletResponse(path, body);
         assertEquals(200, response.getStatus());
         super.assertContentType("application/vnd.ogc.se_xml", response);
-        assertThat("DOCTYPE is disallowed", response.getContentAsString(), containsString("DOCTYPE"));
+        Document dom = dom(new ByteArrayInputStream(response.getContentAsByteArray()));
+        assertThat(checkLegacyException(dom, null, null), containsString("DOCTYPE"));
     }
 }

--- a/src/wms1_1/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
+++ b/src/wms1_1/src/test/java/org/geoserver/wms/wms_1_1_1/GetLegendGraphicTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -424,10 +425,10 @@ public class GetLegendGraphicTest extends WMSTestSupport {
                         + "&SLD_BODY=";
         String sld = IOUtils.toString(TestData.class.getResource("externalEntities.sld"), StandardCharsets.UTF_8);
         MockHttpServletResponse response = getAsServletResponse(base + URLEncoder.encode(sld, UTF_8.name()));
-        // should fail with an error message pointing at entity resolution
+        // should fail with a WMS ServiceException pointing at entity resolution
         assertEquals("application/vnd.ogc.se_xml", getBaseMimeType(response.getContentType()));
-        final String content = response.getContentAsString();
-        assertThat(content, containsString("DOCTYPE is disallowed"));
+        Document dom = dom(new ByteArrayInputStream(response.getContentAsByteArray()));
+        assertThat(checkLegacyException(dom, null, null), containsString("DOCTYPE"));
     }
 
     @Test


### PR DESCRIPTION
There are some test failures in italian locale, I've tried to adapt the test with these principles:
* Check the output is a service exception
* Parse the message out of it
* Check it contains what looks like the stable portion of the error message
 
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.