### PR TITLE
[GEOS-12139] GSIP 241 - GeoWebCache Security-Aware Tile Caching

### DIFF
--- a/doc/en/user/geowebcache/config.md
+++ b/doc/en/user/geowebcache/config.md
@@ -51,6 +51,49 @@ For stability reasons, it is not recommended to use the embedded GeoWebCache wit
 
 GWC Data Security is an option that can be turned on and turned off through the [Caching defaults](webadmin/defaults.md) page. By default it is turned off.
 
-When turned on, the embedded GWC will do a data security check before calling GeoWebCache, i.e. verify whether the user actually has access to the layer, and reject the request if this is not the case. In the case of WMS-C requests, there is also limited support for data access limit filters, only with respect to geographic boundaries (all other types of data access limits will be ignored). The embedded GWC will reject requests for which the requested bounding box is (partly) inaccessible. It is only possible to request a tile within a bounding box that is fully accessible. This behaviour is different from the regular WMS, which will filter the data before serving it. However, if the integrated WMS/WMS-C is used, the request will be forwarded back to WMS and give the desired result.
+When turned on, the embedded GWC enforces GeoServer data security on every tile request:
 
-When using the default GeoServer security system, rules cannot combine data security with service security. However, when using a security subsystem it may be possible to make such particular combinations. In this case the WMS-C service inherits all security rules from the regular WMS service; while all other GWC services will get their security from rules associated with the 'GWC' service itself.
+- **Layer access**: users without access to a layer receive a "layer not found" error (HIDE mode) or an authentication challenge (CHALLENGE mode), consistent with regular WMS behavior.
+
+- **Spatial access limits**: when a user's access is restricted to a geographic area, tiles outside that area are rendered as empty transparent tiles rather than being rejected with an error. This is consistent with the regular WMS, which filters data before serving it.
+
+- **Security-aware tile caching**: when a user has data access restrictions (filters, geometry clips), GeoWebCache caches their tiles separately from unrestricted users and from users with different restrictions. The separation is based on the *access profile* (the actual restriction rules), not on the user identity. Two users with identical restrictions share the same cached tiles; users with different restrictions get independent cache entries.
+
+The tile cache separation is implemented by injecting a synthetic `ACCESS_LIMITS_KEY` parameter into the tile request before it reaches the cache. The value is a compact JSON object encoding the active access restrictions. For example, a user restricted to features where `NAME = 'Blue Lake'` would carry:
+
+  ```
+  ACCESS_LIMITS_KEY={"readFilter":"NAME = 'Blue Lake'"}
+  ```
+
+A user clipped to a raster region in Australia would carry:
+
+  ```
+  ACCESS_LIMITS_KEY={"rasterFilter":"MULTIPOLYGON (((140 -50, 150 -50, 150 -30, 140 -30, 140 -50)))"}
+  ```
+
+Unrestricted users have no `ACCESS_LIMITS_KEY` in their tile parameters and continue to use the shared default cache. GWC hashes all tile parameters into the `parametersId` used to locate tiles in the cache storage, so tiles with different `ACCESS_LIMITS_KEY` values are stored at different cache paths even if they cover the same bounding box.
+
+When access restrictions involve complex geometries or long filter expressions, the `ACCESS_LIMITS_KEY` value can become large. GeoWebCache limits it to **64 KB** by default. If the serialized key exceeds this limit, individual field values are truncated (longest first) until the total fits. Each truncated value is replaced with a visible prefix followed by `...too long, sha is <sha256hex>`, where the SHA-256 is computed from the full original value. The limit can be overridden with the system property `gwc.security.maxKeyLength` (value in characters).
+
+!!! note
+    The `ACCESS_LIMITS_KEY` parameter is injected at runtime and is **never written** to the gwc-layers XML configuration files (`<data_dir>/gwc-layers/`). It will not appear there when inspecting layer configuration. To observe it however one can check out the property files collecting the filter parameter values for the various tile caches, found in each tile layer folder.
+
+### Security tags and targeted invalidation
+
+When access rules change, the tiles cached under the old restrictions become stale. The [disk quota](webadmin/diskquotas.md) eventually reclaims them, but a security subsystem can also trigger immediate invalidation of just the affected tiles.
+
+To make that targeted, GeoWebCache injects a second synthetic parameter, `SECURITY_TAGS_KEY`, alongside `ACCESS_LIMITS_KEY` whenever the access manager attaches *security tags* to the computed restrictions. The value is a comma-separated, sorted list of opaque tags (for example rule identifiers or role names) describing which security rules shaped the restriction:
+
+  ```
+  SECURITY_TAGS_KEY=role:planner,rule:42
+  ```
+
+`SECURITY_TAGS_KEY` is only present when `ACCESS_LIMITS_KEY` is also present (tags without a restriction are meaningless), and like it is injected at runtime, not persisted.
+
+When the security subsystem signals that a rule changed, GeoWebCache drops the cached tiles associated to the modified security tags, leaving unrelated security-keyed tiles intact. Access managers that do not attach tags fall back to dropping all security-keyed tiles for the affected layers. Tiles without an `ACCESS_LIMITS_KEY` (unrestricted access) are never touched. Layer-group tiles are dropped too when one of their member layers is affected.
+
+At the time of writing **no security subsystem ships an implementation that drives this eager removal**: stale tiles are reclaimed by disk quota until one does. Current or third-party access managers can choose to eagerly drop tiles; check their documentation to confirm.
+
+!!! note
+    This invalidation works only in a live, user-driven deployment where security changes flow through the running instance. Changes applied out of band (database restore, bulk imports, environment promotion) produce no invalidation; disk quota remains the cleanup mechanism in those cases. In a clustered deployment with per-node local disk caches, an invalidation reaches only the node that received it; a shared blob store (S3, Azure, NFS) does not have this limitation.
+

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -79,10 +79,7 @@ import org.geoserver.platform.GeoServerEnvironment;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.Operation;
 import org.geoserver.security.AccessLimits;
-import org.geoserver.security.CoverageAccessLimits;
 import org.geoserver.security.DataAccessLimits;
-import org.geoserver.security.WMSAccessLimits;
-import org.geoserver.security.WrapperPolicy;
 import org.geoserver.security.decorators.SecuredLayerInfo;
 import org.geoserver.threadlocals.ThreadLocalsTransfer;
 import org.geoserver.util.HTTPWarningAppender;
@@ -102,7 +99,6 @@ import org.geotools.api.referencing.NoSuchAuthorityCodeException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.MathTransform;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.filter.visitor.ExtractBoundsFilterVisitor;
 import org.geotools.geometry.GeneralBounds;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -2146,64 +2142,19 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         if (layerInfos == null || layerInfos.isEmpty()) {
             throw new ServiceException("Could not find layer " + layerName, "LayerNotDefined");
         }
