### PR TITLE
[GEOS-12127] Remove noop sync context override from CI workflows (backport 2.28.x)

### DIFF
--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.8
+        maven-version: 3.9.16
     - name: Maven repository caching
       uses: actions/cache@v5
       with:

--- a/.github/workflows/cite.yml
+++ b/.github/workflows/cite.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
-          maven-version: 3.9.8
+          maven-version: 3.9.16
       - name: Maven repository caching
         uses: actions/cache@v5
         with:
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
-          maven-version: 3.9.8
+          maven-version: 3.9.16
 
       - name: Download geoserver.war artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.8
+        maven-version: 3.9.16
     - name: Setup python for docs
       uses: actions/setup-python@v6
       with:
@@ -58,7 +58,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.8
+        maven-version: 3.9.16
     - name: Setup python for docs
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.8
+        maven-version: 3.9.16
     - name: Maven repository caching
       uses: actions/cache@v5
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Daether.syncContext.named.time=120 -Daether.syncContext.named.factory=file-lock -Daether.syncContext.named.nameMapper=file-gav -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Daether.syncContext.named.time=120 -Daether.syncContext.named.time.unit=SECONDS -Daether.syncContext.named.factory=noop
+  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true
 
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.8
+        maven-version: 3.9.16
     - name: Maven repository caching
       uses: actions/cache@v5
       with:

--- a/.github/workflows/linux_locales.yml
+++ b/.github/workflows/linux_locales.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.8
+        maven-version: 3.9.16
     - name: Maven repository caching
       uses: actions/cache@v5
       with:

--- a/.github/workflows/linux_locales.yml
+++ b/.github/workflows/linux_locales.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Daether.syncContext.named.time=120 -Daether.syncContext.named.factory=file-lock -Daether.syncContext.named.nameMapper=file-gav -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Daether.syncContext.named.time=120 -Daether.syncContext.named.time.unit=SECONDS -Daether.syncContext.named.factory=noop
+  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Daether.syncContext.named.time=120 -Daether.syncContext.named.factory=file-lock -Daether.syncContext.named.nameMapper=file-gav -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Daether.syncContext.named.time=120 -Daether.syncContext.named.time.unit=SECONDS  -Daether.syncContext.named.factory=noop
+  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.8
+        maven-version: 3.9.16
     - name: Maven repository caching
       uses: actions/cache@v5
       with:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.8
+        maven-version: 3.9.16
     - name: Maven repository caching
       uses: actions/cache@v5
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Daether.syncContext.named.time=120 -Daether.syncContext.named.factory=file-lock -Daether.syncContext.named.nameMapper=file-gav -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Daether.syncContext.named.time=120 -Daether.syncContext.named.time.unit=SECONDS  -Daether.syncContext.named.factory=noop
+  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.8
+        maven-version: 3.9.16
     - name: Maven repository caching
       uses: actions/cache@v5
       with:


### PR DESCRIPTION
[![GEOS-12127](https://badgen.net/badge/JIRA/GEOS-12127/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12127) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Backport of #9556 to 2.28.x branch.

Cherry-picked commits:
- e1f54f3 — Remove dangerous noop sync context from CI workflows
- 9491e8a — Upgrade Maven from 3.9.8 to 3.9.16 in CI workflows

Conflict resolution:
- `linux_timezone.yml` and `acceptance.yml` don't exist on 2.28.x — removed from cherry-pick
- Bumped `docs.yml` Maven version to 3.9.16 as well (not in original commit scope but consistent)

See original PR for full context: https://github.com/geoserver/geoserver/pull/9556 