### PR TITLE
[GEOS-12127] Fix flaky GWCIntegrationTest cache assertion (backport to 2.28.x)

### DIFF
--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -606,6 +606,10 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
 
         final TileLayer tileLayer = gwc.getTileLayerByName(qualifiedName);
         assertNotNull(tileLayer);
+
+        // Ensure clean cache state regardless of test execution order
+        gwc.truncate(qualifiedName);
+
         boolean directWMSIntegrationEndpoint = true;
         String request = TEST_WORKSPACE_NAME
                 + "/"


### PR DESCRIPTION
[![GEOS-12127](https://badgen.net/badge/JIRA/GEOS-12127/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12127) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Backport of #9541 to 2.28.x

The test testDirectWMSIntegrationWithVirtualServicesAndWorkspacedStyle asserted MISS on the first request, but the GWC in-memory blob store retains cached tiles across test methods. The @Before wipes data directory files but not the in-memory cache.

Fix: truncate the specific layer's cache before issuing requests, ensuring the test always starts with a clean cache state regardless of test execution order. The original MISS assertion is preserved. 