-        if (boundingBox != null) {
-            for (LayerInfo layerInfo : layerInfos) {
-                // Unwrap potential proxy instances, so the instanceof SecuredLayerInfo check works.
-                if (layerInfo instanceof Proxy) {
-                    layerInfo = ProxyUtils.unwrap(
-                            layerInfo, Proxy.getInvocationHandler(layerInfo).getClass());
-                }
-
-                if (layerInfo instanceof SecuredLayerInfo securedLayerInfo) {
-                    // test layer bbox limits
-                    WrapperPolicy policy = securedLayerInfo.getWrapperPolicy();
-                    AccessLimits limits = policy.getLimits();
-
-                    if (limits instanceof DataAccessLimits accessLimits1) {
-                        // ensure we are all using the same CRS
-                        CoordinateReferenceSystem dataCrs =
-                                layerInfo.getResource().getCRS();
-                        if (boundingBox.getCoordinateReferenceSystem() != null
-                                && !CRS.equalsIgnoreMetadata(dataCrs, boundingBox.getCoordinateReferenceSystem())) {
-                            try {
-                                boundingBox = boundingBox.transform(dataCrs, true);
-                            } catch (Exception e) {
-                                // bboxes not compatible? deny access for all certainty.
-                                boundingBox = null;
-                            }
-                        }
-                        Envelope limitBox = new ReferencedEnvelope(ReferencedEnvelope.EVERYTHING, dataCrs);
-
-                        Filter filter = accessLimits1.getReadFilter();
-                        if (filter != null) {
-                            // extract filter envelope from filter
-                            Envelope box = (Envelope) filter.accept(ExtractBoundsFilterVisitor.BOUNDS_VISITOR, null);
-                            if (box != null) {
-                                limitBox = new ReferencedEnvelope(limitBox.intersection(box), dataCrs);
-                            }
-                        }
-                        if (limits instanceof CoverageAccessLimits accessLimits) {
-                            if (accessLimits.getRasterFilter() != null) {
-                                Envelope box = accessLimits.getRasterFilter().getEnvelopeInternal();
-                                if (box != null) {
-                                    limitBox = new ReferencedEnvelope(limitBox.intersection(box), dataCrs);
-                                }
-                            }
-                        }
-                        if (limits instanceof WMSAccessLimits accessLimits) {
-                            if (accessLimits.getRasterFilter() != null) {
-                                Envelope box = accessLimits.getRasterFilter().getEnvelopeInternal();
-                                if (box != null) {
-                                    limitBox = new ReferencedEnvelope(limitBox.intersection(box), dataCrs);
-                                }
-                            }
-                        }
-
-                        if (!limitBox.covers(ReferencedEnvelope.EVERYTHING)
-                                && (boundingBox == null || !limitBox.contains(boundingBox))) {
-                            throw new SecurityException("Access denied to bounding box on layer " + layerName);
-                        }
-                    }
+        // HIDE+EXCLUDE layers are already gone: secured catalog returns null above.
+        // For non-HIDE modes (e.g. CHALLENGE), still deny if readFilter is EXCLUDE; any other
+        // filter is a spatial/attribute restriction that the rendering pipeline handles by producing
+        // empty tiles - no need for a bbox check here.
+        for (LayerInfo layerInfo : layerInfos) {
+            if (layerInfo instanceof Proxy) {
+                layerInfo = ProxyUtils.unwrap(
+                        layerInfo, Proxy.getInvocationHandler(layerInfo).getClass());
+            }
+            if (layerInfo instanceof SecuredLayerInfo securedLayerInfo) {
+                AccessLimits limits = securedLayerInfo.getWrapperPolicy().getLimits();
+                if (limits instanceof DataAccessLimits dal && Filter.EXCLUDE.equals(dal.getReadFilter())) {
+                    throw new SecurityException("Access denied to layer " + layerName);
                 }
             }
         }

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -8,6 +8,8 @@ package org.geoserver.gwc.layer;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static org.geoserver.gwc.security.SecurityParameterFilter.ACCESS_LIMITS_KEY;
+import static org.geoserver.gwc.security.SecurityParameterFilter.SECURITY_TAGS_KEY;
 import static org.geoserver.ows.util.ResponseUtils.buildURL;
 import static org.geoserver.ows.util.ResponseUtils.params;
 
@@ -31,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -57,12 +60,17 @@ import org.geoserver.config.GeoServer;
 import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.dispatch.GwcServiceDispatcherCallback;
+import org.geoserver.gwc.security.AccessLimitsKeyBuilder;
+import org.geoserver.gwc.security.SecurityParameterFilter;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.LocalWorkspace;
 import org.geoserver.ows.Request;
 import org.geoserver.ows.URLMangler;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.rest.RequestInfo;
+import org.geoserver.security.AccessLimits;
+import org.geoserver.security.ResourceAccessManager;
+import org.geoserver.security.SecureCatalogImpl;
 import org.geoserver.util.DimensionWarning;
 import org.geoserver.util.HTTPWarningAppender;
 import org.geoserver.wms.GetLegendGraphicRequest;
@@ -123,6 +131,8 @@ import org.geowebcache.util.GWCVars;
 import org.geowebcache.util.ServletUtils;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.vfny.geoserver.util.ResponseUtils;
 
 /** GeoServer {@link TileLayer} implementation. Delegates to {@link GeoServerTileLayerInfo} for layer configuration. */
@@ -137,6 +147,10 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer, TileJSO
 
     public static final ThreadLocal<WebMap> WEB_MAP = new ThreadLocal<>();
     public static final ThreadLocal<Set<DimensionWarning>> DIMENSION_WARNINGS = new ThreadLocal<>();
+
+    // synthetic, stateless filters for tiling security integration (constant to avoid repeated allocation)
+    private static final SecurityParameterFilter ACCESS_LIMITS_FILTER = new SecurityParameterFilter(ACCESS_LIMITS_KEY);
+    private static final SecurityParameterFilter SECURITY_TAGS_FILTER = new SecurityParameterFilter(SECURITY_TAGS_KEY);
 
     private String configErrorMessage;
 
@@ -281,13 +295,119 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer, TileJSO
         return configErrorMessage;
     }
 
-    @Override
-    public List<ParameterFilter> getParameterFilters() {
-        return new ArrayList<>(info.getParameterFilters());
+    private static boolean isSecurityEnabled() {
+        return GWC.get().getConfig().isSecurityEnabled();
     }
 
+    @Override
+    public List<ParameterFilter> getParameterFilters() {
+        List<ParameterFilter> filters = new ArrayList<>(info.getParameterFilters());
+        if (isSecurityEnabled()) {
+            if (filters.stream().noneMatch(f -> ACCESS_LIMITS_KEY.equals(f.getKey()))) {
+                filters.add(ACCESS_LIMITS_FILTER);
+            }
+            if (filters.stream().noneMatch(f -> SECURITY_TAGS_KEY.equals(f.getKey()))) {
+                filters.add(SECURITY_TAGS_FILTER);
+            }
+        }
+        return filters;
+    }
+
+    @Override
+    public Map<String, String> getModifiableParameters(Map<String, ?> map, String encoding)
+            throws GeoWebCacheException {
+        if (!isSecurityEnabled()) {
+            return super.getModifiableParameters(map, encoding);
+        }
+        // never let a client-supplied security parameter influence the cache key; GWC matches filter
+        // keys case-insensitively, so a forged "access_limits_key" would survive a case-sensitive removal
+        Map<String, Object> sanitized = new HashMap<>();
+        for (Map.Entry<String, ?> e : map.entrySet()) {
+            String k = e.getKey();
+            if (!ACCESS_LIMITS_KEY.equalsIgnoreCase(k) && !SECURITY_TAGS_KEY.equalsIgnoreCase(k)) {
+                sanitized.put(k, e.getValue());
+            }
+        }
+
+        SecurityKey security = computeSecurityKey(getPublishedInfo());
+        if (security != null) {
+            sanitized.put(ACCESS_LIMITS_KEY, security.key());
+            if (security.tags() != null) {
+                sanitized.put(SECURITY_TAGS_KEY, security.tags());
+            }
+        }
+        Map<String, String> result = super.getModifiableParameters(sanitized, encoding);
+        // when unrestricted, strip security params to preserve the pre-existing parametersId
+        if (security == null && !result.isEmpty()) {
+            Map<String, String> clean = new HashMap<>(result);
+            boolean changed = clean.remove(ACCESS_LIMITS_KEY) != null;
+            changed |= clean.remove(SECURITY_TAGS_KEY) != null;
+            if (changed) return clean.isEmpty() ? Collections.emptyMap() : clean;
+        }
+        return result;
+    }
+
+    private record SecurityKey(String key, String tags) {}
+
+    /**
+     * Returns the security cache key and tags for the current user and the given layer or group, or {@code null} for
+     * unrestricted access or when the security infrastructure is unavailable.
+     */
+    private static SecurityKey computeSecurityKey(PublishedInfo published) {
+        AccessLimitsKeyBuilder keyBuilder = GeoServerExtensions.bean(AccessLimitsKeyBuilder.class);
+        SecureCatalogImpl secureCatalog = GeoServerExtensions.bean(SecureCatalogImpl.class);
+        if (keyBuilder == null || secureCatalog == null) {
+            // security infrastructure absent: fall back to the unrestricted cache, but leave a trace - this
+            // silently serves every user from the same cache entry, an easy misconfiguration to miss
+            LOGGER.fine(() -> "GWC security: no cache key computed for " + published.prefixedName()
+                    + ", AccessLimitsKeyBuilder/SecureCatalogImpl bean missing");
+            return null;
+        }
+        ResourceAccessManager ram = secureCatalog.getResourceAccessManager();
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        String key;
+        String tags;
+        if (published instanceof LayerInfo layer) {
+            AccessLimits limits = ram.getAccessLimits(auth, layer);
+            key = keyBuilder.buildKey(limits);
+            tags = tagsFrom(limits);
+        } else if (published instanceof LayerGroupInfo group) {
+            List<LayerInfo> layers = group.layers();
+            List<String> names = layers.stream().map(LayerInfo::prefixedName).toList();
+            List<AccessLimits> limits = layers.stream()
+                    .map(l -> (AccessLimits) ram.getAccessLimits(auth, l))
+                    .toList();
+            key = keyBuilder.buildLayerGroupKey(names, limits);
+            Set<String> allTags = new TreeSet<>();
+            limits.forEach(l -> collectTags(l, allTags));
+            tags = allTags.isEmpty() ? null : String.join(",", allTags);
+        } else {
+            return null;
+        }
+        // tags are only meaningful alongside a key (used for targeted invalidation of restricted caches);
+        // a null key means unrestricted, so the request hits the normal cache and tags are irrelevant
+        if (key == null) return null;
+        if (key.isEmpty()) {
+            throw new IllegalStateException("AccessLimitsKeyBuilder returned an empty security key");
+        }
+        return new SecurityKey(key, tags);
+    }
+
+    private static String tagsFrom(AccessLimits limits) {
+        Set<String> tags = new TreeSet<>();
+        collectTags(limits, tags);
+        return tags.isEmpty() ? null : String.join(",", tags);
+    }
+
+    private static void collectTags(AccessLimits limits, Set<String> out) {
+        // tags are validated comma-free at the API boundary (AccessLimits.setSecurityTags)
+        if (limits != null && limits.getSecurityTags() != null) out.addAll(limits.getSecurityTags());
+    }
+
+    /** Reset parameter filter values to their defaults ({@code null}) */
     public void resetParameterFilters() {
-        super.defaultParameterFilterValues = null; // reset default values
+        super.defaultParameterFilterValues = null;
     }
 
     /**

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.KeywordInfo;
+import org.geoserver.catalog.LayerGroupHelper;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.MetadataLinkInfo;
@@ -373,11 +374,15 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer, TileJSO
             key = keyBuilder.buildKey(limits);
             tags = tagsFrom(limits);
         } else if (published instanceof LayerGroupInfo group) {
-            List<LayerInfo> layers = group.layers();
-            List<String> names = layers.stream().map(LayerInfo::prefixedName).toList();
-            List<AccessLimits> limits = layers.stream()
-                    .map(l -> (AccessLimits) ram.getAccessLimits(auth, l))
-                    .toList();
+            // member limits can depend on the containing group (see ResourceAccessManager direct vs group
+            // access), so compute each rendered leaf's limits with its chain of containing groups rather than
+            // treating members as directly accessed; LayerGroupHelper drives the mode-correct traversal
+            List<String> names = new ArrayList<>();
+            List<AccessLimits> limits = new ArrayList<>();
+            new LayerGroupHelper(group).allLayersForRendering((layer, containers) -> {
+                names.add(layer.prefixedName());
+                limits.add(ram.getAccessLimits(auth, layer, containers));
+            });
             key = keyBuilder.buildLayerGroupKey(names, limits);
             Set<String> allTags = new TreeSet<>();
             limits.forEach(l -> collectTags(l, allTags));

--- a/src/gwc/src/main/java/org/geoserver/gwc/security/AccessLimitsKeyBuilder.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/security/AccessLimitsKeyBuilder.java
@@ -1,0 +1,358 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.geoserver.catalog.ResourcePool;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.AccessLimits;
+import org.geoserver.security.CoverageAccessLimits;
+import org.geoserver.security.DataAccessLimits;
+import org.geoserver.security.VectorAccessLimits;
+import org.geoserver.security.WMSAccessLimits;
+import org.geoserver.security.WMTSAccessLimits;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.api.parameter.GeneralParameterValue;
+import org.geotools.api.parameter.ParameterValue;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.util.Range;
+import org.locationtech.jts.geom.Geometry;
+import org.springframework.beans.factory.InitializingBean;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Builds a stable, human-readable JSON cache key from an {@link AccessLimits}, or {@code null} when the limits impose
+ * no content restriction. Never returns an empty string: callers rely on {@code null} vs non-null to tell unrestricted
+ * from restricted.
+ *
+ * <p>Raster read parameter values are serialized by type. Custom {@link ParameterValueKeySerializer} beans are
+ * consulted first and take priority over the built-in handling in {@link #serializeValue}; duplicate registrations for
+ * one value type fail at startup. A parameter that is neither {@link IgnorableParameterRegistry ignorable} nor
+ * serializable fails the build with a message naming the descriptor.
+ *
+ * <p>Keys over {@value #DEFAULT_MAX_KEY_LENGTH} characters (override via the {@value #MAX_KEY_LENGTH_PROPERTY} system
+ * property) are trimmed by truncating the longest field values first, each replaced with its prefix followed by
+ * {@code "...too long, sha is <sha256hex>"}. This keeps every field visible in the stored property file while bounding
+ * total size.
+ */
+public class AccessLimitsKeyBuilder implements InitializingBean {
+
+    static final String MAX_KEY_LENGTH_PROPERTY = "gwc.security.maxKeyLength";
+    static final int DEFAULT_MAX_KEY_LENGTH = 65536;
+
+    private static final String TRUNCATION_SUFFIX = "...too long, sha is ";
+    // TRUNCATION_SUFFIX (20) + sha256 hex (64)
+    private static final int SUFFIX_FIXED_LENGTH = TRUNCATION_SUFFIX.length() + 64;
+    // minimum chars of the original value kept visible after truncation
+    private static final int MIN_FIELD_PREFIX = 50;
+
+    private static final JsonMapper MAPPER = new JsonMapper();
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern(
+                    "yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.ROOT)
+            .withZone(ZoneOffset.UTC);
+
+    private List<ParameterValueKeySerializer<?>> custom;
+    private final IgnorableParameterRegistry ignorable;
+    private final int maxKeyLength;
+
+    /** Spring constructor - custom serializers collected from context in {@link #afterPropertiesSet()}. */
+    public AccessLimitsKeyBuilder(IgnorableParameterRegistry ignorable) {
+        this(List.of(), ignorable, Integer.getInteger(MAX_KEY_LENGTH_PROPERTY, DEFAULT_MAX_KEY_LENGTH));
+    }
+
+    /** Test constructor - custom serializers supplied directly; {@link #afterPropertiesSet()} not called. */
+    public AccessLimitsKeyBuilder(List<ParameterValueKeySerializer<?>> custom, IgnorableParameterRegistry ignorable) {
+        this(custom, ignorable, Integer.getInteger(MAX_KEY_LENGTH_PROPERTY, DEFAULT_MAX_KEY_LENGTH));
+    }
+
+    AccessLimitsKeyBuilder(
+            List<ParameterValueKeySerializer<?>> customSerializers,
+            IgnorableParameterRegistry ignorable,
+            int maxKeyLength) {
+        checkNoDuplicates(customSerializers);
+        this.custom = List.copyOf(customSerializers);
+        this.ignorable = ignorable;
+        this.maxKeyLength = maxKeyLength;
+    }
+
+    /** Collects all {@link ParameterValueKeySerializer} beans from the Spring context. Fails on duplicates. */
+    @Override
+    public void afterPropertiesSet() {
+        @SuppressWarnings("rawtypes")
+        List<ParameterValueKeySerializer> discovered =
+                GeoServerExtensions.extensions(ParameterValueKeySerializer.class);
+        @SuppressWarnings("unchecked")
+        List<ParameterValueKeySerializer<?>> cast = (List<ParameterValueKeySerializer<?>>) (List<?>) discovered;
+        checkNoDuplicates(cast);
+        this.custom = List.copyOf(cast);
+    }
+
+    private static void checkNoDuplicates(List<ParameterValueKeySerializer<?>> serializers) {
+        Map<Class<?>, String> seen = new LinkedHashMap<>();
+        for (ParameterValueKeySerializer<?> s : serializers) {
+            String prev = seen.put(s.getValueType(), s.getClass().getName());
+            if (prev != null) {
+                throw new IllegalStateException(errorDuplicateSerializer(s.getValueType(), prev, s.getClass()));
+            }
+        }
+    }
+
+    /** Cache key for a single layer, or {@code null} for unrestricted access. */
+    public String buildKey(AccessLimits limits) {
+        ObjectNode node = buildKeyNode(limits);
+        if (node == null || node.isEmpty()) return null;
+        return buildAndLimit(node);
+    }
+
+    private ObjectNode buildKeyNode(AccessLimits limits) {
+        if (limits == null) return null;
+        if (limits instanceof VectorAccessLimits val) return buildVectorNode(val);
+        if (limits instanceof CoverageAccessLimits cal) return buildCoverageNode(cal);
+        // WMS/WMTS limits also carry a raster ROI that clips tiles; must be keyed before the DataAccessLimits fallback
+        if (limits instanceof WMSAccessLimits wms)
+            return buildRasterDataNode(wms.getReadFilter(), wms.getRasterFilter());
+        if (limits instanceof WMTSAccessLimits wmts)
+            return buildRasterDataNode(wmts.getReadFilter(), wmts.getRasterFilter());
+        if (limits instanceof DataAccessLimits dal) return buildDataNode(dal);
+        return null; // base AccessLimits has no tile content affecting fields
+    }
+
+    private ObjectNode buildRasterDataNode(Filter readFilter, Geometry rasterFilter) {
+        ObjectNode node = MAPPER.createObjectNode();
+        addReadFilter(node, readFilter);
+        addGeometry(node, "rasterFilter", rasterFilter);
+        return node;
+    }
+
+    private ObjectNode buildVectorNode(VectorAccessLimits limits) {
+        ObjectNode node = MAPPER.createObjectNode();
+        addReadFilter(node, limits.getReadFilter());
+        List<PropertyName> attrs = limits.getReadAttributes();
+        if (attrs != null && !attrs.isEmpty()) {
+            node.put(
+                    "readAttributes",
+                    attrs.stream().map(PropertyName::getPropertyName).sorted().collect(Collectors.joining(",")));
+        }
+        addGeometry(node, "clipVectorFilter", limits.getClipVectorFilter());
+        addGeometry(node, "intersectVectorFilter", limits.getIntersectVectorFilter());
+        return node;
+    }
+
+    private void addReadFilter(ObjectNode node, Filter filter) {
+        if (filter != null && !Filter.INCLUDE.equals(filter)) {
+            node.put("readFilter", serializeValue("readFilter", filter));
+        }
+    }
+
+    private void addGeometry(ObjectNode node, String field, Geometry geom) {
+        if (geom != null) {
+            node.put(field, serializeValue(field, geom));
+        }
+    }
+
+    private ObjectNode buildCoverageNode(CoverageAccessLimits limits) {
+        ObjectNode node = MAPPER.createObjectNode();
+        addReadFilter(node, limits.getReadFilter());
+        addGeometry(node, "rasterFilter", limits.getRasterFilter());
+        GeneralParameterValue[] params = limits.getParams();
+        if (params != null) {
+            for (GeneralParameterValue gpv : params) {
+                if (ignorable.isIgnorable(gpv)) continue;
+                String code = gpv.getDescriptor().getName().getCode();
+                if (!(gpv instanceof ParameterValue<?> pv)) {
+                    throw new IllegalArgumentException(errorUnknownParam(code, gpv));
+                }
+                Object value = pv.getValue();
+                if (value == null) continue;
+                node.put(code, serializeValue(code, value));
+            }
+        }
+        return node;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String serializeValue(String paramName, Object value) {
+        // List and Range recurse into this method, so they can't be ParameterValueKeySerializer instances
+        if (value instanceof List<?> list) {
+            return list.stream()
+                    .filter(Objects::nonNull)
+                    .map(e -> serializeValue(paramName, e))
+                    .sorted()
+                    .collect(Collectors.joining(","));
+        }
+        if (value instanceof Range<?> range) {
+            String min = range.getMinValue() != null ? serializeValue(paramName, range.getMinValue()) : "*";
+            String max = range.getMaxValue() != null ? serializeValue(paramName, range.getMaxValue()) : "*";
+            return min + "/" + max;
+        }
+        // custom serializers take priority over the built-in types below
+        for (ParameterValueKeySerializer<?> s : custom) {
+            if (s.getValueType().isAssignableFrom(value.getClass())) {
+                return ((ParameterValueKeySerializer<Object>) s).toKey(value);
+            }
+        }
+        if (value instanceof Filter filter) return serializeFilter(filter);
+        if (value instanceof Geometry geom) return serializeGeometry(geom);
+        if (value instanceof Date date) return DATE_FORMAT.format(date.toInstant());
+        if (value instanceof Number || value instanceof Boolean || value instanceof String) {
+            return value.toString();
+        }
+        throw new IllegalArgumentException(errorUnknownValue(paramName, value));
+    }
+
+    // new visitor per call: SimplifyingFilterVisitor has mutable state
+    static String serializeFilter(Filter filter) {
+        return ECQL.toCQL((Filter) filter.accept(new NormalizingFilterVisitor(), null));
+    }
+
+    // "AUTHORITY:CODE:WKT" when the CRS is known, plain WKT otherwise; CRS comes from the geometry user data
+    // (a CoordinateReferenceSystem) or its SRID
+    static String serializeGeometry(Geometry geom) {
+        String wkt = geom.norm().toText();
+        String crsCode = computeCrsCode(geom);
+        return crsCode != null ? crsCode + ":" + wkt : wkt;
+    }
+
+    private static String computeCrsCode(Geometry geom) {
+        Object userData = geom.getUserData();
+        if (userData instanceof CoordinateReferenceSystem crs) {
+            try {
+                // fullScan=false: avoid expensive authority factory scans on the tile request path
+                String id = ResourcePool.lookupIdentifier(crs, false);
+                if (id != null) return id;
+            } catch (FactoryException e) {
+                // fall through to SRID
+            }
+        }
+        int srid = geom.getSRID();
+        return srid > 0 ? "EPSG:" + srid : null;
+    }
+
+    private ObjectNode buildDataNode(DataAccessLimits limits) {
+        ObjectNode node = MAPPER.createObjectNode();
+        addReadFilter(node, limits.getReadFilter());
+        return node;
+    }
+
+    /**
+     * Composite key for a layer group; {@code layerNames} and {@code limits} must have the same size and be in
+     * composition order. {@code null} if no constituent is restricted.
+     */
+    public String buildLayerGroupKey(List<String> layerNames, List<AccessLimits> limits) {
+        if (layerNames.size() != limits.size()) {
+            throw new IllegalArgumentException("layerNames and limits must have the same size");
+        }
+        boolean anyRestricted = false;
+        ArrayNode array = MAPPER.createArrayNode();
+        for (int i = 0; i < layerNames.size(); i++) {
+            ObjectNode layerNode = buildKeyNode(limits.get(i));
+            // each entry always has "layer" first, then restriction fields (if any)
+            ObjectNode entry = MAPPER.createObjectNode();
+            entry.put("layer", layerNames.get(i));
+            if (layerNode != null && !layerNode.isEmpty()) {
+                anyRestricted = true;
+                for (String name : layerNode.propertyNames()) {
+                    entry.set(name, layerNode.get(name));
+                }
+            }
+            array.add(entry);
+        }
+        if (!anyRestricted) return null;
+        return buildAndLimit(array);
+    }
+
+    private String buildAndLimit(ObjectNode node) {
+        if (node.toString().length() <= maxKeyLength) return node.toString();
+        truncateLongestFields(List.of(node), node::toString);
+        return node.toString();
+    }
+
+    private String buildAndLimit(ArrayNode array) {
+        if (array.toString().length() <= maxKeyLength) return array.toString();
+        List<ObjectNode> entries = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            if (array.get(i) instanceof ObjectNode on) entries.add(on);
+        }
+        truncateLongestFields(entries, array::toString);
+        return array.toString();
+    }
+
+    private void truncateLongestFields(List<ObjectNode> nodes, Supplier<String> serialized) {
+        record Field(ObjectNode node, String name, String value) {}
+        List<Field> fields = new ArrayList<>();
+        for (ObjectNode n : nodes) {
+            for (String fname : n.propertyNames()) {
+                JsonNode v = n.get(fname);
+                if (v.isString()) fields.add(new Field(n, fname, v.stringValue()));
+            }
+        }
+        // longest value first - each truncation removes the most bytes
+        fields.sort(Comparator.comparingInt(f -> -f.value().length()));
+
+        for (Field f : fields) {
+            // measure the real serialized (JSON-escaped) length each step; estimating from raw value lengths
+            // mis-counts escaped chars and can leave the key over the limit
+            int current = serialized.get().length();
+            if (current <= maxKeyLength) break;
+            String orig = f.value();
+            int length = orig.length();
+            // truncation only helps if the result is shorter than the original
+            if (length <= MIN_FIELD_PREFIX + SUFFIX_FIXED_LENGTH) continue;
+            int excess = current - maxKeyLength;
+            // keep as much prefix as possible while achieving at least `excess` reduction;
+            // fall back to MIN_FIELD_PREFIX when the ideal prefix would be too small
+            int prefix = Math.max(MIN_FIELD_PREFIX, length - SUFFIX_FIXED_LENGTH - excess);
+            if (prefix + SUFFIX_FIXED_LENGTH >= length) continue; // no actual savings
+            f.node().put(f.name(), orig.substring(0, prefix) + TRUNCATION_SUFFIX + sha256hex(orig));
+        }
+    }
+
+    private static String sha256hex(String value) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    private static String errorDuplicateSerializer(Class<?> valueType, String first, Class<?> second) {
+        return "Duplicate ParameterValueKeySerializer for value type %s: %s and %s"
+                .formatted(valueType.getName(), first, second.getName());
+    }
+
+    private static String errorUnknownParam(String code, GeneralParameterValue gpv) {
+        return "Cannot build security cache key for parameter '%s': GeneralParameterValue type %s is not a ParameterValue and has no contributed serializer. Contribute a ParameterValueKeySerializer bean or add '%s' to the %s system property if it does not affect tile content."
+                .formatted(code, gpv.getClass().getName(), code, IgnorableParameterRegistry.SYSTEM_PROPERTY);
+    }
+
+    private static String errorUnknownValue(String paramName, Object value) {
+        return "Cannot build security cache key for parameter '%s': no ParameterValueKeySerializer found for value type %s. Contribute a ParameterValueKeySerializer bean or add '%s' to the %s system property if it does not affect tile content."
+                .formatted(
+                        paramName, value.getClass().getName(), paramName, IgnorableParameterRegistry.SYSTEM_PROPERTY);
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/security/IgnorableParameterRegistry.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/security/IgnorableParameterRegistry.java
@@ -1,0 +1,80 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+import org.geoserver.security.ResourceAccessManager;
+import org.geotools.api.parameter.GeneralParameterDescriptor;
+import org.geotools.api.parameter.GeneralParameterValue;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.gce.imagemosaic.ImageMosaicFormat;
+import org.geotools.util.logging.Logging;
+
+/**
+ * Tracks {@link GeneralParameterValue} descriptors that are safe to ignore when building a security cache key - i.e.
+ * parameters that do not affect tile content.
+ *
+ * <p>Three registration mechanisms, checked in order:
+ *
+ * <ol>
+ *   <li>Built-in descriptors, see ({@link IgnorableParameterRegistry#BUILT_INS}
+ *   <li>Programmatic registration via {@link #registerIgnorable(GeneralParameterDescriptor)}
+ *   <li>System property {@value #SYSTEM_PROPERTY} (comma-separated descriptor codes) - operator last resort when the
+ *       {@link ResourceAccessManager} cannot be modified.
+ * </ol>
+ */
+public class IgnorableParameterRegistry {
+
+    static final String SYSTEM_PROPERTY = "gwc.security.params.ignorable";
+
+    private static final Logger LOGGER = Logging.getLogger(IgnorableParameterRegistry.class);
+
+    // common well-known ignorable parameters
+    private static final Set<GeneralParameterDescriptor> BUILT_INS = Set.of(
+            AbstractGridFormat.USE_IMAGEN_IMAGEREAD,
+            ImageMosaicFormat.ALLOW_MULTITHREADING,
+            ImageMosaicFormat.MAX_ALLOWED_TILES,
+            AbstractGridFormat.SUGGESTED_TILE_SIZE);
+
+    private final Set<GeneralParameterDescriptor> contributed = ConcurrentHashMap.newKeySet();
+    private final Set<String> extraNames;
+
+    public IgnorableParameterRegistry() {
+        String extra = System.getProperty(SYSTEM_PROPERTY);
+        if (extra != null) {
+            Set<String> names = new TreeSet<>();
+            for (String name : extra.split("\\s*,\\s*")) {
+                if (!name.isEmpty()) {
+                    names.add(name);
+                    LOGGER.config("GWC security: treating parameter '" + name + "' as ignorable (via " + SYSTEM_PROPERTY
+                            + ")");
+                }
+            }
+            extraNames = Collections.unmodifiableSet(names);
+        } else {
+            extraNames = Set.of();
+        }
+    }
+
+    /**
+     * Registers a descriptor whose parameter values do not affect tile content. Call this during application startup
+     * (e.g. in {@code afterPropertiesSet}) before any tile requests are served.
+     */
+    public void registerIgnorable(GeneralParameterDescriptor descriptor) {
+        contributed.add(descriptor);
+    }
+
+    /** Returns {@code true} if this parameter does not affect tile content and can be skipped during key building. */
+    public boolean isIgnorable(GeneralParameterValue param) {
+        GeneralParameterDescriptor descriptor = param.getDescriptor();
+        return BUILT_INS.contains(descriptor)
+                || contributed.contains(descriptor)
+                || extraNames.contains(descriptor.getName().getCode());
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/security/NormalizingFilterVisitor.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/security/NormalizingFilterVisitor.java
@@ -1,0 +1,169 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.geotools.api.filter.And;
+import org.geotools.api.filter.BinaryComparisonOperator;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.Or;
+import org.geotools.api.filter.PropertyIsEqualTo;
+import org.geotools.api.filter.PropertyIsGreaterThan;
+import org.geotools.api.filter.PropertyIsGreaterThanOrEqualTo;
+import org.geotools.api.filter.PropertyIsLessThan;
+import org.geotools.api.filter.PropertyIsLessThanOrEqualTo;
+import org.geotools.api.filter.PropertyIsNotEqualTo;
+import org.geotools.api.filter.expression.Expression;
+import org.geotools.api.filter.expression.Function;
+import org.geotools.api.filter.expression.Literal;
+import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.filter.function.InFunction;
+import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.filter.visitor.SimplifyingFilterVisitor;
+
+/**
+ * Normalizes filters to reduce cache key fragmentation. Extends {@link SimplifyingFilterVisitor} (which handles basics
+ * like constant folding, double-negation, AND/OR flattening) and adds:
+ *
+ * <ul>
+ *   <li>Comparison swap: {@code Literal op PropertyName} -> {@code PropertyName inverted-op Literal}
+ *   <li>AND/OR operand sort: stable ordering by (class name, ECQL of child) to absorb producer-side ordering variation
+ *   <li>IN-function value sort: literal arguments in {@link InFunction} sorted lexicographically
+ * </ul>
+ *
+ * <p>Not a complete canonicalization: semantically equivalent filters with structural differences not covered above
+ * will still produce different keys. The goal is reducing fragmentation for the common cases, not eliminating it.
+ */
+class NormalizingFilterVisitor extends SimplifyingFilterVisitor {
+
+    // sort children by ECQL rather than toString: toString is not a stable cross-version contract, and a change
+    // there would reorder operands -> new cache keys -> mass tile orphaning. children are already normalized here.
+    // the try/catch is defensive: ECQL.toCQL covers the filters used in access limits (including id filters, encoded
+    // as IN (...)), the toString fallback only guards exotic types it cannot encode.
+    private static String sortKey(Filter f) {
+        try {
+            return ECQL.toCQL(f);
+        } catch (RuntimeException e) {
+            return f.toString();
+        }
+    }
+
+    @Override
+    public Object visit(PropertyIsEqualTo filter, Object extraData) {
+        Object result = super.visit(filter, extraData);
+        if (result instanceof BinaryComparisonOperator op && isLiteralLeft(op)) {
+            return getFactory(extraData).equal(op.getExpression2(), op.getExpression1(), op.isMatchingCase());
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(PropertyIsNotEqualTo filter, Object extraData) {
+        Object result = super.visit(filter, extraData);
+        if (result instanceof BinaryComparisonOperator op && isLiteralLeft(op)) {
+            return getFactory(extraData).notEqual(op.getExpression2(), op.getExpression1(), op.isMatchingCase());
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(PropertyIsGreaterThan filter, Object extraData) {
+        Object result = super.visit(filter, extraData);
+        if (result instanceof BinaryComparisonOperator op && isLiteralLeft(op)) {
+            // lit > prop -> prop < lit
+            return getFactory(extraData).less(op.getExpression2(), op.getExpression1(), op.isMatchingCase());
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(PropertyIsGreaterThanOrEqualTo filter, Object extraData) {
+        Object result = super.visit(filter, extraData);
+        if (result instanceof BinaryComparisonOperator op && isLiteralLeft(op)) {
+            // lit >= prop -> prop <= lit
+            return getFactory(extraData).lessOrEqual(op.getExpression2(), op.getExpression1(), op.isMatchingCase());
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(PropertyIsLessThan filter, Object extraData) {
+        Object result = super.visit(filter, extraData);
+        if (result instanceof BinaryComparisonOperator op && isLiteralLeft(op)) {
+            // lit < prop -> prop > lit
+            return getFactory(extraData).greater(op.getExpression2(), op.getExpression1(), op.isMatchingCase());
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(PropertyIsLessThanOrEqualTo filter, Object extraData) {
+        Object result = super.visit(filter, extraData);
+        if (result instanceof BinaryComparisonOperator op && isLiteralLeft(op)) {
+            // lit <= prop -> prop >= lit
+            return getFactory(extraData).greaterOrEqual(op.getExpression2(), op.getExpression1(), op.isMatchingCase());
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(And filter, Object extraData) {
+        Object result = super.visit(filter, extraData);
+        if (result instanceof And and) {
+            List<Filter> sorted = sorted(and.getChildren());
+            return sorted.equals(and.getChildren())
+                    ? and
+                    : getFactory(extraData).and(sorted);
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(Or filter, Object extraData) {
+        Object result = super.visit(filter, extraData);
+        if (result instanceof Or or) {
+            List<Filter> sorted = sorted(or.getChildren());
+            return sorted.equals(or.getChildren()) ? or : getFactory(extraData).or(sorted);
+        }
+        return result;
+    }
+
+    @Override
+    public Object visit(Function expression, Object extraData) {
+        Object result = super.visit(expression, extraData);
+        if (InFunction.isInFunction((Expression) result)) {
+            Function fn = (Function) result;
+            List<Expression> args = fn.getParameters();
+            if (args.size() > 2) {
+                // args[0] is the candidate; args[1..N] are the values to match - sort those
+                List<Expression> values = new ArrayList<>(args.subList(1, args.size()));
+                values.sort(Comparator.comparing(Object::toString));
+                if (!values.equals(args.subList(1, args.size()))) {
+                    List<Expression> reordered = new ArrayList<>(args.size());
+                    reordered.add(args.get(0));
+                    reordered.addAll(values);
+                    return getFactory(extraData).function(fn.getName(), reordered.toArray(Expression[]::new));
+                }
+            }
+        }
+        return result;
+    }
+
+    private static boolean isLiteralLeft(BinaryComparisonOperator op) {
+        return op.getExpression1() instanceof Literal && op.getExpression2() instanceof PropertyName;
+    }
+
+    private static List<Filter> sorted(List<Filter> children) {
+        // compute each child's ECQL sort key once rather than on every comparison
+        record Keyed(Filter filter, String type, String ecql) {}
+        return children.stream()
+                .map(f -> new Keyed(f, f.getClass().getName(), sortKey(f)))
+                .sorted(Comparator.comparing(Keyed::type).thenComparing(Keyed::ecql))
+                .map(Keyed::filter)
+                .toList();
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/security/ParameterValueKeySerializer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/security/ParameterValueKeySerializer.java
@@ -1,0 +1,33 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import org.geotools.api.parameter.ParameterValue;
+
+/**
+ * Extension point for serializing the value inside a {@link ParameterValue} to a stable cache key fragment.
+ *
+ * <p>Register custom implementations as Spring beans. {@link AccessLimitsKeyBuilder} collects them all at startup and
+ * dispatches by value type via {@link Class#isAssignableFrom}. Duplicate registrations for the same value type fail at
+ * startup with a descriptive error.
+ *
+ * @param <T> the type of the value inside the {@link ParameterValue} (e.g. {@code Filter}, {@code Geometry})
+ */
+public interface ParameterValueKeySerializer<T> {
+
+    /** Value type this serializer handles. Matched via {@link Class#isAssignableFrom}. */
+    Class<T> getValueType();
+
+    /**
+     * Serializes {@code value} to a stable string fragment for inclusion in the cache key. Must be deterministic:
+     * identical inputs -> identical output; inputs producing different tile content -> different output.
+     *
+     * <p>Default implementation returns {@code value.toString()}, sufficient for types whose {@code toString()} is
+     * already stable and unambiguous (e.g. {@link String}, {@link Boolean}, {@link Number}).
+     */
+    default String toKey(T value) {
+        return value.toString();
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityCacheInvalidationListener.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityCacheInvalidationListener.java
@@ -1,0 +1,16 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+/**
+ * Callback notified when security configuration changes require tile cache invalidation.
+ *
+ * <p>Implemented by {@link SecurityCacheInvalidator}. Sources call this directly - no Spring event bus is involved.
+ */
+public interface SecurityCacheInvalidationListener {
+
+    /** Called when security configuration has changed and some cached tiles may be stale. */
+    void onSecurityConfigChange(SecurityConfigurationChangeEvent event);
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityCacheInvalidationSource.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityCacheInvalidationSource.java
@@ -1,0 +1,21 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+/**
+ * Extension point for components that can detect security configuration changes and trigger tile cache invalidation.
+ *
+ * <p>Any Spring bean can implement this interface. {@link SecurityCacheInvalidator} collects all such beans at startup
+ * and registers itself as a listener. The source owns its change-detection mechanism entirely - Hibernate events,
+ * polling, REST callbacks, or any other approach.
+ *
+ * <p>It is intentionally separate from {@link org.geoserver.security.ResourceAccessManager}: a RAM that cannot be
+ * modified can have a companion bean act as its invalidation source.
+ */
+public interface SecurityCacheInvalidationSource {
+
+    /** Registers a listener to be notified when security configuration changes. */
+    void register(SecurityCacheInvalidationListener listener);
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityCacheInvalidator.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityCacheInvalidator.java
@@ -1,0 +1,137 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.impl.LayerGroupContainmentCache;
+import org.geoserver.security.impl.LayerGroupContainmentCache.LayerGroupSummary;
+import org.geotools.util.logging.Logging;
+import org.geowebcache.filter.parameters.ParametersUtils;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.storage.StorageBroker;
+import org.geowebcache.storage.StorageException;
+import org.springframework.beans.factory.InitializingBean;
+
+/**
+ * Translates {@link SecurityConfigurationChangeEvent}s into GWC tile deletions. For each affected layer it drops the
+ * security-keyed tiles (those carrying {@link SecurityParameterFilter#ACCESS_LIMITS_KEY}); when the event carries a
+ * tag, deletion is restricted to the tiles whose {@link SecurityParameterFilter#SECURITY_TAGS_KEY} contains it. Tiles
+ * without {@code ACCESS_LIMITS_KEY} (unrestricted access) are never touched.
+ *
+ * <p>At startup it registers with every {@link SecurityCacheInvalidationSource} bean in the context.
+ */
+public class SecurityCacheInvalidator implements SecurityCacheInvalidationListener, InitializingBean {
+
+    private static final Logger LOGGER = Logging.getLogger(SecurityCacheInvalidator.class);
+
+    private final StorageBroker storageBroker;
+    private final TileLayerDispatcher tileLayerDispatcher;
+    private final Catalog catalog;
+    private final LayerGroupContainmentCache containmentCache;
+
+    public SecurityCacheInvalidator(
+            StorageBroker storageBroker,
+            TileLayerDispatcher tileLayerDispatcher,
+            Catalog catalog,
+            LayerGroupContainmentCache containmentCache) {
+        this.storageBroker = storageBroker;
+        this.tileLayerDispatcher = tileLayerDispatcher;
+        this.catalog = catalog;
+        this.containmentCache = containmentCache;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        List<SecurityCacheInvalidationSource> sources =
+                GeoServerExtensions.extensions(SecurityCacheInvalidationSource.class);
+        for (SecurityCacheInvalidationSource source : sources) {
+            source.register(this);
+        }
+        if (!sources.isEmpty()) {
+            LOGGER.config("GWC security cache invalidator registered with " + sources.size() + " source(s)");
+        }
+    }
+
+    @Override
+    public void onSecurityConfigChange(SecurityConfigurationChangeEvent event) {
+        Set<String> layerNames = resolveLayerNames(event.affectedLayers());
+        for (String layerName : layerNames) {
+            try {
+                invalidateLayer(layerName, event.targetTags());
+            } catch (StorageException e) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "Failed to invalidate security tile cache for layer '" + layerName + "': " + e.getMessage(),
+                        e);
+            }
+        }
+    }
+
+    private Set<String> resolveLayerNames(Set<LayerInfo> affectedLayers) {
+        if (affectedLayers == null) return tileLayerDispatcher.getLayerNames();
+        Set<String> tileLayers = tileLayerDispatcher.getLayerNames();
+        Set<String> names = new HashSet<>();
+        for (LayerInfo layer : affectedLayers) {
+            // resolve to the catalog instance: prefixedName can be rewritten by workspace-local decorators that
+            // un-prefix layer names, making the passed-in copy unreliable as a tile-layer name
+            LayerInfo canonical = catalog.getLayer(layer.getId());
+            LayerInfo resolved = canonical != null ? canonical : layer;
+            names.add(resolved.prefixedName());
+            // layer-group tiles embed each member's limits, so a member change must also invalidate every containing
+            // group; the containment cache returns transitive containers without scanning the whole catalog.
+            // includeSingle=true: GWC caches SINGLE-mode group tiles too, unlike security rule evaluation
+            ResourceInfo resource = resolved.getResource();
+            if (resource == null) continue;
+            for (LayerGroupSummary group : containmentCache.getContainerGroupsFor(resource, true)) {
+                String groupName = group.prefixedName();
+                if (tileLayers.contains(groupName)) names.add(groupName);
+            }
+        }
+        return names;
+    }
+
+    private void invalidateLayer(String layerName, Set<String> targetTags) throws StorageException {
+        Set<Map<String, String>> cached = storageBroker.getCachedParameters(layerName);
+        if (cached == null || cached.isEmpty()) return;
+        int deleted = 0;
+        for (Map<String, String> params : cached) {
+            if (!params.containsKey(SecurityParameterFilter.ACCESS_LIMITS_KEY)) continue;
+            if (targetTags != null
+                    && !containsAnyTag(params.get(SecurityParameterFilter.SECURITY_TAGS_KEY), targetTags)) continue;
+            // guard each delete so one failure does not abort the remaining sets for this layer
+            try {
+                storageBroker.deleteByParametersId(layerName, ParametersUtils.getId(params));
+                deleted++;
+            } catch (Exception e) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "Failed to delete a security tile set for layer '" + layerName + "': " + e.getMessage(),
+                        e);
+            }
+        }
+        if (deleted > 0) {
+            LOGGER.fine("GWC security: invalidated " + deleted + " parameter set(s) for layer '" + layerName + "'"
+                    + (targetTags != null ? " (tags: " + targetTags + ")" : ""));
+        }
+    }
+
+    /** True if the comma-separated {@code tagsValue} stored on a tile contains any of {@code targetTags}. */
+    static boolean containsAnyTag(String tagsValue, Set<String> targetTags) {
+        if (tagsValue == null || tagsValue.isEmpty()) return false;
+        for (String t : tagsValue.split(",")) {
+            if (targetTags.contains(t.trim())) return true;
+        }
+        return false;
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityConfigurationChangeEvent.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityConfigurationChangeEvent.java
@@ -1,0 +1,29 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import java.util.Set;
+import org.geoserver.catalog.LayerInfo;
+
+/**
+ * Signals that security restrictions changed and some cached tiles may be stale.
+ *
+ * <p>{@code affectedLayers}: layers to sweep, {@code null} means scope unknown so check all tile layers (the source
+ * expands workspace-scoped changes to individual {@link LayerInfo}). {@code targetTags}: restrict the sweep to tiles
+ * whose {@code SECURITY_TAGS_KEY} contains any of these tags, {@code null} drops all security-keyed tiles for the
+ * affected layers. A tag must not contain a comma (commas separate tags in the stored value).
+ */
+public record SecurityConfigurationChangeEvent(Set<LayerInfo> affectedLayers, Set<String> targetTags) {
+    public SecurityConfigurationChangeEvent {
+        if (targetTags != null) {
+            for (String tag : targetTags) {
+                if (tag.indexOf(',') >= 0) {
+                    throw new IllegalArgumentException("targetTag must not contain a comma: " + tag);
+                }
+            }
+            targetTags = Set.copyOf(targetTags);
+        }
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityParameterFilter.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/security/SecurityParameterFilter.java
@@ -1,0 +1,66 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import java.io.Serial;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.geowebcache.filter.parameters.ParameterFilter;
+
+/**
+ * A GWC {@link ParameterFilter} that injects the security cache key as a tile dimension, ensuring that tiles cached
+ * under different access restrictions are stored separately.
+ *
+ * <p>The key value is computed by {@link org.geoserver.gwc.layer.GeoServerTileLayer#getModifiableParameters} and
+ * injected into the tile parameter map. This filter simply passes the value through unchanged.
+ *
+ * <p><strong>Warning:</strong> the {@link #ACCESS_LIMITS_KEY} and {@link #SECURITY_TAGS_KEY} constants are not
+ * persisted in the GWC configuration, but they are saved in the parameter filters property file for each tile cache.
+ * Changing them orphans all existing tile caches.
+ */
+public class SecurityParameterFilter extends ParameterFilter {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /** Parameter key for the security access-limits cache dimension. */
+    public static final String ACCESS_LIMITS_KEY = "ACCESS_LIMITS_KEY";
+
+    /** Parameter key for the security-tags cache dimension, used for targeted cache invalidation. */
+    public static final String SECURITY_TAGS_KEY = "SECURITY_TAGS_KEY";
+
+    public SecurityParameterFilter(String key) {
+        super(key, ""); // "" = unrestricted access (no security key)
+    }
+
+    @Override
+    protected Object readResolve() {
+        // synthetic filter - must never appear in persisted config; security would silently
+        // break if deserialized because the filter would survive even after security is disabled
+        throw new UnsupportedOperationException(
+                "SecurityParameterFilter must not be persisted; it is added only at runtime");
+    }
+
+    /** Synthetic cache-partitioning filter: never advertised in preview, seed form or WMS/WMTS capabilities. */
+    @Override
+    public boolean isUserVisible() {
+        return false;
+    }
+
+    /**
+     * Returns the value unchanged. The security key is computed upstream; this filter exists only to register the
+     * parameter as a GWC cache dimension.
+     */
+    @Override
+    public String apply(@Nullable String value) {
+        return value == null ? getDefaultValue() : value;
+    }
+
+    /** Returns {@code null}: the set of possible security keys is unbounded. */
+    @Override
+    public @Nullable List<String> getLegalValues() {
+        return null;
+    }
+}

--- a/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
@@ -150,4 +150,14 @@
     <constructor-arg ref="gwcGridSetBroker"/>
   </bean>
 
+  <!-- GWC security parameter filter -->
+
+  <bean id="gwcIgnorableParameterRegistry"
+        class="org.geoserver.gwc.security.IgnorableParameterRegistry"/>
+
+  <bean id="gwcAccessLimitsKeyBuilder"
+        class="org.geoserver.gwc.security.AccessLimitsKeyBuilder">
+    <constructor-arg ref="gwcIgnorableParameterRegistry"/>
+  </bean>
+
 </beans>

--- a/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
@@ -160,4 +160,12 @@
     <constructor-arg ref="gwcIgnorableParameterRegistry"/>
   </bean>
 
+  <bean id="gwcSecurityCacheInvalidator"
+        class="org.geoserver.gwc.security.SecurityCacheInvalidator">
+    <constructor-arg ref="gwcStorageBroker"/>
+    <constructor-arg ref="gwcTLDispatcher"/>
+    <constructor-arg ref="rawCatalog"/>
+    <constructor-arg ref="layerGroupContainmentCache"/>
+  </bean>
+
 </beans>

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCDataSecurityTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCDataSecurityTest.java
@@ -9,10 +9,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -20,6 +23,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.logging.Logger;
+import javax.imageio.ImageIO;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CoverageInfo;
@@ -44,6 +48,7 @@ import org.geoserver.wms.WMSTestSupport;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.image.ImageWorker;
 import org.geotools.referencing.CRS;
 import org.geotools.util.logging.Logging;
 import org.geowebcache.service.ve.VEConverter;
@@ -282,13 +287,9 @@ public class GWCDataSecurityTest extends WMSTestSupport {
         }
     }
 
-    protected void doPermissionCropTileTest(
-            BiFunction<String, long[], String> pathForLayer, String failFormat, TestGridset grid) throws Exception {
+    protected void doPermissionCropTileTest(BiFunction<String, long[], String> pathForLayer, TestGridset grid)
+            throws Exception {
         final String tileFormat = "image/png";
-        //      final String pathInBounds = pathForLayer.apply("sf:mosaic", new
-        // long[]{4073,4118,13});
-        //      final String pathOutOfBounds = pathForLayer.apply("sf:mosaic", new
-        // long[]{4073,4117,13});
         final String pathInBounds = pathForLayer.apply("sf:mosaic", grid.tileInBounds);
         final String pathOutOfBounds = pathForLayer.apply("sf:mosaic", grid.tileOutOfBounds);
         GWC.get().getConfig().setSecurityEnabled(true);
@@ -299,20 +300,15 @@ public class GWCDataSecurityTest extends WMSTestSupport {
         MockHttpServletResponse response = getAsServletResponse(pathOutOfBounds);
         assertThat(
                 response,
-                addBodyOnFail(hasProperty("contentType", equalTo(tileFormat)))); // If this was unsuccessful the test is
-        // invalid
+                addBodyOnFail(hasProperty("contentType", equalTo(tileFormat)))); // If this fails the test is invalid
 
         setRequestAuth("cite_cropmosaic", "cite");
 
-        // Request out of bounds should fail
+        // Out-of-clip tile returns empty PNG; rendering pipeline handles it (no data inside clip)
         response = getAsServletResponse(pathOutOfBounds);
-        assertThat(
-                response,
-                allOf(
-                        hasProperty("contentType", equalTo(failFormat)),
-                        hasBody(Matchers.containsString("Not Authorized"))));
+        assertThat(response, addBodyOnFail(hasProperty("contentType", equalTo(tileFormat))));
 
-        // Request within bounds should work
+        // Request within bounds returns clipped tile
         response = getAsServletResponse(pathInBounds);
         assertThat(response, addBodyOnFail(hasProperty("contentType", equalTo(tileFormat))));
     }
@@ -396,7 +392,6 @@ public class GWCDataSecurityTest extends WMSTestSupport {
         doPermissionCropTileTest(
                 (layer, index) -> "gwc/service/tms/1.0.0/%s@EPSG:900913@png/%d/%d/%d.png"
                         .formatted(layer, index[2], index[0], index[1]),
-                SECURITY_ERROR_TYPE,
                 TestGridset.GoogleMapsCompatible);
     }
 
@@ -429,7 +424,6 @@ public class GWCDataSecurityTest extends WMSTestSupport {
                         "gwc/service/wmts?LAYER=%s&FORMAT=image/png&SERVICE=WMTS&VERSION=1.0.0"
                                 + "&REQUEST=GetTile&TILEMATRIXSET=EPSG:900913&TILEMATRIX=EPSG:900913:%d&TILECOL=%d&TILEROW=%d",
                         layer, index[2], index[0], (1 << index[2]) - index[1] - 1),
-                SECURITY_ERROR_TYPE,
                 TestGridset.GoogleMapsCompatible);
     }
 
@@ -438,7 +432,6 @@ public class GWCDataSecurityTest extends WMSTestSupport {
         doPermissionCropTileTest(
                 (layer, index) -> "gwc/service/gmaps?LAYERS=%s&FORMAT=image/png&ZOOM=%d&X=%d&Y=%d"
                         .formatted(layer, index[2], index[0], (1 << index[2]) - index[1] - 1),
-                SECURITY_ERROR_TYPE,
                 TestGridset.GoogleMapsCompatible);
     }
 
@@ -447,7 +440,6 @@ public class GWCDataSecurityTest extends WMSTestSupport {
         doPermissionCropTileTest(
                 (layer, index) -> "gwc/service/mgmaps?LAYERS=%s&FORMAT=image/png&ZOOM=%d&X=%d&Y=%d"
                         .formatted(layer, 17 - index[2], index[0], (1 << index[2]) - index[1] - 1),
-                SECURITY_ERROR_TYPE,
                 TestGridset.GoogleMapsCompatible);
     }
 
@@ -455,7 +447,6 @@ public class GWCDataSecurityTest extends WMSTestSupport {
     public void testPermissionCropTileKml() throws Exception {
         doPermissionCropTileTest(
                 (layer, index) -> "gwc/service/kml/%s/x%dy%dz%d.png".formatted(layer, index[0], index[1], index[2]),
-                SECURITY_ERROR_TYPE,
                 TestGridset.GlobalCRS84Geometric);
     }
 
@@ -478,7 +469,6 @@ public class GWCDataSecurityTest extends WMSTestSupport {
                     // the test is broken
                     return "gwc/service/ve?layers=%s&format=image/png&quadKey=%s".formatted(layer, quadKey);
                 },
-                SECURITY_ERROR_TYPE,
                 TestGridset.GoogleMapsCompatible);
     }
 
@@ -535,21 +525,47 @@ public class GWCDataSecurityTest extends WMSTestSupport {
         MockHttpServletResponse response = getAsServletResponse(path);
         assertEquals("image/png", response.getContentType());
 
-        // this should fail
         setRequestAuth("cite_cropmosaic", "cite");
 
-        path = "gwc/service/wms?bgcolor=0x000000&LAYERS=sf:mosaic&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
-                + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=0,-90,180,90&WIDTH=256&HEIGHT=256&transparent=false";
+        // tile in western hemisphere: no overlap with the Australia clip, so rendered as empty transparent PNG
+        path = "gwc/service/wms?LAYERS=sf:mosaic&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
+                + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=-180,-90,0,90&WIDTH=256&HEIGHT=256&transparent=true";
         response = getAsServletResponse(path);
-        assertEquals(SECURITY_ERROR_TYPE, response.getContentType());
-        String str = string(getBinaryInputStream(response));
-        assertTrue(str.contains("Not Authorized"));
+        assertEquals("image/png", response.getContentType());
+        BufferedImage img = ImageIO.read(new ByteArrayInputStream(response.getContentAsByteArray()));
+        // forceComponentColorModel puts alpha as the last band; max alpha = 0 means fully transparent
+        double[] maxima = new ImageWorker(img).forceComponentColorModel().getMaximums();
+        assertEquals("tile outside clip must be fully transparent", 0.0, maxima[maxima.length - 1], 0.0);
 
         // but this should be fine
         path = "gwc/service/wms?bgcolor=0x000000&LAYERS=sf:mosaic&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
                 + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=143.4375,-42.1875,146.25,-39.375&WIDTH=256&HEIGHT=256&transparent=false";
         response = getAsServletResponse(path);
         assertEquals("image/png", response.getContentType());
+    }
+
+    @Test
+    public void testCroppedMosaicDirectWms() throws Exception {
+        // direct WMS integration path: /wms with tiled=true and tile-aligned bbox goes through GWC
+        GWC.get().truncate("sf:mosaic");
+        GWC.get().getConfig().setDirectWMSIntegrationEnabled(true);
+        setRequestAuth("cite_cropmosaic", "cite");
+        // zoom-0 left tile (-180,-90,0,90): outside Australia clip - mosaic data here does not intersect Australia
+        String path = "wms?LAYERS=sf:mosaic&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
+                + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=-180,-90,0,90&WIDTH=256&HEIGHT=256&transparent=true&tiled=true";
+        MockHttpServletResponse response = getAsServletResponse(path);
+        assertEquals("image/png", response.getContentType());
+        assertThat(
+                "GWC must handle tile-aligned request via direct integration",
+                response.getHeader("geowebcache-tile-index"),
+                Matchers.notNullValue());
+        assertThat(
+                "first request must be a MISS",
+                response.getHeader("geowebcache-cache-result"),
+                equalToIgnoringCase("MISS"));
+        BufferedImage img = ImageIO.read(new ByteArrayInputStream(response.getContentAsByteArray()));
+        double[] maxima = new ImageWorker(img).forceComponentColorModel().getMaximums();
+        assertEquals("area outside Australia clip must be fully transparent", 0.0, maxima[maxima.length - 1], 0.0);
     }
 
     @Test
@@ -562,17 +578,15 @@ public class GWCDataSecurityTest extends WMSTestSupport {
         MockHttpServletResponse response = getAsServletResponse(path);
         assertEquals("image/png", response.getContentType());
 
-        // this should fail
+        // readFilter-only (no rasterFilter): no bbox check, tile renders normally (filter applied by reader)
         setRequestAuth("cite_filtermosaic", "cite");
 
         path = "gwc/service/wms?bgcolor=0x000000&LAYERS=sf:mosaic&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
                 + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=0,-90,180,90&WIDTH=256&HEIGHT=256&transparent=false";
         response = getAsServletResponse(path);
-        assertEquals(SECURITY_ERROR_TYPE, response.getContentType());
-        String str = string(getBinaryInputStream(response));
-        assertThat(str, containsString("Not Authorized"));
+        assertEquals("image/png", response.getContentType());
 
-        // but this should be fine
+        // this too
         path = "gwc/service/wms?bgcolor=0x000000&LAYERS=sf:mosaic&STYLES=&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
                 + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=143.4375,-42.1875,146.25,-39.375&WIDTH=256&HEIGHT=256&transparent=false";
         response = getAsServletResponse(path);
@@ -613,6 +627,48 @@ public class GWCDataSecurityTest extends WMSTestSupport {
         setRequestAuth("cite", "cite");
         response = getAsServletResponse(path);
         assertEquals("image/png", response.getContentType());
+    }
+
+    @Test
+    public void testWmscCacheIsolation() throws Exception {
+        // gwc/service/wms (WMS-C) goes through a different dispatcher path than WMTS/TMS.
+        // Verify that SecurityParameterFilter still isolates tiles per user access profile.
+        GWC.get().truncate("sf:mosaic");
+        // cite_cropmosaic has a raster clip to Australia, giving it a different ACCESS_LIMITS_KEY
+        String wmscPath = "gwc/service/wms?LAYERS=sf:mosaic&FORMAT=image/png&SERVICE=WMS&VERSION=1.1.1"
+                + "&REQUEST=GetMap&SRS=EPSG:4326&BBOX=0,-90,180,90&WIDTH=256&HEIGHT=256";
+
+        setRequestAuth("cite", "cite");
+        MockHttpServletResponse response = getAsServletResponse(wmscPath);
+        assertEquals("image/png", response.getContentType());
+        assertThat(
+                "first cite request must be a MISS",
+                response.getHeader("geowebcache-cache-result"),
+                equalToIgnoringCase("MISS"));
+
+        setRequestAuth("cite", "cite");
+        response = getAsServletResponse(wmscPath);
+        assertEquals("image/png", response.getContentType());
+        assertThat(
+                "second cite request must HIT the cache",
+                response.getHeader("geowebcache-cache-result"),
+                equalToIgnoringCase("HIT"));
+
+        setRequestAuth("cite_cropmosaic", "cite");
+        response = getAsServletResponse(wmscPath);
+        assertEquals("image/png", response.getContentType());
+        assertThat(
+                "restricted user must MISS (different ACCESS_LIMITS_KEY)",
+                response.getHeader("geowebcache-cache-result"),
+                equalToIgnoringCase("MISS"));
+
+        setRequestAuth("cite_cropmosaic", "cite");
+        response = getAsServletResponse(wmscPath);
+        assertEquals("image/png", response.getContentType());
+        assertThat(
+                "restricted user must HIT own cache entry",
+                response.getHeader("geowebcache-cache-result"),
+                equalToIgnoringCase("HIT"));
     }
 
     @Test

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCSecurityParameterFilterTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCSecurityParameterFilterTest.java
@@ -1,0 +1,684 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import static org.geoserver.gwc.security.SecurityParameterFilter.ACCESS_LIMITS_KEY;
+import static org.geoserver.gwc.security.SecurityParameterFilter.SECURITY_TAGS_KEY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.imageio.ImageIO;
+import javax.xml.namespace.QName;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.data.test.CiteTestData;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.data.test.SystemTestData.LayerProperty;
+import org.geoserver.gwc.security.CustomParam;
+import org.geoserver.gwc.security.CustomParamSerializer;
+import org.geoserver.security.CatalogMode;
+import org.geoserver.security.CoverageAccessLimits;
+import org.geoserver.security.TestResourceAccessManager;
+import org.geoserver.security.VectorAccessLimits;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.parameter.GeneralParameterValue;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.image.ImageWorker;
+import org.geotools.parameter.DefaultParameterDescriptor;
+import org.geotools.parameter.Parameter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Integration tests for GWC security parameter filter. Verifies tile cache segmentation per user access limits across
+ * vector, raster, and layer group scenarios, covering all security limit types.
+ */
+public class GWCSecurityParameterFilterTest extends GeoServerSystemTestSupport {
+
+    static final QName MOSAIC = new QName(MockData.SF_URI, "mosaic", MockData.SF_PREFIX);
+    static final String GROUP = "secTestGroup";
+
+    static final GeometryFactory GF = new GeometryFactory();
+    static final FilterFactory FF = CommonFactoryFinder.getFilterFactory();
+
+    // clip polygons for vector clip tests - within BASIC_POLYGONS/LAKES feature extent
+    static final MultiPolygon CLIP_A = bbox(-2, 0, 3, 5);
+    static final MultiPolygon CLIP_B = bbox(0, 2, 4, 6);
+
+    static final MultiPolygon RASTER_CLIP_A = bbox(10, 20, 50, 60);
+    static final MultiPolygon RASTER_CLIP_B = bbox(100, 30, 150, 70);
+
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        springContextLocations.add("classpath:/org/geoserver/wms/ResourceAccessManagerContext.xml");
+        springContextLocations.add("classpath:/org/geoserver/gwc/security/CustomParamSerializerContext.xml");
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        GWC.get().getConfig().setDirectWMSIntegrationEnabled(true);
+        addRasterLayer(testData);
+        addLayerGroup();
+    }
+
+    private void addRasterLayer(SystemTestData testData) throws Exception {
+        testData.addStyle("raster", "raster.sld", SystemTestData.class, getCatalog());
+        Map<LayerProperty, Object> props = new HashMap<>();
+        props.put(LayerProperty.STYLE, "raster");
+        testData.addRasterLayer(MOSAIC, "raster-filter-test.zip", null, props, SystemTestData.class, getCatalog());
+        CoverageInfo ci = getCatalog().getCoverageByName("sf:mosaic");
+        ci.setNativeBoundingBox(CiteTestData.DEFAULT_LATLON_ENVELOPE);
+        getCatalog().save(ci);
+    }
+
+    private void addLayerGroup() throws Exception {
+        Catalog catalog = getCatalog();
+        LayerGroupInfo group = catalog.getFactory().createLayerGroup();
+        group.setName(GROUP);
+        LayerInfo lakes = catalog.getLayerByName(getLayerId(MockData.LAKES));
+        LayerInfo forests = catalog.getLayerByName(getLayerId(MockData.FORESTS));
+        group.getLayers().add(lakes);
+        group.getLayers().add(forests);
+        group.getStyles().add(null);
+        group.getStyles().add(null);
+        new CatalogBuilder(catalog).calculateLayerGroupBounds(group);
+        catalog.add(group);
+    }
+
+    @Before
+    public void reset() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(false);
+        GWC gwc = GWC.get();
+        gwc.truncate(getLayerId(MockData.BASIC_POLYGONS));
+        gwc.truncate("sf:mosaic");
+        gwc.truncate(GROUP);
+        getRAM().clearLimits();
+        SecurityContextHolder.clearContext();
+    }
+
+    @After
+    public void cleanUp() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private TestResourceAccessManager getRAM() {
+        return (TestResourceAccessManager) applicationContext.getBean("testResourceAccessManager");
+    }
+
+    /** Tile request at EPSG:4326:0 - world-scale tile, suitable for all test layers. */
+    private void assertTileResult(QName layer, String expected) throws Exception {
+        assertTileResult(getLayerId(layer), 0, expected);
+    }
+
+    private void assertRasterTileResult(String expected) throws Exception {
+        assertTileResult("sf:mosaic", 0, expected);
+    }
+
+    private void assertTileResult(String layerId, int col, String expected) throws Exception {
+        String path = "gwc/service/wmts?request=GetTile&layer=" + layerId
+                + "&format=image/png&tilematrixset=EPSG:4326&tilematrix=EPSG:4326:0"
+                + "&tilerow=0&tilecol=" + col;
+        MockHttpServletResponse response = getAsServletResponse(path);
+        assertEquals("HTTP status for " + layerId, 200, response.getStatus());
+        assertEquals("image/png", response.getContentType());
+        assertThat(
+                "Cache result for " + layerId,
+                response.getHeader("geowebcache-cache-result"),
+                equalToIgnoringCase(expected));
+    }
+
+    private static MultiPolygon bbox(double minX, double minY, double maxX, double maxY) {
+        Polygon p = GF.createPolygon(new Coordinate[] {
+            new Coordinate(minX, minY),
+            new Coordinate(minX, maxY),
+            new Coordinate(maxX, maxY),
+            new Coordinate(maxX, minY),
+            new Coordinate(minX, minY)
+        });
+        return GF.createMultiPolygon(new Polygon[] {p});
+    }
+
+    private static VectorAccessLimits vectorFilter(String ecql) throws Exception {
+        return new VectorAccessLimits(CatalogMode.HIDE, null, ECQL.toFilter(ecql), null, Filter.INCLUDE);
+    }
+
+    private static VectorAccessLimits vectorClip(MultiPolygon clip) {
+        return new VectorAccessLimits(CatalogMode.HIDE, null, Filter.INCLUDE, null, Filter.INCLUDE, clip);
+    }
+
+    private static VectorAccessLimits vectorIntersect(MultiPolygon intersect) {
+        VectorAccessLimits limits =
+                new VectorAccessLimits(CatalogMode.HIDE, null, Filter.INCLUDE, null, Filter.INCLUDE);
+        limits.setIntersectVectorFilter(intersect);
+        return limits;
+    }
+
+    private static VectorAccessLimits vectorAttributes(String name) {
+        return new VectorAccessLimits(
+                CatalogMode.HIDE, List.of(FF.property(name)), Filter.INCLUDE, null, Filter.INCLUDE);
+    }
+
+    private static CoverageAccessLimits coverageClip(MultiPolygon clip) {
+        return new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, clip, null);
+    }
+
+    private static CoverageAccessLimits coverageParam(String value) {
+        return new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, rasterParam(value));
+    }
+
+    private static CoverageAccessLimits coverageCustom(String value) {
+        return new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, customParam(value));
+    }
+
+    private static GeneralParameterValue[] rasterParam(String value) {
+        DefaultParameterDescriptor<String> desc =
+                new DefaultParameterDescriptor<>("SECURITY_PARAM", String.class, null, null);
+        return new GeneralParameterValue[] {new Parameter<>(desc, value)};
+    }
+
+    private static GeneralParameterValue[] customParam(String value) {
+        return new GeneralParameterValue[] {new Parameter<>(CustomParamSerializer.DESCRIPTOR, new CustomParam(value))};
+    }
+
+    /** Max value of the tile's alpha band: 0 means a fully transparent (empty) tile. */
+    private static double maxAlpha(byte[] png) throws IOException {
+        double[] max = new ImageWorker(ImageIO.read(new ByteArrayInputStream(png)))
+                .forceComponentColorModel()
+                .getMaximums();
+        return max[max.length - 1];
+    }
+
+    @Test
+    public void testSecurityDisabledSharesCache() throws Exception {
+        // all users map to the same parametersId when security is off
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testVectorUnrestrictedSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testCapabilitiesOmitsSecurityFilters() throws Exception {
+        // synthetic security filters partition the cache but must never surface in WMTS capabilities
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_a", layer.getResource(), vectorFilter("FID = 'BasicPolygons.1107531493630'"));
+        login("user_a", "test");
+
+        String caps = getAsString("gwc/service/wmts?request=GetCapabilities");
+        assertThat(caps, not(containsString(ACCESS_LIMITS_KEY)));
+        assertThat(caps, not(containsString(SECURITY_TAGS_KEY)));
+    }
+
+    @Test
+    public void testVectorReadFilterSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_b", layer.getResource(), vectorFilter("FID = 'BasicPolygons.1107531493630'"));
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS"); // different key -> own cache
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testVectorDifferentReadFiltersSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_a", layer.getResource(), vectorFilter("FID = 'BasicPolygons.1107531493630'"));
+        getRAM().putLimits("user_b", layer.getResource(), vectorFilter("FID = 'BasicPolygons.1107531493643'"));
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS"); // different filter -> own cache
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testVectorSameReadFilterSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        VectorAccessLimits shared = vectorFilter("FID = 'BasicPolygons.1107531493630'");
+        getRAM().putLimits("user_a", layer.getResource(), shared);
+        getRAM().putLimits("user_b", layer.getResource(), shared);
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testVectorReadAttributesSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        // the_geom must be included or WMS renderer cannot render the layer
+        getRAM().putLimits("user_b", layer.getResource(), vectorAttributes("the_geom"));
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS"); // attribute restriction -> different key
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testVectorSameReadAttributesSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_a", layer.getResource(), vectorAttributes("the_geom"));
+        getRAM().putLimits("user_b", layer.getResource(), vectorAttributes("the_geom"));
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testVectorClipGeometrySeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_a", layer.getResource(), vectorClip(CLIP_A));
+        getRAM().putLimits("user_b", layer.getResource(), vectorClip(CLIP_B));
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS"); // different clip -> different key
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testVectorSameClipGeometrySharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_a", layer.getResource(), vectorClip(CLIP_A));
+        getRAM().putLimits("user_b", layer.getResource(), vectorClip(CLIP_A));
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testRasterUnrestrictedSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+
+        login("user_a", "test");
+        assertRasterTileResult("MISS");
+
+        login("user_b", "test");
+        assertRasterTileResult("HIT");
+    }
+
+    @Test
+    public void testRasterFilterSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        CoverageInfo coverage = getCatalog().getCoverageByName("sf:mosaic");
+        // raster clip must fully contain the requested tile (0,-90)-(180,90) to pass security
+        getRAM().putLimits("user_b", coverage, coverageClip(RASTER_CLIP_A));
+
+        login("user_a", "test");
+        assertRasterTileResult("MISS");
+
+        login("user_b", "test");
+        assertRasterTileResult("MISS"); // raster clip key -> own cache
+
+        login("user_b", "test");
+        assertRasterTileResult("HIT");
+    }
+
+    @Test
+    public void testRasterDifferentFiltersSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        CoverageInfo coverage = getCatalog().getCoverageByName("sf:mosaic");
+        getRAM().putLimits("user_a", coverage, coverageClip(RASTER_CLIP_A));
+        getRAM().putLimits("user_b", coverage, coverageClip(RASTER_CLIP_B));
+
+        login("user_a", "test");
+        assertRasterTileResult("MISS");
+
+        login("user_b", "test");
+        assertRasterTileResult("MISS"); // different clip -> own cache
+
+        login("user_a", "test");
+        assertRasterTileResult("HIT");
+    }
+
+    @Test
+    public void testRasterSameFilterSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        CoverageInfo coverage = getCatalog().getCoverageByName("sf:mosaic");
+        CoverageAccessLimits shared = coverageClip(RASTER_CLIP_A);
+        getRAM().putLimits("user_a", coverage, shared);
+        getRAM().putLimits("user_b", coverage, shared);
+
+        login("user_a", "test");
+        assertRasterTileResult("MISS");
+
+        login("user_b", "test");
+        assertRasterTileResult("HIT");
+    }
+
+    @Test
+    public void testGroupUnrestrictedSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+
+        login("user_a", "test");
+        assertTileResult(GROUP, 0, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(GROUP, 0, "HIT");
+    }
+
+    @Test
+    public void testGroupPartialRestrictionSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo lakes = getCatalog().getLayerByName(getLayerId(MockData.LAKES));
+        // user_b restricted on one group layer; group key changes even if user sees other layers
+        getRAM().putLimits("user_b", lakes.getResource(), vectorFilter("NAME = 'Blue Lake'"));
+
+        login("user_a", "test");
+        assertTileResult(GROUP, 0, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(GROUP, 0, "MISS"); // restriction on group member -> different key
+
+        login("user_b", "test");
+        assertTileResult(GROUP, 0, "HIT");
+    }
+
+    @Test
+    public void testGroupDifferentRestrictionsSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo lakes = getCatalog().getLayerByName(getLayerId(MockData.LAKES));
+        getRAM().putLimits("user_a", lakes.getResource(), vectorFilter("NAME = 'Blue Lake'"));
+        getRAM().putLimits("user_b", lakes.getResource(), vectorFilter("NAME = 'Green Lake'"));
+
+        login("user_a", "test");
+        assertTileResult(GROUP, 0, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(GROUP, 0, "MISS"); // different restriction -> own cache
+
+        login("user_a", "test");
+        assertTileResult(GROUP, 0, "HIT");
+    }
+
+    @Test
+    public void testGroupSameRestrictionsSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo lakes = getCatalog().getLayerByName(getLayerId(MockData.LAKES));
+        VectorAccessLimits shared = vectorFilter("NAME = 'Blue Lake'");
+        getRAM().putLimits("user_a", lakes.getResource(), shared);
+        getRAM().putLimits("user_b", lakes.getResource(), shared);
+
+        login("user_a", "test");
+        assertTileResult(GROUP, 0, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(GROUP, 0, "HIT");
+    }
+
+    @Test
+    public void testVectorIntersectFilterSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_a", layer.getResource(), vectorIntersect(CLIP_A));
+        getRAM().putLimits("user_b", layer.getResource(), vectorIntersect(CLIP_B));
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS"); // different intersect -> different key
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testVectorSameIntersectFilterSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_a", layer.getResource(), vectorIntersect(CLIP_A));
+        getRAM().putLimits("user_b", layer.getResource(), vectorIntersect(CLIP_A));
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testTagsSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        VectorAccessLimits noTags = vectorFilter("FID = 'BasicPolygons.1107531493630'");
+        VectorAccessLimits withTags = vectorFilter("FID = 'BasicPolygons.1107531493630'");
+        withTags.setSecurityTags(Set.of("tenant-a"));
+        getRAM().putLimits("user_a", layer.getResource(), noTags);
+        getRAM().putLimits("user_b", layer.getResource(), withTags);
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        // same ACCESS_LIMITS_KEY but different SECURITY_TAGS_KEY -> own cache
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testTagsSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        VectorAccessLimits limitsA = vectorFilter("FID = 'BasicPolygons.1107531493630'");
+        limitsA.setSecurityTags(Set.of("tenant-a"));
+        VectorAccessLimits limitsB = vectorFilter("FID = 'BasicPolygons.1107531493630'");
+        limitsB.setSecurityTags(Set.of("tenant-a"));
+        getRAM().putLimits("user_a", layer.getResource(), limitsA);
+        getRAM().putLimits("user_b", layer.getResource(), limitsB);
+
+        login("user_a", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "HIT");
+    }
+
+    @Test
+    public void testClientInjectedParamsIgnored() throws Exception {
+        // a restricted, untagged user must not influence the cache key by forging ACCESS_LIMITS_KEY /
+        // SECURITY_TAGS_KEY request parameters: both are stripped/overwritten server-side. If the forged
+        // SECURITY_TAGS_KEY leaked into the key the second request would MISS (own cache entry) and, worse,
+        // pin tiles under an attacker tag that tag-targeted invalidation would never reach.
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_b", layer.getResource(), vectorFilter("FID = 'BasicPolygons.1107531493630'"));
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        // same tile, now with forged security parameters -> must hit the same cache entry
+        String injected = "gwc/service/wmts?request=GetTile&layer=" + getLayerId(MockData.BASIC_POLYGONS)
+                + "&format=image/png&tilematrixset=EPSG:4326&tilematrix=EPSG:4326:0&tilerow=0&tilecol=0"
+                + "&ACCESS_LIMITS_KEY=forged&SECURITY_TAGS_KEY=forged";
+        MockHttpServletResponse response = getAsServletResponse(injected);
+        assertEquals(200, response.getStatus());
+        assertThat(response.getHeader("geowebcache-cache-result"), equalToIgnoringCase("HIT"));
+    }
+
+    @Test
+    public void testLowercaseForgeIgnored() throws Exception {
+        // GWC matches filter keys case-insensitively, so a forged lowercase "access_limits_key" must still be
+        // stripped server-side; otherwise it collides with the injected key and steers the cache entry
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_b", layer.getResource(), vectorFilter("FID = 'BasicPolygons.1107531493630'"));
+
+        login("user_b", "test");
+        assertTileResult(MockData.BASIC_POLYGONS, "MISS");
+
+        String injected = "gwc/service/wmts?request=GetTile&layer=" + getLayerId(MockData.BASIC_POLYGONS)
+                + "&format=image/png&tilematrixset=EPSG:4326&tilematrix=EPSG:4326:0&tilerow=0&tilecol=0"
+                + "&access_limits_key=forged&security_tags_key=forged";
+        MockHttpServletResponse response = getAsServletResponse(injected);
+        assertEquals(200, response.getStatus());
+        assertThat(response.getHeader("geowebcache-cache-result"), equalToIgnoringCase("HIT"));
+    }
+
+    @Test
+    public void testRasterParamsSeparatesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        CoverageInfo coverage = getCatalog().getCoverageByName("sf:mosaic");
+        getRAM().putLimits("user_a", coverage, coverageParam("zone-1"));
+        getRAM().putLimits("user_b", coverage, coverageParam("zone-2"));
+
+        login("user_a", "test");
+        assertRasterTileResult("MISS");
+
+        login("user_b", "test");
+        assertRasterTileResult("MISS"); // different param value -> own cache
+
+        login("user_a", "test");
+        assertRasterTileResult("HIT");
+    }
+
+    @Test
+    public void testRasterSameParamsSharesCache() throws Exception {
+        GWC.get().getConfig().setSecurityEnabled(true);
+        CoverageInfo coverage = getCatalog().getCoverageByName("sf:mosaic");
+        getRAM().putLimits("user_a", coverage, coverageParam("zone-1"));
+        getRAM().putLimits("user_b", coverage, coverageParam("zone-1"));
+
+        login("user_a", "test");
+        assertRasterTileResult("MISS");
+
+        login("user_b", "test");
+        assertRasterTileResult("HIT");
+    }
+
+    @Test
+    public void testRasterCustomSerializerSeparatesCache() throws Exception {
+        // verifies that CustomParamSerializer (registered as a Spring bean in CustomParamSerializerContext.xml)
+        // is picked up by AccessLimitsKeyBuilder.afterPropertiesSet() at context startup
+        GWC.get().getConfig().setSecurityEnabled(true);
+        CoverageInfo coverage = getCatalog().getCoverageByName("sf:mosaic");
+        getRAM().putLimits("user_a", coverage, coverageCustom("value_a"));
+        getRAM().putLimits("user_b", coverage, coverageCustom("value_b"));
+
+        login("user_a", "test");
+        assertRasterTileResult("MISS");
+
+        login("user_b", "test");
+        assertRasterTileResult("MISS"); // different custom param -> own cache
+
+        login("user_a", "test");
+        assertRasterTileResult("HIT");
+    }
+
+    @Test
+    public void testRasterClipEnforced() throws Exception {
+        // verifies that the raster clip is actually applied during rendering, not just segregating cache keys.
+        // tile col=0 at EPSG:4326:0 covers the western hemisphere (-180,-90,0,90);
+        // clip (10,10,20,20) is entirely in the eastern hemisphere -> no intersection -> null coverage -> transparent
+        // tile.
+        GWC.get().getConfig().setSecurityEnabled(true);
+        CoverageInfo coverage = getCatalog().getCoverageByName("sf:mosaic");
+        getRAM().putLimits("user_b", coverage, coverageClip(bbox(10, 10, 20, 20)));
+
+        String path = "gwc/service/wmts?request=GetTile&layer=sf:mosaic"
+                + "&format=image/png&tilematrixset=EPSG:4326&tilematrix=EPSG:4326:0&tilerow=0&tilecol=0";
+
+        login("user_a", "test");
+        byte[] tileA = getAsServletResponse(path).getContentAsByteArray();
+        login("user_b", "test");
+        byte[] tileB = getAsServletResponse(path).getContentAsByteArray();
+
+        assertThat(maxAlpha(tileA), greaterThan(0.0));
+        assertEquals("clip outside tile extent must produce transparent tile", 0.0, maxAlpha(tileB), 0.0);
+    }
+
+    @Test
+    public void testVectorFilterEnforced() throws Exception {
+        // the read filter must drop features during rendering, not just segregate the cache key:
+        // user_b restricted to a non-existent FID gets an empty tile, user_a sees the polygons
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));
+        getRAM().putLimits("user_b", layer.getResource(), vectorFilter("FID = 'does.not.exist'"));
+
+        String path = "gwc/service/wmts?request=GetTile&layer=" + getLayerId(MockData.BASIC_POLYGONS)
+                + "&format=image/png&tilematrixset=EPSG:4326&tilematrix=EPSG:4326:0&tilerow=0&tilecol=1";
+
+        login("user_a", "test");
+        byte[] tileA = getAsServletResponse(path).getContentAsByteArray();
+        login("user_b", "test");
+        byte[] tileB = getAsServletResponse(path).getContentAsByteArray();
+
+        assertThat("unrestricted user must see polygon content", maxAlpha(tileA), greaterThan(0.0));
+        assertEquals("filtered-out user must get an empty tile", 0.0, maxAlpha(tileB), 0.0);
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCSecurityParameterFilterTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCSecurityParameterFilterTest.java
@@ -480,6 +480,31 @@ public class GWCSecurityParameterFilterTest extends GeoServerSystemTestSupport {
     }
 
     @Test
+    public void testGroupContainerContextRestrictionSeparatesCache() throws Exception {
+        // a member layer restricted only when accessed via the group (container context): the group key must
+        // reflect that limit, while direct access to the same layer stays unrestricted
+        GWC.get().getConfig().setSecurityEnabled(true);
+        LayerInfo lakes = getCatalog().getLayerByName(getLayerId(MockData.LAKES));
+        LayerGroupInfo group = getCatalog().getLayerGroupByName(GROUP);
+        getRAM().putLimits("user_b", lakes, group, vectorFilter("NAME = 'Blue Lake'"));
+
+        // direct access ignores the group-scoped limit, so both users share the direct-layer cache
+        login("user_a", "test");
+        assertTileResult(MockData.LAKES, "MISS");
+        login("user_b", "test");
+        assertTileResult(MockData.LAKES, "HIT");
+
+        // group access applies the container-scoped limit for user_b, giving it a distinct key
+        login("user_a", "test");
+        assertTileResult(GROUP, 0, "MISS");
+        login("user_b", "test");
+        assertTileResult(GROUP, 0, "MISS");
+
+        login("user_b", "test");
+        assertTileResult(GROUP, 0, "HIT");
+    }
+
+    @Test
     public void testVectorIntersectFilterSeparatesCache() throws Exception {
         GWC.get().getConfig().setSecurityEnabled(true);
         LayerInfo layer = getCatalog().getLayerByName(getLayerId(MockData.BASIC_POLYGONS));

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -186,7 +186,10 @@ public class GeoServerTileLayerTest {
     public void tearDown() throws Exception {
         GWC.set(null, null);
         Dispatcher.REQUEST.remove();
-        GeoServerExtensionsHelper.clear();
+        // tests that set a context via setApplicationContext close it in their own
+        // try-with-resources; reset to null (not just clear caches) so the closed
+        // context is not referenced by later test methods
+        GeoServerExtensionsHelper.init(null);
     }
 
     @Before

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -6,13 +6,17 @@
 package org.geoserver.gwc.layer;
 
 import static org.geoserver.gwc.GWC.tileLayerName;
+import static org.geoserver.gwc.security.SecurityParameterFilter.ACCESS_LIMITS_KEY;
+import static org.geoserver.gwc.security.SecurityParameterFilter.SECURITY_TAGS_KEY;
 import static org.geotools.referencing.crs.DefaultGeographicCRS.WGS84;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -94,9 +98,15 @@ import org.geoserver.gwc.GWC;
 import org.geoserver.gwc.GWCSynchEnv;
 import org.geoserver.gwc.config.GWCConfig;
 import org.geoserver.gwc.dispatch.GwcServiceDispatcherCallback;
+import org.geoserver.gwc.security.AccessLimitsKeyBuilder;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.LocalWorkspace;
 import org.geoserver.ows.Request;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.security.DataAccessLimits;
+import org.geoserver.security.ResourceAccessManager;
+import org.geoserver.security.SecureCatalogImpl;
 import org.geoserver.util.DimensionWarning;
 import org.geoserver.util.DimensionWarning.WarningType;
 import org.geoserver.util.HTTPWarningAppender;
@@ -141,6 +151,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -175,6 +186,7 @@ public class GeoServerTileLayerTest {
     public void tearDown() throws Exception {
         GWC.set(null, null);
         Dispatcher.REQUEST.remove();
+        GeoServerExtensionsHelper.clear();
     }
 
     @Before
@@ -273,6 +285,7 @@ public class GeoServerTileLayerTest {
         layerGroup.setLayers(Collections.singletonList(layerInfo));
 
         defaults = GWCConfig.getOldDefaults();
+        when(mockGWC.getConfig()).thenReturn(defaults);
 
         when(catalog.getLayer(eq(layerInfoId))).thenReturn(layerInfo);
         when(catalog.getLayerGroup(eq(layerGroupId))).thenReturn(layerGroup);
@@ -415,6 +428,83 @@ public class GeoServerTileLayerTest {
             } else {
                 assertEquals(Collections.singletonMap("STYLES", legalStyle), modifiedParams);
             }
+        }
+    }
+
+    @Test
+    public void testGetParameterFiltersSecurityOn() {
+        defaults.setSecurityEnabled(true);
+        layerInfoTileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
+        List<ParameterFilter> parameterFilters = layerInfoTileLayer.getParameterFilters();
+        assertEquals(3, parameterFilters.size()); // STYLES + ACCESS_LIMITS_KEY + SECURITY_TAGS_KEY
+        assertThat(parameterFilters, hasItem(hasProperty("key", is(ACCESS_LIMITS_KEY))));
+        assertThat(parameterFilters, hasItem(hasProperty("key", is(SECURITY_TAGS_KEY))));
+    }
+
+    @Test
+    public void testGetParameterFiltersSecurityOff() {
+        defaults.setSecurityEnabled(false);
+        layerInfoTileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
+        List<ParameterFilter> parameterFilters = layerInfoTileLayer.getParameterFilters();
+        assertEquals(1, parameterFilters.size()); // STYLES
+        assertThat(parameterFilters, not(hasItem(hasProperty("key", is(ACCESS_LIMITS_KEY)))));
+        assertThat(parameterFilters, not(hasItem(hasProperty("key", is(SECURITY_TAGS_KEY)))));
+    }
+
+    @Test
+    public void testGetDefaultParameterFiltersSecurityOn() {
+        defaults.setSecurityEnabled(true);
+        layerInfoTileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
+        Map<String, String> defaultFilters = layerInfoTileLayer.getDefaultParameterFilters();
+        assertEquals(3, defaultFilters.size()); // STYLES + ACCESS_LIMITS_KEY + SECURITY_TAGS_KEY
+        assertEquals("", defaultFilters.get(ACCESS_LIMITS_KEY));
+        assertEquals("", defaultFilters.get(SECURITY_TAGS_KEY));
+    }
+
+    @Test
+    public void testModifiableParamsUnrestricted() throws GeoWebCacheException {
+        defaults.setSecurityEnabled(true);
+        // mock key builder returning null = unrestricted access
+        AccessLimitsKeyBuilder mockKeyBuilder = mock(AccessLimitsKeyBuilder.class);
+        ResourceAccessManager mockRam = mock(ResourceAccessManager.class);
+        when(mockRam.getAccessLimits(any(), any(LayerInfo.class))).thenReturn(mock(DataAccessLimits.class));
+        when(mockKeyBuilder.buildKey(any())).thenReturn(null);
+        SecureCatalogImpl mockSecureCatalog = mock(SecureCatalogImpl.class);
+        when(mockSecureCatalog.getResourceAccessManager()).thenReturn(mockRam);
+        try (GenericApplicationContext ctx = new GenericApplicationContext()) {
+            ctx.getBeanFactory().registerSingleton("keyBuilder", mockKeyBuilder);
+            ctx.getBeanFactory().registerSingleton("secureCatalog", mockSecureCatalog);
+            ctx.refresh();
+            new GeoServerExtensions().setApplicationContext(ctx);
+
+            layerInfoTileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
+            // non-default STYLES: result must not contain ACCESS_LIMITS_KEY
+            Map<String, String> params = Collections.singletonMap("sTyLeS", "alternateStyle-1");
+            Map<String, String> result = layerInfoTileLayer.getModifiableParameters(params, "UTF-8");
+            assertEquals(Collections.singletonMap("STYLES", "alternateStyle-1"), result);
+        }
+    }
+
+    @Test
+    public void testModifiableParamsWithSecurityKey() throws GeoWebCacheException {
+        defaults.setSecurityEnabled(true);
+        AccessLimitsKeyBuilder mockKeyBuilder = mock(AccessLimitsKeyBuilder.class);
+        ResourceAccessManager mockRam = mock(ResourceAccessManager.class);
+        when(mockRam.getAccessLimits(any(), any(LayerInfo.class))).thenReturn(mock(DataAccessLimits.class));
+        when(mockKeyBuilder.buildKey(any())).thenReturn("user_hash");
+        SecureCatalogImpl mockSecureCatalog = mock(SecureCatalogImpl.class);
+        when(mockSecureCatalog.getResourceAccessManager()).thenReturn(mockRam);
+        try (GenericApplicationContext ctx = new GenericApplicationContext()) {
+            ctx.getBeanFactory().registerSingleton("keyBuilder", mockKeyBuilder);
+            ctx.getBeanFactory().registerSingleton("secureCatalog", mockSecureCatalog);
+            ctx.refresh();
+            new GeoServerExtensions().setApplicationContext(ctx);
+
+            layerInfoTileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
+            Map<String, String> params = Collections.singletonMap("sTyLeS", "alternateStyle-1");
+            Map<String, String> result = layerInfoTileLayer.getModifiableParameters(params, "UTF-8");
+            assertEquals("alternateStyle-1", result.get("STYLES"));
+            assertEquals("user_hash", result.get(ACCESS_LIMITS_KEY));
         }
     }
 

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/AccessLimitsKeyBuilderTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/AccessLimitsKeyBuilderTest.java
@@ -1,0 +1,464 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Date;
+import java.util.HexFormat;
+import java.util.List;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.security.AccessLimits;
+import org.geoserver.security.CatalogMode;
+import org.geoserver.security.CoverageAccessLimits;
+import org.geoserver.security.DataAccessLimits;
+import org.geoserver.security.VectorAccessLimits;
+import org.geoserver.security.WMSAccessLimits;
+import org.geoserver.security.WMTSAccessLimits;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.expression.PropertyName;
+import org.geotools.api.parameter.GeneralParameterValue;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.gce.imagemosaic.ImageMosaicFormat;
+import org.geotools.parameter.DefaultParameterDescriptor;
+import org.geotools.parameter.Parameter;
+import org.geotools.util.DateRange;
+import org.geotools.util.NumberRange;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
+
+public class AccessLimitsKeyBuilderTest {
+
+    static final GeometryFactory GF = new GeometryFactory();
+    static final FilterFactory FF = CommonFactoryFinder.getFilterFactory();
+
+    // expected key strings are load-bearing: any change breaks existing tile caches
+    static final String TRIANGLE_WKT = "MULTIPOLYGON (((0 0, 0 1, 1 1, 0 0)))";
+
+    // limit chosen so a 500-char field value triggers truncation (JSON overhead ~14 chars -> total 514 > 300)
+    static final int TRUNC_LIMIT = 300;
+
+    AccessLimitsKeyBuilder builder;
+    AccessLimitsKeyBuilder truncBuilder;
+    IgnorableParameterRegistry ignorable;
+
+    @Before
+    public void setUp() {
+        ignorable = new IgnorableParameterRegistry();
+        builder = new AccessLimitsKeyBuilder(List.of(), ignorable);
+        truncBuilder = new AccessLimitsKeyBuilder(List.of(), ignorable, TRUNC_LIMIT);
+    }
+
+    @After
+    public void tearDown() {
+        GeoServerExtensionsHelper.clear();
+    }
+
+    /** CoverageAccessLimits with a single string parameter: convenient for truncation tests. */
+    private static CoverageAccessLimits coverageParam(String paramName, String value) {
+        DefaultParameterDescriptor<String> desc = new DefaultParameterDescriptor<>(paramName, String.class, null, null);
+        return new CoverageAccessLimits(
+                CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {new Parameter<>(desc, value)});
+    }
+
+    private static String sha256hex(String value) throws Exception {
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+        return HexFormat.of().formatHex(hash);
+    }
+
+    static MultiPolygon triangle() {
+        Polygon tri = GF.createPolygon(
+                new Coordinate[] {new Coordinate(0, 0), new Coordinate(0, 1), new Coordinate(1, 1), new Coordinate(0, 0)
+                });
+        return GF.createMultiPolygon(new Polygon[] {tri});
+    }
+
+    @Test
+    public void testNullReturnsNull() {
+        assertNull(builder.buildKey(null));
+    }
+
+    @Test
+    public void testBaseAccessLimitsReturnsNull() {
+        assertNull(builder.buildKey(new AccessLimits(CatalogMode.HIDE)));
+    }
+
+    @Test
+    public void testIncludeFilterReturnsNull() {
+        assertNull(builder.buildKey(new DataAccessLimits(CatalogMode.HIDE, Filter.INCLUDE)));
+    }
+
+    @Test
+    public void testEmptyVectorLimitsReturnsNull() {
+        VectorAccessLimits v = new VectorAccessLimits(CatalogMode.HIDE, null, Filter.INCLUDE, null, Filter.INCLUDE);
+        assertNull(builder.buildKey(v));
+    }
+
+    @Test
+    public void testDataFilter() throws Exception {
+        DataAccessLimits d = new DataAccessLimits(CatalogMode.HIDE, ECQL.toFilter("population > 1000"));
+        assertEquals("{\"readFilter\":\"population > 1000\"}", builder.buildKey(d));
+    }
+
+    @Test
+    public void testVectorAttributes() {
+        List<PropertyName> attrs = List.of(FF.property("name"), FF.property("pop"));
+        VectorAccessLimits v = new VectorAccessLimits(CatalogMode.HIDE, attrs, Filter.INCLUDE, null, Filter.INCLUDE);
+        assertEquals("{\"readAttributes\":\"name,pop\"}", builder.buildKey(v));
+    }
+
+    @Test
+    public void testVectorAttributesSorted() {
+        List<PropertyName> ab = List.of(FF.property("a"), FF.property("b"));
+        List<PropertyName> ba = List.of(FF.property("b"), FF.property("a"));
+        VectorAccessLimits va = new VectorAccessLimits(CatalogMode.HIDE, ab, Filter.INCLUDE, null, Filter.INCLUDE);
+        VectorAccessLimits vb = new VectorAccessLimits(CatalogMode.HIDE, ba, Filter.INCLUDE, null, Filter.INCLUDE);
+        assertEquals(builder.buildKey(va), builder.buildKey(vb));
+    }
+
+    @Test
+    public void testVectorClip() {
+        VectorAccessLimits v =
+                new VectorAccessLimits(CatalogMode.HIDE, null, Filter.INCLUDE, null, Filter.INCLUDE, triangle());
+        assertEquals("{\"clipVectorFilter\":\"" + TRIANGLE_WKT + "\"}", builder.buildKey(v));
+    }
+
+    @Test
+    public void testVectorIntersect() {
+        VectorAccessLimits v = new VectorAccessLimits(CatalogMode.HIDE, null, Filter.INCLUDE, null, Filter.INCLUDE);
+        v.setIntersectVectorFilter(GF.createPoint(new Coordinate(5, 5)));
+        assertEquals("{\"intersectVectorFilter\":\"POINT (5 5)\"}", builder.buildKey(v));
+    }
+
+    @Test
+    public void testCoverageRasterFilter() {
+        CoverageAccessLimits c = new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, triangle(), null);
+        assertEquals("{\"rasterFilter\":\"" + TRIANGLE_WKT + "\"}", builder.buildKey(c));
+    }
+
+    @Test
+    public void testWMSRasterFilter() {
+        WMSAccessLimits w = new WMSAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, triangle(), true);
+        assertEquals("{\"rasterFilter\":\"" + TRIANGLE_WKT + "\"}", builder.buildKey(w));
+    }
+
+    @Test
+    public void testWMSUnrestrictedReturnsNull() {
+        assertNull(builder.buildKey(new WMSAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, true)));
+    }
+
+    @Test
+    public void testWMTSRasterFilter() throws Exception {
+        WMTSAccessLimits w = new WMTSAccessLimits(CatalogMode.HIDE, ECQL.toFilter("population > 1000"), triangle());
+        assertEquals(
+                "{\"readFilter\":\"population > 1000\",\"rasterFilter\":\"" + TRIANGLE_WKT + "\"}",
+                builder.buildKey(w));
+    }
+
+    @Test
+    public void testCoverageIgnorableParam() {
+        Parameter<Boolean> mt = new Parameter<>(ImageMosaicFormat.ALLOW_MULTITHREADING, true);
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {mt});
+        assertNull(builder.buildKey(c));
+    }
+
+    @Test
+    public void testCoverageParam() {
+        DefaultParameterDescriptor<String> desc = new DefaultParameterDescriptor<>("BANDS", String.class, null, null);
+        Parameter<String> bands = new Parameter<>(desc, "1,2,3");
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {bands});
+        assertEquals("{\"BANDS\":\"1,2,3\"}", builder.buildKey(c));
+    }
+
+    @Test
+    public void testCoverageUnknownParamThrows() {
+        DefaultParameterDescriptor<double[]> desc =
+                new DefaultParameterDescriptor<>("MyArray", double[].class, null, null);
+        Parameter<double[]> bad = new Parameter<>(desc, new double[] {1.0, 2.0});
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {bad});
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> builder.buildKey(c));
+        assertThat(ex.getMessage(), containsString("MyArray"));
+        assertThat(ex.getMessage(), containsString(IgnorableParameterRegistry.SYSTEM_PROPERTY));
+    }
+
+    @Test
+    public void testLayerGroupAllUnrestricted() throws Exception {
+        List<String> names = List.of("ws:a", "ws:b");
+        List<AccessLimits> limits = List.of(
+                new DataAccessLimits(CatalogMode.HIDE, Filter.INCLUDE),
+                new DataAccessLimits(CatalogMode.HIDE, Filter.INCLUDE));
+        assertNull(builder.buildLayerGroupKey(names, limits));
+    }
+
+    @Test
+    public void testLayerGroupPartialRestriction() throws Exception {
+        DataAccessLimits restricted = new DataAccessLimits(CatalogMode.HIDE, ECQL.toFilter("population > 0"));
+        DataAccessLimits open = new DataAccessLimits(CatalogMode.HIDE, Filter.INCLUDE);
+        assertEquals(
+                "[{\"layer\":\"ws:a\",\"readFilter\":\"population > 0\"},{\"layer\":\"ws:b\"}]",
+                builder.buildLayerGroupKey(List.of("ws:a", "ws:b"), List.of(restricted, open)));
+    }
+
+    @Test
+    public void testLayerGroupSizeMismatch() {
+        assertThrows(IllegalArgumentException.class, () -> builder.buildLayerGroupKey(List.of("a"), List.of()));
+    }
+
+    @Test
+    public void testCustomSerializerPriority() {
+        ParameterValueKeySerializer<String> upper = new ParameterValueKeySerializer<>() {
+            @Override
+            public Class<String> getValueType() {
+                return String.class;
+            }
+
+            @Override
+            public String toKey(String value) {
+                return value.toUpperCase();
+            }
+        };
+        AccessLimitsKeyBuilder b2 = new AccessLimitsKeyBuilder(List.of(upper), ignorable);
+        DefaultParameterDescriptor<String> desc = new DefaultParameterDescriptor<>("TAG", String.class, null, null);
+        Parameter<String> tag = new Parameter<>(desc, "hello");
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {tag});
+        assertEquals("{\"TAG\":\"HELLO\"}", b2.buildKey(c));
+    }
+
+    @Test
+    public void testDuplicateSerializerFails() {
+        ParameterValueKeySerializer<String> s1 = () -> String.class;
+        ParameterValueKeySerializer<String> s2 = () -> String.class;
+        assertThrows(IllegalStateException.class, () -> new AccessLimitsKeyBuilder(List.of(s1, s2), ignorable));
+    }
+
+    @Test
+    public void testFilterNormalization() throws Exception {
+        DataAccessLimits a = new DataAccessLimits(CatalogMode.HIDE, ECQL.toFilter("13 = population"));
+        DataAccessLimits b = new DataAccessLimits(CatalogMode.HIDE, ECQL.toFilter("population = 13"));
+        assertEquals(builder.buildKey(a), builder.buildKey(b));
+    }
+
+    @Test
+    public void testTimeParam() {
+        Date t1 = new Date(1000L);
+        Date t2 = new Date(2000L);
+        DefaultParameterDescriptor<List> desc = new DefaultParameterDescriptor<>("TIME", List.class, null, null);
+        Parameter<List> time = new Parameter<>(desc, List.of(t1, t2));
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {time});
+        assertEquals("{\"TIME\":\"1970-01-01T00:00:01.000Z,1970-01-01T00:00:02.000Z\"}", builder.buildKey(c));
+    }
+
+    @Test
+    public void testTimeSorted() {
+        Date t1 = new Date(1000L);
+        Date t2 = new Date(2000L);
+        DefaultParameterDescriptor<List> desc = new DefaultParameterDescriptor<>("TIME", List.class, null, null);
+        Parameter<List> fwd = new Parameter<>(desc, List.of(t1, t2));
+        Parameter<List> rev = new Parameter<>(desc, List.of(t2, t1));
+        CoverageAccessLimits ca =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {fwd});
+        CoverageAccessLimits cb =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {rev});
+        assertEquals(builder.buildKey(ca), builder.buildKey(cb));
+    }
+
+    @Test
+    public void testDateRange() {
+        DateRange range = new DateRange(new Date(1000L), new Date(2000L));
+        DefaultParameterDescriptor<List> desc = new DefaultParameterDescriptor<>("TIME", List.class, null, null);
+        Parameter<List> time = new Parameter<>(desc, List.of(range));
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {time});
+        assertEquals("{\"TIME\":\"1970-01-01T00:00:01.000Z/1970-01-01T00:00:02.000Z\"}", builder.buildKey(c));
+    }
+
+    @Test
+    public void testNumberRange() {
+        NumberRange<Double> range = new NumberRange<>(Double.class, 100.0, 200.0);
+        DefaultParameterDescriptor<List> desc = new DefaultParameterDescriptor<>("ELEVATION", List.class, null, null);
+        Parameter<List> elev = new Parameter<>(desc, List.of(range));
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {elev});
+        assertEquals("{\"ELEVATION\":\"100.0/200.0\"}", builder.buildKey(c));
+    }
+
+    @Test
+    public void testCustomDimension() {
+        DefaultParameterDescriptor<List> desc = new DefaultParameterDescriptor<>("WAVELENGTH", List.class, null, null);
+        Parameter<List> dim = new Parameter<>(desc, List.of(1, 2, 3));
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {dim});
+        assertEquals("{\"WAVELENGTH\":\"1,2,3\"}", builder.buildKey(c));
+    }
+
+    @Test
+    public void testNoTruncationWhenUnderLimit() {
+        // 100-char value -> JSON ~114 chars, well under TRUNC_LIMIT=300
+        String key = truncBuilder.buildKey(coverageParam("PARAM_A", "A".repeat(100)));
+        assertThat(key, not(containsString("...too long")));
+        assertThat(key.length(), lessThanOrEqualTo(TRUNC_LIMIT));
+    }
+
+    @Test
+    public void testSingleFieldTruncated() throws Exception {
+        // 500-char value > 300 (truncation limit)
+        String longValue = "A".repeat(500);
+        String key = truncBuilder.buildKey(coverageParam("PARAM_A", longValue));
+        assertThat(key, containsString("...too long, sha is "));
+        assertThat(key, containsString(sha256hex(longValue)));
+        assertThat(key.length(), lessThanOrEqualTo(TRUNC_LIMIT));
+    }
+
+    @Test
+    public void testTruncationKeepsPrefix() {
+        // prefix must be at least MIN_FIELD_PREFIX chars of the original value
+        String longValue = "X".repeat(500);
+        String key = truncBuilder.buildKey(coverageParam("PARAM_A", longValue));
+        // value in JSON is between the opening quote and "...too long"
+        int valueStart = key.indexOf('"', key.indexOf(':') + 1) + 1;
+        int truncMarker = key.indexOf("...too long");
+        String visiblePrefix = key.substring(valueStart, truncMarker);
+        assertThat(visiblePrefix.length(), greaterThanOrEqualTo(50));
+        assertEquals(
+                "visible prefix must match original start",
+                longValue.substring(0, visiblePrefix.length()),
+                visiblePrefix);
+    }
+
+    @Test
+    public void testSameValueProducesSameKey() {
+        // two users with the same large restriction must share cache -> identical key
+        String longValue = "A".repeat(500);
+        String k1 = truncBuilder.buildKey(coverageParam("PARAM_A", longValue));
+        String k2 = truncBuilder.buildKey(coverageParam("PARAM_A", longValue));
+        assertEquals(k1, k2);
+    }
+
+    @Test
+    public void testDifferentValuesDifferentKeys() throws Exception {
+        // different long values must NOT share cache
+        String k1 = truncBuilder.buildKey(coverageParam("PARAM_A", "A".repeat(500)));
+        String k2 = truncBuilder.buildKey(coverageParam("PARAM_A", "A".repeat(499) + "B"));
+        assertNotEquals("different long values must yield different sha -> different keys", k1, k2);
+    }
+
+    @Test
+    public void testLongestFieldTruncatedFirst() throws Exception {
+        // PARAM_A=500 chars (long), PARAM_B=20 chars (short) - only PARAM_A needs truncating
+        String longValue = "A".repeat(500);
+        String shortValue = "B".repeat(20);
+        DefaultParameterDescriptor<String> descA =
+                new DefaultParameterDescriptor<>("PARAM_A", String.class, null, null);
+        DefaultParameterDescriptor<String> descB =
+                new DefaultParameterDescriptor<>("PARAM_B", String.class, null, null);
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {
+                    new Parameter<>(descA, longValue), new Parameter<>(descB, shortValue)
+                });
+        String key = truncBuilder.buildKey(c);
+        // long field must be truncated with sha
+        assertThat(key, containsString("...too long, sha is " + sha256hex(longValue)));
+        // short field must appear verbatim
+        assertThat(key, containsString("\"PARAM_B\":\"" + shortValue + "\""));
+        assertThat(key.length(), lessThanOrEqualTo(TRUNC_LIMIT));
+    }
+
+    @Test
+    public void testMultiFieldsTruncated() throws Exception {
+        // PARAM_A=500 chars, PARAM_B=500 chars - truncating only A is not enough
+        String valueA = "A".repeat(500);
+        String valueB = "B".repeat(500);
+        DefaultParameterDescriptor<String> descA =
+                new DefaultParameterDescriptor<>("PARAM_A", String.class, null, null);
+        DefaultParameterDescriptor<String> descB =
+                new DefaultParameterDescriptor<>("PARAM_B", String.class, null, null);
+        CoverageAccessLimits c =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {
+                    new Parameter<>(descA, valueA), new Parameter<>(descB, valueB)
+                });
+        String key = truncBuilder.buildKey(c);
+        assertThat(key, containsString("...too long, sha is " + sha256hex(valueA)));
+        assertThat(key, containsString("...too long, sha is " + sha256hex(valueB)));
+        assertThat(key.length(), lessThanOrEqualTo(TRUNC_LIMIT));
+    }
+
+    @Test
+    public void testLayerGroupFieldTruncated() {
+        // layer group with one entry whose rasterFilter WKT exceeds the limit
+        // a 30-vertex circle polygon produces ~700 chars of WKT - well over TRUNC_LIMIT=300
+        Coordinate[] coords = new Coordinate[31];
+        for (int i = 0; i < 30; i++) {
+            double a = 2 * Math.PI * i / 30;
+            coords[i] = new Coordinate(Math.cos(a) * 100, Math.sin(a) * 100);
+        }
+        coords[30] = coords[0]; // close the ring
+        MultiPolygon bigPoly = GF.createMultiPolygon(new Polygon[] {GF.createPolygon(coords)});
+        CoverageAccessLimits restricted = new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, bigPoly, null);
+        DataAccessLimits open = new DataAccessLimits(CatalogMode.HIDE, Filter.INCLUDE);
+        String key = truncBuilder.buildLayerGroupKey(List.of("ws:a", "ws:b"), List.of(restricted, open));
+        assertThat(key, containsString("...too long, sha is "));
+        // the second layer entry must still be present and untouched
+        assertThat(key, containsString("\"layer\":\"ws:b\""));
+        assertThat(key.length(), lessThanOrEqualTo(TRUNC_LIMIT));
+    }
+
+    @Test
+    public void testShortFieldNotTruncated() {
+        // field value <= MIN_FIELD_PREFIX(50) + SUFFIX_FIXED_LENGTH(84) = 134 chars cannot be truncated to shorter form
+        // use a tiny limit that can't be achieved - field must appear verbatim anyway
+        AccessLimitsKeyBuilder tinyLimitBuilder = new AccessLimitsKeyBuilder(List.of(), ignorable, 10);
+        String shortValue = "A".repeat(100); // 100 <= 134, skip truncation
+        String key = tinyLimitBuilder.buildKey(coverageParam("PARAM_A", shortValue));
+        // field untouched - no truncation marker present
+        assertThat(key, not(containsString("...too long")));
+        assertThat(key, containsString(shortValue));
+    }
+
+    @Test
+    public void testCollectsContributedSerializers() {
+        GeoServerExtensionsHelper.singleton(
+                "customParamSerializer", new CustomParamSerializer(), ParameterValueKeySerializer.class);
+
+        AccessLimitsKeyBuilder b = new AccessLimitsKeyBuilder(ignorable);
+        b.afterPropertiesSet();
+
+        CoverageAccessLimits limits =
+                new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, null, new GeneralParameterValue[] {
+                    new Parameter<>(CustomParamSerializer.DESCRIPTOR, new CustomParam("hello"))
+                });
+        assertEquals("{\"CUSTOM_PARAM\":\"hello\"}", b.buildKey(limits));
+    }
+
+    @Test
+    public void testDuplicateContributedFails() {
+        GeoServerExtensionsHelper.singleton("ser1", new CustomParamSerializer(), ParameterValueKeySerializer.class);
+        GeoServerExtensionsHelper.singleton("ser2", new CustomParamSerializer(), ParameterValueKeySerializer.class);
+
+        AccessLimitsKeyBuilder b = new AccessLimitsKeyBuilder(ignorable);
+        assertThrows(IllegalStateException.class, b::afterPropertiesSet);
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/CachingRAMIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/CachingRAMIntegrationTest.java
@@ -1,0 +1,117 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.xml.namespace.QName;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.data.test.SystemTestData.LayerProperty;
+import org.geoserver.gwc.GWC;
+import org.geoserver.security.CatalogMode;
+import org.geoserver.security.DataAccessLimits;
+import org.geoserver.security.TestResourceAccessManager;
+import org.geoserver.wms.WMSTestSupport;
+import org.geotools.api.filter.Filter;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Verifies that {@link org.geoserver.security.CachingResourceAccessManager} actually reduces inner-RAM invocations
+ * within a single GWC tile request. The {@link CountingResourceAccessManager} sits beneath the caching wrapper and
+ * counts real delegate calls; the caching wrapper bounds inner RAM calls to one per distinct method overload per
+ * request scope, not one per catalog check.
+ */
+public class CachingRAMIntegrationTest extends WMSTestSupport {
+
+    /**
+     * Inner RAM that counts {@link #getAccessLimits} invocations. Registered as a Spring bean so
+     * {@code lookupResourceAccessManager()} wraps it with {@code CachingResourceAccessManager}.
+     */
+    public static class CountingResourceAccessManager extends TestResourceAccessManager {
+
+        /** Shared counter, reset by the test before each request under examination. */
+        public static final AtomicInteger CALL_COUNT = new AtomicInteger();
+
+        @Override
+        public DataAccessLimits getAccessLimits(Authentication user, LayerInfo layer) {
+            CALL_COUNT.incrementAndGet();
+            return super.getAccessLimits(user, layer);
+        }
+    }
+
+    static final QName MOSAIC = new QName(MockData.SF_URI, "mosaic", MockData.SF_PREFIX);
+
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        springContextLocations.add("classpath:/org/geoserver/gwc/security/CachingRAMContext.xml");
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        GWC.get().getConfig().setSecurityEnabled(true);
+
+        testData.addStyle("raster", "raster.sld", SystemTestData.class, getCatalog());
+        testData.addRasterLayer(
+                MOSAIC,
+                "raster-filter-test.zip",
+                null,
+                Collections.singletonMap(LayerProperty.STYLE, "raster"),
+                SystemTestData.class,
+                getCatalog());
+
+        Catalog catalog = getCatalog();
+        CountingResourceAccessManager ram =
+                (CountingResourceAccessManager) applicationContext.getBean("testResourceAccessManager");
+        LayerInfo layer = catalog.getLayerByName(getLayerId(MOSAIC));
+        ram.putLimits("cite", layer, new DataAccessLimits(CatalogMode.HIDE, Filter.INCLUDE));
+    }
+
+    @Before
+    public void setUp() {
+        CountingResourceAccessManager.CALL_COUNT.set(0);
+    }
+
+    @Test
+    public void testCachingReducesInnerRAMCallsOnTileMiss() throws Exception {
+        login("cite", "cite", "ROLE_DUMMY");
+        String path = "gwc/service/wms?bgcolor=0x000000&LAYERS=sf:mosaic&STYLES=&FORMAT=image/png"
+                + "&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&SRS=EPSG:4326"
+                + "&BBOX=0,-90,180,90&WIDTH=256&HEIGHT=256&transparent=false";
+
+        // tile-miss: WMS sub-dispatch triggers additional catalog access checks, but
+        // the caching wrapper ensures each distinct (kind, user, target) is computed once
+        CountingResourceAccessManager.CALL_COUNT.set(0);
+        MockHttpServletResponse response = getAsServletResponse(path);
+        assertEquals("image/png", response.getContentType());
+        int missCalls = CountingResourceAccessManager.CALL_COUNT.get();
+
+        // tile-hit: GWC serves from cache; only computeSecurityKey() needs the inner RAM
+        CountingResourceAccessManager.CALL_COUNT.set(0);
+        response = getAsServletResponse(path);
+        assertEquals("image/png", response.getContentType());
+        int hitCalls = CountingResourceAccessManager.CALL_COUNT.get();
+
+        // Both requests produce 2 inner-RAM calls: one for computeSecurityKey() and one for the
+        // catalog security check. In the tile-miss case the WMS sub-dispatch runs on the same thread
+        // and inherits the same request scope, so the catalog check is already cached when the
+        // sub-dispatch runs -- no extra inner call. Without caching every catalog access in both
+        // the outer request and the sub-dispatch would invoke the inner RAM independently,
+        // bringing the total to 5+.
+        assertEquals("cached tile: inner RAM calls", 2, hitCalls);
+        assertEquals("tile miss: inner RAM calls with caching", 2, missCalls);
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/CustomParam.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/CustomParam.java
@@ -1,0 +1,8 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+/** Test value type for {@link ParameterValueKeySerializer} extension point tests. */
+public record CustomParam(String value) {}

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/CustomParamSerializer.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/CustomParamSerializer.java
@@ -1,0 +1,24 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import org.geotools.parameter.DefaultParameterDescriptor;
+
+/** Test serializer for {@link CustomParam} - registered as a Spring bean in integration tests. */
+public class CustomParamSerializer implements ParameterValueKeySerializer<CustomParam> {
+
+    public static final DefaultParameterDescriptor<CustomParam> DESCRIPTOR =
+            new DefaultParameterDescriptor<>("CUSTOM_PARAM", CustomParam.class, null, null);
+
+    @Override
+    public Class<CustomParam> getValueType() {
+        return CustomParam.class;
+    }
+
+    @Override
+    public String toKey(CustomParam value) {
+        return value.value();
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/IgnorableParameterRegistryTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/IgnorableParameterRegistryTest.java
@@ -1,0 +1,60 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.gce.imagemosaic.ImageMosaicFormat;
+import org.geotools.parameter.DefaultParameterDescriptor;
+import org.geotools.parameter.Parameter;
+import org.junit.Test;
+
+public class IgnorableParameterRegistryTest {
+
+    @Test
+    public void testBuiltIns() {
+        IgnorableParameterRegistry reg = new IgnorableParameterRegistry();
+        assertTrue(reg.isIgnorable(new Parameter<>(ImageMosaicFormat.ALLOW_MULTITHREADING)));
+        assertTrue(reg.isIgnorable(new Parameter<>(ImageMosaicFormat.MAX_ALLOWED_TILES)));
+        assertTrue(reg.isIgnorable(new Parameter<>(AbstractGridFormat.SUGGESTED_TILE_SIZE)));
+    }
+
+    @Test
+    public void testNotIgnorable() {
+        IgnorableParameterRegistry reg = new IgnorableParameterRegistry();
+        assertFalse(reg.isIgnorable(new Parameter<>(ImageMosaicFormat.FILTER)));
+    }
+
+    @Test
+    public void testRegister() {
+        DefaultParameterDescriptor<Boolean> custom =
+                new DefaultParameterDescriptor<>("MyCustomParam", Boolean.class, null, null);
+        IgnorableParameterRegistry reg = new IgnorableParameterRegistry();
+        reg.registerIgnorable(custom);
+        assertTrue(reg.isIgnorable(new Parameter<>(custom)));
+        // built-ins still present
+        assertTrue(reg.isIgnorable(new Parameter<>(ImageMosaicFormat.ALLOW_MULTITHREADING)));
+    }
+
+    @Test
+    public void testSystemProperty() {
+        System.setProperty(IgnorableParameterRegistry.SYSTEM_PROPERTY, "MY_CUSTOM_PARAM, ANOTHER_PARAM");
+        try {
+            IgnorableParameterRegistry reg = new IgnorableParameterRegistry();
+            assertTrue(reg.isIgnorable(param("MY_CUSTOM_PARAM")));
+            assertTrue(reg.isIgnorable(param("ANOTHER_PARAM")));
+            // built-ins still present
+            assertTrue(reg.isIgnorable(new Parameter<>(ImageMosaicFormat.ALLOW_MULTITHREADING)));
+        } finally {
+            System.clearProperty(IgnorableParameterRegistry.SYSTEM_PROPERTY);
+        }
+    }
+
+    private static Parameter<String> param(String name) {
+        return new Parameter<>(new DefaultParameterDescriptor<>(name, String.class, null, null));
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/KeySerializerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/KeySerializerTest.java
@@ -1,0 +1,102 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.geotools.api.filter.Filter;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.referencing.CRS;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+
+public class KeySerializerTest {
+
+    static final GeometryFactory GF = new GeometryFactory();
+
+    @Test
+    public void testFilterNormalization() throws Exception {
+        // literal-left swap: "13 = population" and "population = 13" must produce the same key
+        Filter a = ECQL.toFilter("13 = population");
+        Filter b = ECQL.toFilter("population = 13");
+        assertEquals(AccessLimitsKeyBuilder.serializeFilter(b), AccessLimitsKeyBuilder.serializeFilter(a));
+    }
+
+    @Test
+    public void testFilterEcql() throws Exception {
+        Filter f = ECQL.toFilter("population > 1000");
+        String key = AccessLimitsKeyBuilder.serializeFilter(f);
+        // round-trip: re-parsing the key must produce a semantically equal filter
+        assertEquals(f, ECQL.toFilter(key));
+    }
+
+    @Test
+    public void testGeometryNorm() {
+        // two rings with same vertices in different order -> same key after norm()
+        Coordinate[] cw = {
+            new Coordinate(0, 0), new Coordinate(0, 1), new Coordinate(1, 1), new Coordinate(1, 0), new Coordinate(0, 0)
+        };
+        Coordinate[] ccw = {
+            new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(1, 1), new Coordinate(0, 1), new Coordinate(0, 0)
+        };
+        Geometry a = GF.createPolygon(GF.createLinearRing(cw));
+        Geometry b = GF.createPolygon(GF.createLinearRing(ccw));
+        assertEquals(AccessLimitsKeyBuilder.serializeGeometry(a), AccessLimitsKeyBuilder.serializeGeometry(b));
+    }
+
+    @Test
+    public void testCrsUserData() throws Exception {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:4326");
+        Geometry geom = GF.createPoint(new Coordinate(10, 20));
+        geom.setUserData(crs);
+        String key = AccessLimitsKeyBuilder.serializeGeometry(geom);
+        assertThat(key, startsWith("EPSG:4326:"));
+    }
+
+    @Test
+    public void testCrsSrid() {
+        Geometry geom = GF.createPoint(new Coordinate(10, 20));
+        geom.setSRID(3857);
+        String key = AccessLimitsKeyBuilder.serializeGeometry(geom);
+        assertThat(key, startsWith("EPSG:3857:"));
+    }
+
+    @Test
+    public void testNoCrs() {
+        Geometry geom = GF.createPoint(new Coordinate(10, 20));
+        // SRID defaults to 0, no userData
+        String key = AccessLimitsKeyBuilder.serializeGeometry(geom);
+        assertEquals("POINT (10 20)", key);
+    }
+
+    @Test
+    public void testCrsUserDataWins() throws Exception {
+        // userData CRS wins; SRID is ignored when userData is set
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:4326");
+        Geometry geom = GF.createPoint(new Coordinate(10, 20));
+        geom.setUserData(crs);
+        geom.setSRID(3857);
+        String key = AccessLimitsKeyBuilder.serializeGeometry(geom);
+        assertThat(key, startsWith("EPSG:4326:"));
+    }
+
+    @Test
+    public void testDifferentCrs() throws Exception {
+        Geometry geom4326 = GF.createPoint(new Coordinate(10, 20));
+        geom4326.setSRID(4326);
+        Geometry geom3857 = GF.createPoint(new Coordinate(10, 20));
+        geom3857.setSRID(3857);
+        assertNotEquals(
+                "same WKT in different CRS must produce different keys",
+                AccessLimitsKeyBuilder.serializeGeometry(geom4326),
+                AccessLimitsKeyBuilder.serializeGeometry(geom3857));
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/NormalizingFilterVisitorTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/NormalizingFilterVisitorTest.java
@@ -1,0 +1,105 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import static org.junit.Assert.assertEquals;
+
+import org.geotools.api.filter.Filter;
+import org.geotools.filter.text.ecql.ECQL;
+import org.junit.Test;
+
+public class NormalizingFilterVisitorTest {
+
+    static final NormalizingFilterVisitor VISITOR = new NormalizingFilterVisitor();
+
+    private static Filter normalize(Filter f) {
+        return (Filter) f.accept(VISITOR, null);
+    }
+
+    @Test
+    public void testEqualSwap() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("13 = foo"));
+        Filter expected = ECQL.toFilter("foo = 13");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testGtSwap() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("13 > foo"));
+        Filter expected = ECQL.toFilter("foo < 13");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testGteSwap() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("13 >= foo"));
+        Filter expected = ECQL.toFilter("foo <= 13");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testLtSwap() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("13 < foo"));
+        Filter expected = ECQL.toFilter("foo > 13");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testLteSwap() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("13 <= foo"));
+        Filter expected = ECQL.toFilter("foo >= 13");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testPropertyLeft() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("foo = 13"));
+        Filter expected = ECQL.toFilter("foo = 13");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testAndSort() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("foo = 1 AND bar = 2"));
+        Filter expected = ECQL.toFilter("bar = 2 AND foo = 1");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testOrSort() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("foo = 1 OR bar = 2"));
+        Filter expected = ECQL.toFilter("bar = 2 OR foo = 1");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testAndSwapSort() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("13 = foo AND bar = 'x'"));
+        Filter expected = ECQL.toFilter("bar = 'x' AND foo = 13");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testOrSort3() throws Exception {
+        // normalize flattens nested OR (via SimplifyingFilterVisitor), so expected must also be normalized
+        Filter expected = normalize(ECQL.toFilter("a = 1 OR b = 2 OR c = 3"));
+        assertEquals(expected, normalize(ECQL.toFilter("c = 3 OR a = 1 OR b = 2")));
+        assertEquals(expected, normalize(ECQL.toFilter("b = 2 OR c = 3 OR a = 1")));
+    }
+
+    @Test
+    public void testInSort() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("in3(foo,'c','a','b') = true"));
+        Filter expected = ECQL.toFilter("in3(foo,'a','b','c') = true");
+        assertEquals(expected, normalized);
+    }
+
+    @Test
+    public void testInAlreadySorted() throws Exception {
+        Filter normalized = normalize(ECQL.toFilter("in3(foo,'a','b','c') = true"));
+        Filter expected = ECQL.toFilter("in3(foo,'a','b','c') = true");
+        assertEquals(expected, normalized);
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/PrecisionAgricultureRAM.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/PrecisionAgricultureRAM.java
@@ -1,0 +1,140 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.security.AbstractResourceAccessManager;
+import org.geoserver.security.CatalogMode;
+import org.geoserver.security.CoverageAccessLimits;
+import org.geoserver.security.DataAccessLimits;
+import org.geoserver.security.VectorAccessLimits;
+import org.geotools.api.filter.Filter;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.filter.text.ecql.ECQL;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Test RAM modeling precision agriculture access control: each user owns a set of "fields" identified by integer IDs.
+ * Users can only read records/raster areas belonging to their fields. A manager user can own multiple fields.
+ *
+ * <p>For raster layers, access limits are a {@link CoverageAccessLimits} with the union of the user's field geometries
+ * as raster clip. For vector layers, access limits are a {@link VectorAccessLimits} with a {@code FIELD_ID IN (...)}
+ * filter. Security tags are set to {@code "field:N"} for each owned field N - allowing targeted cache invalidation when
+ * a specific field's ownership changes.
+ *
+ * <p>Also implements {@link SecurityCacheInvalidationSource}: calling {@link #addField} or {@link #removeField}
+ * notifies all registered listeners with a {@link SecurityConfigurationChangeEvent} carrying the changed field tag.
+ */
+public class PrecisionAgricultureRAM extends AbstractResourceAccessManager implements SecurityCacheInvalidationSource {
+
+    private static final GeometryFactory GF = new GeometryFactory();
+
+    private final Map<String, Set<Integer>> userFields = new ConcurrentHashMap<>();
+    private final List<SecurityCacheInvalidationListener> listeners = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void register(SecurityCacheInvalidationListener listener) {
+        listeners.add(listener);
+    }
+
+    /** Sets the initial field assignment without firing an invalidation event. For test setup only. */
+    public void setInitialFields(String username, int... fieldIds) {
+        Set<Integer> fields = ConcurrentHashMap.newKeySet();
+        for (int id : fieldIds) fields.add(id);
+        userFields.put(username, fields);
+    }
+
+    public void addField(String username, int fieldId) {
+        userFields.computeIfAbsent(username, k -> ConcurrentHashMap.newKeySet()).add(fieldId);
+        fireEvent(fieldId);
+    }
+
+    public void removeField(String username, int fieldId) {
+        Set<Integer> fields = userFields.get(username);
+        if (fields != null) fields.remove(fieldId);
+        fireEvent(fieldId);
+    }
+
+    /** Revokes several fields at once, firing a single event carrying all the affected tags. */
+    public void removeFields(String username, int... fieldIds) {
+        Set<Integer> fields = userFields.get(username);
+        for (int id : fieldIds) {
+            if (fields != null) fields.remove(id);
+        }
+        fireEvent(fieldIds);
+    }
+
+    private void fireEvent(int... fieldIds) {
+        Set<String> tags = new HashSet<>();
+        for (int id : fieldIds) tags.add("field:" + id);
+        SecurityConfigurationChangeEvent event = new SecurityConfigurationChangeEvent(null, tags);
+        for (SecurityCacheInvalidationListener listener : listeners) {
+            listener.onSecurityConfigChange(event);
+        }
+    }
+
+    @Override
+    public DataAccessLimits getAccessLimits(Authentication user, LayerInfo layer) {
+        return getAccessLimits(user, layer.getResource());
+    }
+
+    @Override
+    public DataAccessLimits getAccessLimits(Authentication user, ResourceInfo resource) {
+        String username = user != null ? user.getName() : null;
+        Set<Integer> fields = userFields.get(username);
+        if (fields == null || fields.isEmpty()) return null;
+
+        Set<String> tags = fields.stream().map(f -> "field:" + f).collect(Collectors.toSet());
+
+        if (resource instanceof CoverageInfo) {
+            Polygon[] polygons = fields.stream()
+                    .sorted()
+                    .map(PrecisionAgricultureRAM::fieldPolygon)
+                    .toArray(Polygon[]::new);
+            MultiPolygon clip = GF.createMultiPolygon(polygons);
+            CoverageAccessLimits limits = new CoverageAccessLimits(CatalogMode.HIDE, Filter.INCLUDE, clip, null);
+            limits.setSecurityTags(tags);
+            return limits;
+        }
+
+        String inList = fields.stream().sorted().map(Object::toString).collect(Collectors.joining(", "));
+        Filter filter;
+        try {
+            filter = ECQL.toFilter("FIELD_ID IN (" + inList + ")");
+        } catch (CQLException e) {
+            throw new IllegalStateException("Failed to build field filter: " + inList, e);
+        }
+        VectorAccessLimits limits = new VectorAccessLimits(CatalogMode.HIDE, null, filter, null, Filter.INCLUDE);
+        limits.setSecurityTags(tags);
+        return limits;
+    }
+
+    /**
+     * Returns a 1x1 unit square for the given field ID. Fields are laid out in a row: field 1 = (0,0)-(1,1), field 2 =
+     * (2,0)-(3,1), field 3 = (4,0)-(5,1), etc.
+     */
+    static Polygon fieldPolygon(int fieldId) {
+        double x = (fieldId - 1) * 2.0;
+        Coordinate[] ring = {
+            new Coordinate(x, 0), new Coordinate(x, 1),
+            new Coordinate(x + 1, 1), new Coordinate(x + 1, 0),
+            new Coordinate(x, 0)
+        };
+        return GF.createPolygon(ring);
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/SecurityCacheInvalidatorTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/SecurityCacheInvalidatorTest.java
@@ -1,0 +1,260 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import static org.geoserver.gwc.security.SecurityParameterFilter.ACCESS_LIMITS_KEY;
+import static org.geoserver.gwc.security.SecurityParameterFilter.SECURITY_TAGS_KEY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.security.impl.LayerGroupContainmentCache;
+import org.geoserver.security.impl.LayerGroupContainmentCache.LayerGroupSummary;
+import org.geowebcache.filter.parameters.ParametersUtils;
+import org.geowebcache.layer.TileLayerDispatcher;
+import org.geowebcache.storage.StorageBroker;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SecurityCacheInvalidator}. Uses a mock {@link StorageBroker} to verify that the correct
+ * parameter sets are deleted for each invalidation scenario.
+ *
+ * <p>Layer "farm:fields" simulates a secured layer with several cached parameter combinations representing different
+ * users' access profiles. Each combination carries {@code ACCESS_LIMITS_KEY} (content fingerprint) and optionally
+ * {@code SECURITY_TAGS_KEY} (field ownership tags).
+ */
+public class SecurityCacheInvalidatorTest {
+
+    static final String LAYER = "farm:fields";
+
+    // cached parameter maps representing access profiles for different field combinations
+    static final Map<String, String> PARAMS_FIELD1 = params("{\"readFilter\":\"FIELD_ID IN (1)\"}", "field:1");
+    static final Map<String, String> PARAMS_FIELD2 = params("{\"readFilter\":\"FIELD_ID IN (2)\"}", "field:2");
+    static final Map<String, String> PARAMS_FIELD1_2 =
+            params("{\"readFilter\":\"FIELD_ID IN (1, 2)\"}", "field:1,field:2");
+    static final Map<String, String> PARAMS_FIELD2_3 =
+            params("{\"readFilter\":\"FIELD_ID IN (2, 3)\"}", "field:2,field:3");
+    // unrestricted - no ACCESS_LIMITS_KEY
+    static final Map<String, String> PARAMS_UNRESTRICTED = Map.of("STYLES", "");
+
+    private StorageBroker mockBroker;
+    private TileLayerDispatcher mockDispatcher;
+    private Catalog mockCatalog;
+    private LayerGroupContainmentCache mockContainmentCache;
+    private PrecisionAgricultureRAM ram;
+    private SecurityCacheInvalidator invalidator;
+
+    @Before
+    public void setUp() throws Exception {
+        mockBroker = mock(StorageBroker.class);
+        mockDispatcher = mock(TileLayerDispatcher.class);
+        when(mockDispatcher.getLayerNames()).thenReturn(Set.of(LAYER));
+        mockCatalog = mock(Catalog.class);
+        mockContainmentCache = mock(LayerGroupContainmentCache.class);
+        ram = new PrecisionAgricultureRAM();
+        invalidator = new SecurityCacheInvalidator(mockBroker, mockDispatcher, mockCatalog, mockContainmentCache);
+        ram.register(invalidator);
+    }
+
+    @Test
+    public void testSingleFieldUserRevoke() throws Exception {
+        // farmer_alice has field 1 cached; revoke fires event for "field:1" -> that tile set deleted
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of(PARAMS_FIELD1, PARAMS_UNRESTRICTED));
+        ram.addField("farmer_alice", 1);
+        ram.removeField("farmer_alice", 1);
+        // two events fired (add + remove), each should delete PARAMS_FIELD1
+        verify(mockBroker, times(2)).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1));
+        verify(mockBroker, never()).deleteByParametersId(eq(LAYER), eq(ParametersUtils.getId(PARAMS_UNRESTRICTED)));
+    }
+
+    @Test
+    public void testEventMatchesTileWithMultipleTags() throws Exception {
+        // tile tagged "field:1,field:2" - event for field:1 must delete it
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of(PARAMS_FIELD1_2));
+        ram.addField("manager", 1);
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1_2));
+    }
+
+    @Test
+    public void testEventDoesNotDeleteUnrelatedField() throws Exception {
+        // tiles for field 2 and field 2+3 should not be touched by a field:1 event
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of(PARAMS_FIELD2, PARAMS_FIELD2_3));
+        ram.addField("farmer_alice", 1);
+        verify(mockBroker, never()).deleteByParametersId(eq(LAYER), eq(ParametersUtils.getId(PARAMS_FIELD2)));
+        verify(mockBroker, never()).deleteByParametersId(eq(LAYER), eq(ParametersUtils.getId(PARAMS_FIELD2_3)));
+    }
+
+    @Test
+    public void testNullTagDeletesAllSecurityKeyedTiles() throws Exception {
+        // event with targetTag=null drops all entries carrying ACCESS_LIMITS_KEY
+        when(mockBroker.getCachedParameters(LAYER))
+                .thenReturn(Set.of(PARAMS_FIELD1, PARAMS_FIELD2, PARAMS_FIELD1_2, PARAMS_UNRESTRICTED));
+        SecurityConfigurationChangeEvent event = new SecurityConfigurationChangeEvent(null, null);
+        invalidator.onSecurityConfigChange(event);
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1));
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD2));
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1_2));
+        verify(mockBroker, never()).deleteByParametersId(eq(LAYER), eq(ParametersUtils.getId(PARAMS_UNRESTRICTED)));
+    }
+
+    @Test
+    public void testUnrestrictedTilesNeverDeleted() throws Exception {
+        // tiles without ACCESS_LIMITS_KEY are never touched, regardless of targetTag
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of(PARAMS_UNRESTRICTED));
+        SecurityConfigurationChangeEvent event = new SecurityConfigurationChangeEvent(null, null);
+        invalidator.onSecurityConfigChange(event);
+        verify(mockBroker, never()).deleteByParametersId(eq(LAYER), eq(ParametersUtils.getId(PARAMS_UNRESTRICTED)));
+    }
+
+    @Test
+    public void testNullAffectedLayersSweepsAll() throws Exception {
+        // a null scope means "unknown" -> every tile layer is swept
+        String otherLayer = "other:layer";
+        when(mockDispatcher.getLayerNames()).thenReturn(Set.of(LAYER, otherLayer));
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of(PARAMS_FIELD1));
+        when(mockBroker.getCachedParameters(otherLayer)).thenReturn(Set.of(PARAMS_FIELD1));
+
+        invalidator.onSecurityConfigChange(new SecurityConfigurationChangeEvent(null, Set.of("field:1")));
+
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1));
+        verify(mockBroker).deleteByParametersId(otherLayer, ParametersUtils.getId(PARAMS_FIELD1));
+    }
+
+    @Test
+    public void testScopedAffectedLayersExcludesOthers() throws Exception {
+        // a non-null scope must invalidate only the listed layers, never an unrelated one
+        String otherLayer = "other:layer";
+        when(mockDispatcher.getLayerNames()).thenReturn(Set.of(LAYER, otherLayer));
+        LayerInfo affected = mock(LayerInfo.class);
+        when(affected.getId()).thenReturn("layer-1");
+        when(affected.prefixedName()).thenReturn(LAYER);
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of(PARAMS_FIELD1));
+
+        invalidator.onSecurityConfigChange(new SecurityConfigurationChangeEvent(Set.of(affected), null));
+
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1));
+        verify(mockBroker, never()).getCachedParameters(otherLayer);
+    }
+
+    @Test
+    public void testMultiFieldUserRevokeSingleField() throws Exception {
+        // manager has fields 1 and 2; cached tiles: field:1 only, field:2 only, field:1,2 combined
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of(PARAMS_FIELD1, PARAMS_FIELD2, PARAMS_FIELD1_2));
+        ram.addField("manager", 1);
+        ram.addField("manager", 2);
+        // each add event fires for its tag; after two adds: field:1 event fired once, field:2 event once
+        // field:1 event should delete PARAMS_FIELD1 and PARAMS_FIELD1_2 (both carry field:1 tag)
+        // field:2 event should delete PARAMS_FIELD2 and PARAMS_FIELD1_2 (both carry field:2 tag)
+        verify(mockBroker, times(1)).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1));
+        verify(mockBroker, times(1)).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD2));
+        // PARAMS_FIELD1_2 matches both events so deleted twice
+        verify(mockBroker, times(2)).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1_2));
+    }
+
+    @Test
+    public void testRevokeFieldFromManagerLeavesOtherFieldTilesIntact() throws Exception {
+        // pre-populate manager with fields 1+2 without firing events, then revoke field 1 only
+        ram.setInitialFields("manager", 1, 2);
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of(PARAMS_FIELD1, PARAMS_FIELD2, PARAMS_FIELD1_2));
+
+        ram.removeField("manager", 1); // fires field:1 event only
+
+        // field:1 event must delete tiles carrying field:1 tag
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1));
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1_2));
+        // PARAMS_FIELD2 (tagged only "field:2") must not be touched
+        verify(mockBroker, never()).deleteByParametersId(eq(LAYER), eq(ParametersUtils.getId(PARAMS_FIELD2)));
+    }
+
+    @Test
+    public void testEmptyCachedParameters() throws Exception {
+        // no cached params - no deletions, no exceptions
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of());
+        SecurityConfigurationChangeEvent event = new SecurityConfigurationChangeEvent(null, Set.of("field:1"));
+        invalidator.onSecurityConfigChange(event);
+        verify(mockBroker, never()).deleteByParametersId(eq(LAYER), eq(ParametersUtils.getId(PARAMS_FIELD1)));
+    }
+
+    @Test
+    public void testMemberLayerEventInvalidatesContainingGroup() throws Exception {
+        // a member-layer change must also sweep the group tile-layer, whose tiles embed the member's limits.
+        // the containing groups come from LayerGroupContainmentCache, keyed by the member's resource
+        String groupName = "farm:overview";
+        ResourceInfo resource = mock(ResourceInfo.class);
+        LayerInfo affected = mock(LayerInfo.class);
+        when(affected.getId()).thenReturn("layer-1");
+        when(affected.prefixedName()).thenReturn(LAYER);
+        when(affected.getResource()).thenReturn(resource);
+        LayerGroupSummary group = mock(LayerGroupSummary.class);
+        when(group.prefixedName()).thenReturn(groupName);
+        when(mockContainmentCache.getContainerGroupsFor(resource, true)).thenReturn(List.of(group));
+        when(mockDispatcher.getLayerNames()).thenReturn(Set.of(LAYER, groupName));
+        when(mockBroker.getCachedParameters(LAYER)).thenReturn(Set.of(PARAMS_FIELD1));
+        when(mockBroker.getCachedParameters(groupName)).thenReturn(Set.of(PARAMS_FIELD1));
+
+        invalidator.onSecurityConfigChange(new SecurityConfigurationChangeEvent(Set.of(affected), Set.of("field:1")));
+
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1));
+        verify(mockBroker).deleteByParametersId(groupName, ParametersUtils.getId(PARAMS_FIELD1));
+    }
+
+    @Test
+    public void testMultiTagEventDeletesAnyMatch() throws Exception {
+        // a single event carrying several tags must delete every tile matching any of them
+        when(mockBroker.getCachedParameters(LAYER))
+                .thenReturn(Set.of(PARAMS_FIELD1, PARAMS_FIELD2, PARAMS_FIELD1_2, PARAMS_FIELD2_3));
+        ram.setInitialFields("manager", 1, 3);
+        ram.removeFields("manager", 1, 3); // one event with tags {field:1, field:3}
+
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1)); // field:1
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD1_2)); // field:1
+        verify(mockBroker).deleteByParametersId(LAYER, ParametersUtils.getId(PARAMS_FIELD2_3)); // field:3
+        // PARAMS_FIELD2 (only field:2) matches neither
+        verify(mockBroker, never()).deleteByParametersId(eq(LAYER), eq(ParametersUtils.getId(PARAMS_FIELD2)));
+    }
+
+    @Test
+    public void testContainsAnyTagHelper() {
+        assertTrue(SecurityCacheInvalidator.containsAnyTag("field:1", Set.of("field:1")));
+        assertTrue(SecurityCacheInvalidator.containsAnyTag("field:1,field:2", Set.of("field:1")));
+        assertTrue(SecurityCacheInvalidator.containsAnyTag("field:1,field:2", Set.of("field:3", "field:2")));
+        assertFalse(SecurityCacheInvalidator.containsAnyTag("field:2", Set.of("field:1")));
+        assertFalse(SecurityCacheInvalidator.containsAnyTag(null, Set.of("field:1")));
+        assertFalse(SecurityCacheInvalidator.containsAnyTag("", Set.of("field:1")));
+        assertFalse(SecurityCacheInvalidator.containsAnyTag("field:10", Set.of("field:1"))); // no partial match
+    }
+
+    @Test
+    public void testEventTargetTagWithCommaRejected() {
+        // a comma in a tag would never match a stored tag (split on commas), leaving stale tiles behind
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> new SecurityConfigurationChangeEvent(null, Set.of("field:1,field:2")));
+        assertThat(e.getMessage(), containsString("field:1,field:2"));
+    }
+
+    private static Map<String, String> params(String accessKey, String tags) {
+        Map<String, String> m = new HashMap<>();
+        m.put(ACCESS_LIMITS_KEY, accessKey);
+        if (tags != null) m.put(SECURITY_TAGS_KEY, tags);
+        return m;
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/security/SecurityParameterFilterTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/security/SecurityParameterFilterTest.java
@@ -1,0 +1,40 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+public class SecurityParameterFilterTest {
+
+    @Test
+    public void testNotUserVisible() {
+        // keeps the synthetic filter out of preview, seed form and WMS/WMTS capabilities
+        SecurityParameterFilter filter = new SecurityParameterFilter(SecurityParameterFilter.ACCESS_LIMITS_KEY);
+        assertFalse(filter.isUserVisible());
+    }
+
+    @Test
+    public void testApplyPassesThrough() {
+        SecurityParameterFilter filter = new SecurityParameterFilter(SecurityParameterFilter.ACCESS_LIMITS_KEY);
+        assertEquals("somekey", filter.apply("somekey"));
+    }
+
+    @Test
+    public void testApplyNullReturnsDefault() {
+        SecurityParameterFilter filter = new SecurityParameterFilter(SecurityParameterFilter.ACCESS_LIMITS_KEY);
+        assertEquals("", filter.apply(null));
+    }
+
+    @Test
+    public void testReadResolveRejected() {
+        // synthetic filter must never be reconstructed from persisted config
+        SecurityParameterFilter filter = new SecurityParameterFilter(SecurityParameterFilter.ACCESS_LIMITS_KEY);
+        assertThrows(UnsupportedOperationException.class, filter::readResolve);
+    }
+}

--- a/src/gwc/src/test/resources/org/geoserver/gwc/security/CachingRAMContext.xml
+++ b/src/gwc/src/test/resources/org/geoserver/gwc/security/CachingRAMContext.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<beans>
+  <bean id="testResourceAccessManager"
+        class="org.geoserver.gwc.security.CachingRAMIntegrationTest$CountingResourceAccessManager"/>
+</beans>

--- a/src/gwc/src/test/resources/org/geoserver/gwc/security/CustomParamSerializerContext.xml
+++ b/src/gwc/src/test/resources/org/geoserver/gwc/security/CustomParamSerializerContext.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<beans>
+  <bean id="customParamSerializer"
+        class="org.geoserver.gwc.security.CustomParamSerializer"/>
+</beans>

--- a/src/main/src/main/java/org/geoserver/catalog/LayerGroupHelper.java
+++ b/src/main/src/main/java/org/geoserver/catalog/LayerGroupHelper.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Stack;
+import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.catalog.LayerGroupInfo.Mode;
@@ -250,8 +251,18 @@ public class LayerGroupHelper {
 
     public List<LayerInfo> allLayersForRendering() {
         List<LayerInfo> layers = new ArrayList<>();
-        allLayersForRendering(group, null, layers, true);
+        allLayersForRendering((layer, containers) -> layers.add(layer));
         return layers;
+    }
+
+    /**
+     * Visits every leaf layer that would be rendered for this group, together with the chain of groups containing it
+     * (top group first, direct parent last), mirroring {@link #allLayersForRendering()} including mode handling. The
+     * container list handed to the consumer is a snapshot safe to retain. Self-referential groups are skipped, so the
+     * traversal terminates even on a cyclic (invalid) structure.
+     */
+    public void allLayersForRendering(BiConsumer<LayerInfo, List<LayerGroupInfo>> consumer) {
+        allLayersForRendering(group, null, true, List.of(), consumer);
     }
 
     /**
@@ -270,10 +281,20 @@ public class LayerGroupHelper {
 
     @SuppressWarnings("FallThrough") // switch intentionally falls through default
     private void allLayersForRendering(
-            LayerGroupInfo group, LayerGroupStyle groupStyle, List<LayerInfo> layers, boolean root) {
+            LayerGroupInfo group,
+            LayerGroupStyle groupStyle,
+            boolean root,
+            List<LayerGroupInfo> parents,
+            BiConsumer<LayerInfo, List<LayerGroupInfo>> consumer) {
+        // guard against cyclic references; catalog validation forbids them, but be defensive so the walk terminates
+        if (parents.contains(group)) {
+            return;
+        }
+        List<LayerGroupInfo> containers = new ArrayList<>(parents);
+        containers.add(group);
         switch (group.getMode()) {
             case EO:
-                layers.add(group.getRootLayer());
+                consumer.accept(group.getRootLayer(), containers);
                 break;
             case CONTAINER:
                 if (root) {
@@ -289,13 +310,14 @@ public class LayerGroupHelper {
                     PublishedInfo p = publishables.get(i);
                     StyleInfo s = styles.get(i);
                     if (p instanceof LayerInfo l) {
-                        layers.add(l);
+                        consumer.accept(l, containers);
                     } else if (p instanceof LayerGroupInfo groupInfo) {
-                        LayerGroupStyle gStyle = null;
-                        gStyle = getStyleOrThrow(groupInfo, s);
-                        allLayersForRendering(groupInfo, gStyle, layers, false);
+                        LayerGroupStyle gStyle = getStyleOrThrow(groupInfo, s);
+                        allLayersForRendering(groupInfo, gStyle, false, containers, consumer);
                     } else if (p == null && s != null) {
-                        expandStyleGroup(s, getCrs(group.getBounds()), layers, null);
+                        List<LayerInfo> expanded = new ArrayList<>();
+                        expandStyleGroup(s, getCrs(group.getBounds()), expanded, null);
+                        expanded.forEach(l -> consumer.accept(l, containers));
                     }
                 }
         }

--- a/src/main/src/main/java/org/geoserver/security/AccessLimits.java
+++ b/src/main/src/main/java/org/geoserver/security/AccessLimits.java
@@ -7,6 +7,7 @@ package org.geoserver.security;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Set;
 
 /**
  * Base class for all AccessLimits declared by a {@link ResourceAccessManager}.
@@ -25,6 +26,14 @@ public class AccessLimits implements Serializable, Cloneable {
     /** Gets the catalog mode for this layer */
     CatalogMode mode;
 
+    /**
+     * Optional tags used for targeted cache invalidation (tile caches, CDNs, WMS caches, etc.).
+     * {@link ResourceAccessManager} implementations supporting tag-based invalidation may populate this with opaque
+     * tags, that can then be used to drop tile caches affected by security rule changes. Deliberately excluded from
+     * {@link #equals} and {@link #hashCode}: tags are invalidation metadata, not part of the content fingerprint.
+     */
+    private Set<String> securityTags;
+
     /** Builds a generic AccessLimits */
     public AccessLimits(CatalogMode mode) {
         this.mode = mode;
@@ -33,6 +42,29 @@ public class AccessLimits implements Serializable, Cloneable {
     /** The catalog mode for this layer */
     public CatalogMode getMode() {
         return mode;
+    }
+
+    /** Tags used for targeted cache invalidation, or null if none. See {@link #securityTags}. */
+    public Set<String> getSecurityTags() {
+        return securityTags;
+    }
+
+    /**
+     * Sets tags used for targeted cache invalidation. See {@link #securityTags}.
+     *
+     * @throws IllegalArgumentException if any tag contains a comma
+     */
+    public void setSecurityTags(Set<String> securityTags) {
+        if (securityTags == null) {
+            this.securityTags = null;
+            return;
+        }
+        for (String tag : securityTags) {
+            if (tag.indexOf(',') >= 0) {
+                throw new IllegalArgumentException("Security tag must not contain a comma: " + tag);
+            }
+        }
+        this.securityTags = Set.copyOf(securityTags);
     }
 
     @Override

--- a/src/main/src/main/java/org/geoserver/security/AccessLimits.java
+++ b/src/main/src/main/java/org/geoserver/security/AccessLimits.java
@@ -31,6 +31,9 @@ public class AccessLimits implements Serializable, Cloneable {
      * {@link ResourceAccessManager} implementations supporting tag-based invalidation may populate this with opaque
      * tags, that can then be used to drop tile caches affected by security rule changes. Deliberately excluded from
      * {@link #equals} and {@link #hashCode}: tags are invalidation metadata, not part of the content fingerprint.
+     *
+     * <p><strong>A tag must not contain a comma</strong>: tags are stored as a single comma-separated value in the tile
+     * cache, so a comma in a tag breaks targeted invalidation. Comma-bearing tags are rejected.
      */
     private Set<String> securityTags;
 

--- a/src/main/src/main/java/org/geoserver/security/CachingResourceAccessManager.java
+++ b/src/main/src/main/java/org/geoserver/security/CachingResourceAccessManager.java
@@ -1,0 +1,147 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geotools.api.filter.Filter;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * Memoizes {@link ResourceAccessManager} results within a single HTTP request.
+ *
+ * <p>When no request is bound (background threads, startup), every call delegates directly with no caching. Results are
+ * assumed read-only by callers (callers that need to mutate must clone first).
+ */
+public class CachingResourceAccessManager extends ResourceAccessManagerWrapper {
+
+    private static final String CACHE_ATTR = CachingResourceAccessManager.class.getName();
+
+    private enum Kind {
+        WORKSPACE,
+        LAYER,
+        LAYER_CTX,
+        RESOURCE,
+        STYLE,
+        LAYER_GROUP,
+        LAYER_GROUP_CTX,
+        SECURITY_FILTER,
+        IS_WS_ADMIN
+    }
+
+    private record Key(Kind kind, String user, String target, String containers) {}
+
+    @Override
+    public WorkspaceAccessLimits getAccessLimits(Authentication user, WorkspaceInfo workspace) {
+        return cached(Kind.WORKSPACE, user, workspace.getId(), null, () -> delegate.getAccessLimits(user, workspace));
+    }
+
+    @Override
+    public DataAccessLimits getAccessLimits(Authentication user, LayerInfo layer) {
+        return cached(Kind.LAYER, user, layer.getId(), null, () -> delegate.getAccessLimits(user, layer));
+    }
+
+    @Override
+    public DataAccessLimits getAccessLimits(Authentication user, LayerInfo layer, List<LayerGroupInfo> containers) {
+        return cached(
+                Kind.LAYER_CTX,
+                user,
+                layer.getId(),
+                containerKey(containers),
+                () -> delegate.getAccessLimits(user, layer, containers));
+    }
+
+    @Override
+    public DataAccessLimits getAccessLimits(Authentication user, ResourceInfo resource) {
+        return cached(Kind.RESOURCE, user, resource.getId(), null, () -> delegate.getAccessLimits(user, resource));
+    }
+
+    @Override
+    public StyleAccessLimits getAccessLimits(Authentication user, StyleInfo style) {
+        return cached(Kind.STYLE, user, style.getId(), null, () -> delegate.getAccessLimits(user, style));
+    }
+
+    @Override
+    public LayerGroupAccessLimits getAccessLimits(Authentication user, LayerGroupInfo layerGroup) {
+        return cached(
+                Kind.LAYER_GROUP, user, layerGroup.getId(), null, () -> delegate.getAccessLimits(user, layerGroup));
+    }
+
+    @Override
+    public LayerGroupAccessLimits getAccessLimits(
+            Authentication user, LayerGroupInfo layerGroup, List<LayerGroupInfo> containers) {
+        return cached(
+                Kind.LAYER_GROUP_CTX,
+                user,
+                layerGroup.getId(),
+                containerKey(containers),
+                () -> delegate.getAccessLimits(user, layerGroup, containers));
+    }
+
+    @Override
+    public Filter getSecurityFilter(Authentication user, Class<? extends CatalogInfo> clazz) {
+        return cached(Kind.SECURITY_FILTER, user, clazz.getName(), null, () -> delegate.getSecurityFilter(user, clazz));
+    }
+
+    @Override
+    public boolean isWorkspaceAdmin(Authentication user, Catalog catalog) {
+        Boolean result = cached(Kind.IS_WS_ADMIN, user, null, null, () -> delegate.isWorkspaceAdmin(user, catalog));
+        return Boolean.TRUE.equals(result);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T cached(Kind kind, Authentication auth, String targetId, String containers, Supplier<T> loader) {
+        // if targetId is null we can't build a safe key - two different objects with null IDs
+        // would wrongly share a cache entry
+        if (targetId == null && kind != Kind.IS_WS_ADMIN) return loader.get();
+
+        // bypass if there is no current request context (e.g., background thread, post-request cleanup)
+        RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
+        if (attrs == null) return loader.get();
+
+        Map<Key, Object> cache;
+        try {
+            cache = (Map<Key, Object>) attrs.getAttribute(CACHE_ATTR, RequestAttributes.SCOPE_REQUEST);
+            if (cache == null) {
+                cache = new HashMap<>();
+                attrs.setAttribute(CACHE_ATTR, cache, RequestAttributes.SCOPE_REQUEST);
+            }
+        } catch (IllegalStateException e) {
+            // request already completed but attributes still bound to thread (importer, WPS post-processing);
+            // clear the stale binding so subsequent calls on this thread skip the cache cleanly
+            RequestContextHolder.resetRequestAttributes();
+            return loader.get();
+        }
+
+        Key key = new Key(kind, userKey(auth), targetId, containers);
+        if (cache.containsKey(key)) {
+            return (T) cache.get(key);
+        }
+        T result = loader.get();
+        cache.put(key, result);
+        return result;
+    }
+
+    private static String userKey(Authentication auth) {
+        return auth == null ? "" : auth.getName();
+    }
+
+    private static String containerKey(List<LayerGroupInfo> containers) {
+        if (containers == null || containers.isEmpty()) return "";
+        return containers.stream().map(LayerGroupInfo::getId).collect(Collectors.joining(","));
+    }
+}

--- a/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
+++ b/src/main/src/main/java/org/geoserver/security/SecureCatalogImpl.java
@@ -120,7 +120,10 @@ public class SecureCatalogImpl extends AbstractDecorator<Catalog> implements Cat
 
         CatalogFilterAccessManager lwManager = new CatalogFilterAccessManager();
         lwManager.setDelegate(manager);
-        return lwManager;
+        // will cache results of the RAM within the same HTTP request
+        CachingResourceAccessManager cachingManager = new CachingResourceAccessManager();
+        cachingManager.setDelegate(lwManager);
+        return cachingManager;
     }
 
     public SecureCatalogImpl(Catalog catalog, ResourceAccessManager manager) {

--- a/src/main/src/main/java/org/geoserver/security/impl/LayerGroupContainmentCache.java
+++ b/src/main/src/main/java/org/geoserver/security/impl/LayerGroupContainmentCache.java
@@ -126,8 +126,17 @@ public class LayerGroupContainmentCache implements ApplicationListener<ContextRe
         }
     }
 
-    /** Returns all groups containing directly or indirectly containing the resource */
+    /** Returns all groups containing directly or indirectly the resource, excluding {@link Mode#SINGLE} ones. */
     public Collection<LayerGroupSummary> getContainerGroupsFor(ResourceInfo resource) {
+        return getContainerGroupsFor(resource, false);
+    }
+
+    /**
+     * Returns all groups containing directly or indirectly the resource. {@link Mode#SINGLE} containers are excluded
+     * from security rule evaluation, but tile caching keys group tiles by their members' access limits regardless of
+     * mode, so callers invalidating those tiles pass {@code includeSingle = true}.
+     */
+    public Collection<LayerGroupSummary> getContainerGroupsFor(ResourceInfo resource, boolean includeSingle) {
         String id = resource.getId();
         Set<LayerGroupSummary> groups = resourceContainmentCache.get(id);
         if (groups == null) {
@@ -135,7 +144,7 @@ public class LayerGroupContainmentCache implements ApplicationListener<ContextRe
         }
         Set<LayerGroupSummary> result = new HashSet<>();
         for (LayerGroupSummary lg : groups) {
-            collectContainers(lg, result);
+            collectContainers(lg, result, includeSingle);
         }
         return result;
     }
@@ -156,19 +165,19 @@ public class LayerGroupContainmentCache implements ApplicationListener<ContextRe
 
         Set<LayerGroupSummary> result = new HashSet<>();
         for (LayerGroupSummary container : summary.getContainerGroups()) {
-            collectContainers(container, result);
+            collectContainers(container, result, false);
         }
         return result;
     }
 
     /** Recursively collects the group and all its containers in the <data>groups</data> collection */
-    private void collectContainers(LayerGroupSummary lg, Set<LayerGroupSummary> groups) {
+    private void collectContainers(LayerGroupSummary lg, Set<LayerGroupSummary> groups, boolean includeSingle) {
         if (!groups.contains(lg)) {
-            if (lg.getMode() != LayerGroupInfo.Mode.SINGLE) {
+            if (includeSingle || lg.getMode() != LayerGroupInfo.Mode.SINGLE) {
                 groups.add(lg);
             }
             for (LayerGroupSummary container : lg.containerGroups) {
-                collectContainers(container, groups);
+                collectContainers(container, groups, includeSingle);
             }
         }
     }

--- a/src/main/src/test/java/org/geoserver/catalog/LayerGroupHelperTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/LayerGroupHelperTest.java
@@ -12,7 +12,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Stack;
 import javax.xml.namespace.QName;
 import org.geoserver.catalog.LayerGroupInfo.Mode;
@@ -241,6 +243,37 @@ public class LayerGroupHelperTest extends GeoServerMockTestSupport {
     private void assertExpectedRenderingLayers(List<LayerInfo> expected, LayerGroupInfo group) {
         List<LayerInfo> layers = new LayerGroupHelper(group).allLayersForRendering();
         assertEquals(expected, layers);
+    }
+
+    @Test
+    public void testAllLayersForRenderingWithContainers() {
+        Map<LayerInfo, List<LayerGroupInfo>> containers = renderingContainers(nested);
+
+        // each rendered leaf carries its chain of containing groups (top group first)
+        Map<LayerInfo, List<LayerGroupInfo>> expected = new HashMap<>();
+        expected.put(forestLayer, Arrays.asList(nested)); // direct member
+        expected.put(roadSegmentsLayer, Arrays.asList(nested, lakesNeatline)); // EO root of a nested group
+        expected.put(buildingsLayer, Arrays.asList(nested));
+        expected.put(pondsLayer, Arrays.asList(nested, ponds)); // member of a nested group
+        assertEquals(expected, containers);
+    }
+
+    @Test
+    public void testAllLayersForRenderingTerminatesOnLoop() {
+        // self reference: the leaf is emitted once, the recursive reference is skipped by the cycle guard
+        assertEquals(Map.of(forestLayer, Arrays.asList(loop1)), renderingContainers(loop1));
+
+        // indirect loop2 -> ponds -> loop2: each leaf emitted once, the back-reference to loop2 is skipped
+        Map<LayerInfo, List<LayerGroupInfo>> expected = new HashMap<>();
+        expected.put(forestLayer, Arrays.asList(loop2));
+        expected.put(pondsLayer, Arrays.asList(loop2, loop2Child));
+        assertEquals(expected, renderingContainers(loop2));
+    }
+
+    private Map<LayerInfo, List<LayerGroupInfo>> renderingContainers(LayerGroupInfo group) {
+        Map<LayerInfo, List<LayerGroupInfo>> containers = new HashMap<>();
+        new LayerGroupHelper(group).allLayersForRendering(containers::put);
+        return containers;
     }
 
     @Test

--- a/src/main/src/test/java/org/geoserver/security/AccessLimitsTest.java
+++ b/src/main/src/test/java/org/geoserver/security/AccessLimitsTest.java
@@ -1,0 +1,31 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Set;
+import org.junit.Test;
+
+public class AccessLimitsTest {
+
+    @Test
+    public void testSecurityTagWithCommaRejected() {
+        AccessLimits limits = new AccessLimits(CatalogMode.HIDE);
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> limits.setSecurityTags(Set.of("a,b")));
+        assertThat(e.getMessage(), containsString("a,b"));
+    }
+
+    @Test
+    public void testSecurityTagsAccepted() {
+        AccessLimits limits = new AccessLimits(CatalogMode.HIDE);
+        limits.setSecurityTags(Set.of("tenant-a", "tenant-b"));
+        assertEquals(Set.of("tenant-a", "tenant-b"), limits.getSecurityTags());
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/CachingResourceAccessManagerTest.java
+++ b/src/main/src/test/java/org/geoserver/security/CachingResourceAccessManagerTest.java
@@ -1,0 +1,245 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class CachingResourceAccessManagerTest {
+
+    private CachingResourceAccessManager caching;
+    private ResourceAccessManager delegate;
+    private Authentication user;
+
+    @Before
+    public void setUp() {
+        delegate = mock(ResourceAccessManager.class);
+        caching = new CachingResourceAccessManager();
+        caching.setDelegate(delegate);
+
+        user = mock(Authentication.class);
+        when(user.getName()).thenReturn("testuser");
+
+        bindRequest();
+    }
+
+    @After
+    public void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    private void bindRequest() {
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+    }
+
+    @Test
+    public void testLayerCachesWithinRequest() {
+        LayerInfo layer = layerWithId("l1");
+        DataAccessLimits limits = mock(DataAccessLimits.class);
+        when(delegate.getAccessLimits(user, layer)).thenReturn(limits);
+
+        assertSame(limits, caching.getAccessLimits(user, layer));
+        assertSame(limits, caching.getAccessLimits(user, layer));
+        verify(delegate, times(1)).getAccessLimits(user, layer);
+    }
+
+    @Test
+    public void testNullResultCached() {
+        LayerInfo layer = layerWithId("l1");
+        when(delegate.getAccessLimits(user, layer)).thenReturn(null);
+
+        assertNull(caching.getAccessLimits(user, layer));
+        assertNull(caching.getAccessLimits(user, layer));
+        verify(delegate, times(1)).getAccessLimits(user, layer);
+    }
+
+    @Test
+    public void testNoRequestContextDelegatesEveryTime() {
+        RequestContextHolder.resetRequestAttributes();
+        LayerInfo layer = layerWithId("l1");
+
+        caching.getAccessLimits(user, layer);
+        caching.getAccessLimits(user, layer);
+        verify(delegate, times(2)).getAccessLimits(user, layer);
+    }
+
+    @Test
+    public void testDifferentLayersMiss() {
+        LayerInfo l1 = layerWithId("l1");
+        LayerInfo l2 = layerWithId("l2");
+
+        caching.getAccessLimits(user, l1);
+        caching.getAccessLimits(user, l2);
+        verify(delegate, times(1)).getAccessLimits(user, l1);
+        verify(delegate, times(1)).getAccessLimits(user, l2);
+    }
+
+    @Test
+    public void testDifferentUsersMiss() {
+        Authentication u2 = mock(Authentication.class);
+        when(u2.getName()).thenReturn("otheruser");
+
+        LayerInfo layer = layerWithId("l1");
+        caching.getAccessLimits(user, layer);
+        caching.getAccessLimits(u2, layer);
+        verify(delegate, times(1)).getAccessLimits(user, layer);
+        verify(delegate, times(1)).getAccessLimits(u2, layer);
+    }
+
+    @Test
+    public void testContainersDifferentMiss() {
+        LayerInfo layer = layerWithId("l1");
+        LayerGroupInfo g1 = mock(LayerGroupInfo.class);
+        when(g1.getId()).thenReturn("g1");
+
+        caching.getAccessLimits(user, layer, List.of());
+        caching.getAccessLimits(user, layer, List.of(g1));
+        verify(delegate, times(1)).getAccessLimits(user, layer, List.of());
+        verify(delegate, times(1)).getAccessLimits(user, layer, List.of(g1));
+    }
+
+    @Test
+    public void testContainersSameHit() {
+        LayerInfo layer = layerWithId("l1");
+        LayerGroupInfo g1 = mock(LayerGroupInfo.class);
+        when(g1.getId()).thenReturn("g1");
+
+        caching.getAccessLimits(user, layer, List.of(g1));
+        caching.getAccessLimits(user, layer, List.of(g1));
+        verify(delegate, times(1)).getAccessLimits(user, layer, List.of(g1));
+    }
+
+    @Test
+    public void testNullIdSkipsCaching() {
+        LayerInfo layer = mock(LayerInfo.class);
+        when(layer.getId()).thenReturn(null);
+
+        caching.getAccessLimits(user, layer);
+        caching.getAccessLimits(user, layer);
+        verify(delegate, times(2)).getAccessLimits(user, layer);
+    }
+
+    @Test
+    public void testWorkspaceCachesWithinRequest() {
+        WorkspaceInfo ws = mock(WorkspaceInfo.class);
+        when(ws.getId()).thenReturn("ws1");
+        WorkspaceAccessLimits limits = mock(WorkspaceAccessLimits.class);
+        when(delegate.getAccessLimits(user, ws)).thenReturn(limits);
+
+        assertSame(limits, caching.getAccessLimits(user, ws));
+        assertSame(limits, caching.getAccessLimits(user, ws));
+        verify(delegate, times(1)).getAccessLimits(user, ws);
+    }
+
+    @Test
+    public void testResourceCachesWithinRequest() {
+        ResourceInfo res = mock(ResourceInfo.class);
+        when(res.getId()).thenReturn("r1");
+
+        caching.getAccessLimits(user, res);
+        caching.getAccessLimits(user, res);
+        verify(delegate, times(1)).getAccessLimits(user, res);
+    }
+
+    @Test
+    public void testStyleCachesWithinRequest() {
+        StyleInfo style = mock(StyleInfo.class);
+        when(style.getId()).thenReturn("s1");
+
+        caching.getAccessLimits(user, style);
+        caching.getAccessLimits(user, style);
+        verify(delegate, times(1)).getAccessLimits(user, style);
+    }
+
+    @Test
+    public void testLayerGroupCachesWithinRequest() {
+        LayerGroupInfo lg = mock(LayerGroupInfo.class);
+        when(lg.getId()).thenReturn("lg1");
+
+        caching.getAccessLimits(user, lg);
+        caching.getAccessLimits(user, lg);
+        verify(delegate, times(1)).getAccessLimits(user, lg);
+    }
+
+    @Test
+    public void testSecurityFilterCachesWithinRequest() {
+        caching.getSecurityFilter(user, ResourceInfo.class);
+        caching.getSecurityFilter(user, ResourceInfo.class);
+        verify(delegate, times(1)).getSecurityFilter(user, ResourceInfo.class);
+    }
+
+    @Test
+    public void testIsWorkspaceAdminCachesWithinRequest() {
+        Catalog catalog = mock(Catalog.class);
+        when(delegate.isWorkspaceAdmin(user, catalog)).thenReturn(true);
+
+        caching.isWorkspaceAdmin(user, catalog);
+        caching.isWorkspaceAdmin(user, catalog);
+        verify(delegate, times(1)).isWorkspaceAdmin(user, catalog);
+    }
+
+    @Test
+    public void testCrossRequestIsolation() {
+        LayerInfo layer = layerWithId("l1");
+        DataAccessLimits limits = mock(DataAccessLimits.class);
+        when(delegate.getAccessLimits(user, layer)).thenReturn(limits);
+
+        caching.getAccessLimits(user, layer);
+
+        // simulate second request
+        RequestContextHolder.resetRequestAttributes();
+        bindRequest();
+
+        caching.getAccessLimits(user, layer);
+        verify(delegate, times(2)).getAccessLimits(user, layer);
+    }
+
+    @Test
+    public void testStaleRequestAttributesClearedAfterException() {
+        // simulate post-request background thread: attrs bound but request already completed
+        RequestAttributes stale = mock(RequestAttributes.class);
+        when(stale.getAttribute(anyString(), anyInt())).thenThrow(new IllegalStateException("request not active"));
+        RequestContextHolder.setRequestAttributes(stale);
+
+        LayerInfo layer = layerWithId("l1");
+
+        // first call: hits the exception, clears the stale binding, delegates
+        caching.getAccessLimits(user, layer);
+        verify(delegate, times(1)).getAccessLimits(user, layer);
+        assertNull("stale binding must be cleared", RequestContextHolder.getRequestAttributes());
+
+        // subsequent calls: no request context, delegate directly, no further exceptions
+        caching.getAccessLimits(user, layer);
+        verify(delegate, times(2)).getAccessLimits(user, layer);
+    }
+
+    private LayerInfo layerWithId(String id) {
+        LayerInfo layer = mock(LayerInfo.class);
+        when(layer.getId()).thenReturn(id);
+        return layer;
+    }
+}

--- a/src/main/src/test/java/org/geoserver/security/TestResourceAccessManager.java
+++ b/src/main/src/test/java/org/geoserver/security/TestResourceAccessManager.java
@@ -6,6 +6,7 @@
 package org.geoserver.security;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.LayerGroupInfo;
@@ -64,6 +65,22 @@ public class TestResourceAccessManager extends AbstractResourceAccessManager {
     }
 
     @Override
+    public DataAccessLimits getAccessLimits(Authentication user, LayerInfo layer, List<LayerGroupInfo> containers) {
+        if (user == null) {
+            return null;
+        }
+        // container-specific limits win: a rule may restrict a layer only when reached through a given group
+        Map<String, AccessLimits> userMap = getUserMap(user.getName());
+        for (LayerGroupInfo container : containers) {
+            DataAccessLimits limits = (DataAccessLimits) userMap.get(containerKey(layer, container));
+            if (limits != null) {
+                return limits;
+            }
+        }
+        return getAccessLimits(user, layer);
+    }
+
+    @Override
     public DataAccessLimits getAccessLimits(Authentication user, ResourceInfo resource) {
         if (user == null) {
             return null;
@@ -100,6 +117,15 @@ public class TestResourceAccessManager extends AbstractResourceAccessManager {
      */
     public void putLimits(String userName, CatalogInfo securedItem, AccessLimits limits) {
         getUserMap(userName).put(securedItem.getId(), limits);
+    }
+
+    /** Limits applied to {@code layer} only when it is accessed through {@code container} (directly or nested). */
+    public void putLimits(String userName, LayerInfo layer, LayerGroupInfo container, DataAccessLimits limits) {
+        getUserMap(userName).put(containerKey(layer, container), limits);
+    }
+
+    private static String containerKey(LayerInfo layer, LayerGroupInfo container) {
+        return layer.getId() + "@" + container.getId();
     }
 
     public void clearLimits() {

--- a/src/main/src/test/java/org/geoserver/security/TestResourceAccessManager.java
+++ b/src/main/src/test/java/org/geoserver/security/TestResourceAccessManager.java
@@ -102,6 +102,10 @@ public class TestResourceAccessManager extends AbstractResourceAccessManager {
         getUserMap(userName).put(securedItem.getId(), limits);
     }
 
+    public void clearLimits() {
+        limits.clear();
+    }
+
     Map<String, AccessLimits> getUserMap(String userName) {
         Map<String, AccessLimits> userMap = limits.get(userName);
         if (userMap == null) {

--- a/src/main/src/test/java/org/geoserver/security/impl/LayerGroupContainmentCacheTest.java
+++ b/src/main/src/test/java/org/geoserver/security/impl/LayerGroupContainmentCacheTest.java
@@ -218,6 +218,23 @@ public class LayerGroupContainmentCacheTest {
     }
 
     @Test
+    public void testContainersIncludingSingle() throws Exception {
+        FeatureTypeInfo lakes = getResource(MockData.LAKES);
+        // default: the SINGLE-mode nature group is not reported as a container
+        assertThat(
+                cc.getContainerGroupsFor(lakes).stream()
+                        .map(LayerGroupSummary::prefixedName)
+                        .collect(Collectors.toSet()),
+                equalTo(set(CONTAINER_GROUP)));
+        // includeSingle=true: the SINGLE-mode nature group is reported too
+        assertThat(
+                cc.getContainerGroupsFor(lakes, true).stream()
+                        .map(LayerGroupSummary::prefixedName)
+                        .collect(Collectors.toSet()),
+                equalTo(set(nature.prefixedName(), CONTAINER_GROUP)));
+    }
+
+    @Test
     public void testAddLayerToNature() throws Exception {
         LayerInfo neatline = catalog.getLayerByName(getLayerId(MockData.MAP_NEATLINE));
         nature.getLayers().add(neatline);


### PR DESCRIPTION
[![GEOS-12139](https://badgen.net/badge/JIRA/GEOS-12139/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12139) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

See https://github.com/geoserver/geoserver/wiki/GSIP-241 for reference.
I've managed to get a simpler implementation for some aspects (e.g. no thread locals), implemented part 2 anyways, and added a caching ResourceAccessManager wrapper for extra measure.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 