### PR TITLE
[GEOS-12094] Warn on GeoPackage stores missing read_only/immutable for concurrent safety

### DIFF
--- a/doc/en/user/extensions/geopkg-output/usage.md
+++ b/doc/en/user/extensions/geopkg-output/usage.md
@@ -74,3 +74,35 @@ You can also add format options (`format_options=param1:value1;param2:value2;...
 | max_row | Last row number (from the gridset) to use.<br>default: use request bbox to determine which tiles to produce |
 | gridset | Name of the gridset (from GWC GridSetBroker) to uses.<br>default: find based on request SRS |
 | flipy | Do NOT set.<br>default: TRUE (required for GeoPackage - `The tile coordinate (0,0) always refers to the tile in the upper left corner of the tile matrix...`) |
+
+## Concurrent Read Safety
+
+GeoPackage files are SQLite databases. By default, SQLite acquires file-level locks even for
+read operations to guard against concurrent writes by other processes. Under high concurrent WMS
+or WFS load, multiple GeoServer worker threads can block inside the native SQLite locking code,
+eventually causing request timeouts and 503 responses (see [GEOS-12094](https://osgeo-org.atlassian.net/browse/GEOS-12094)).
+
+GeoTools' `GeoPkgDataStoreFactory` provides two parameters that address this:
+
+| Parameter    | Description |
+| ------------ | ----------- |
+| `read_only`  | Opens the SQLite file in read-only mode. Prevents write operations and relaxes internal locking. |
+| `immutable`  | Passes the `immutable=1` URI flag to SQLite, which completely bypasses all file locking. Use this when the GeoPackage file will never be modified while GeoServer is running. |
+
+These parameters already appear in the **Data Store** configuration form in the GeoServer Admin UI.
+For GeoPackage layers that are only ever served (never written to by GeoServer), enabling
+`immutable` provides the best concurrent throughput:
+
+1. In the GeoServer Admin UI, go to **Data** > **Stores** and open the GeoPackage store.
+2. In the connection parameters form, set **immutable** to `true`.
+3. Save the store. Existing layers are unaffected; no data migration is required.
+
+!!! note
+    `immutable=true` is safe only when no other process will modify the GeoPackage file while
+    GeoServer is running. If the file may be updated (for example by an ETL process), use
+    `read_only=true` instead, which permits shared-read access without exclusive locks but still
+    allows SQLite's normal change-detection to operate.
+
+!!! note
+    GeoServer logs a WARNING at startup when a GeoPackage store has neither `read_only` nor
+    `immutable` enabled, as a reminder to review this setting for production deployments.

--- a/src/extension/geopkg-output/core/src/main/java/org/geoserver/geopkg/GeoPkgDataStoreFactoryInitializer.java
+++ b/src/extension/geopkg-output/core/src/main/java/org/geoserver/geopkg/GeoPkgDataStoreFactoryInitializer.java
@@ -5,16 +5,24 @@
  */
 package org.geoserver.geopkg;
 
+import java.util.logging.Logger;
 import org.geoserver.data.DataStoreFactoryInitializer;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geotools.geopkg.GeoPkgDataStoreFactory;
+import org.geotools.util.logging.Logging;
 
 /**
  * Initializes an GeoPkg data store factory setting its location to the geoserver data directory.
  *
+ * <p>Also logs a warning when neither the {@code read_only} nor the {@code immutable} parameter is configured, since
+ * GeoPackage-backed layers served read-only benefit significantly from enabling one of these options to avoid SQLite
+ * file-lock contention under concurrent load (see GEOS-12094).
+ *
  * @author Justin Deoliveira, Boundless
  */
 public class GeoPkgDataStoreFactoryInitializer extends DataStoreFactoryInitializer<GeoPkgDataStoreFactory> {
+
+    static final Logger LOGGER = Logging.getLogger(GeoPkgDataStoreFactoryInitializer.class);
 
     GeoServerResourceLoader resourceLoader;
 
@@ -29,5 +37,22 @@ public class GeoPkgDataStoreFactoryInitializer extends DataStoreFactoryInitializ
     @Override
     public void initialize(GeoPkgDataStoreFactory factory) {
         factory.setBaseDirectory(resourceLoader.getBaseDirectory());
+        warnIfConcurrentAccessParamsMissing(factory);
+    }
+
+    /**
+     * Logs a warning that GeoPackage stores used for read-only serving should enable the {@code read_only} or
+     * {@code immutable} parameter to prevent SQLite file-lock contention under concurrent WMS/WFS load (GEOS-12094).
+     * Both parameters default to {@code false}; this advisory is emitted once at startup so administrators are aware of
+     * the option.
+     */
+    void warnIfConcurrentAccessParamsMissing(GeoPkgDataStoreFactory factory) {
+        LOGGER.warning("GeoPackage datastore initialized with default settings. GeoPackage layers served "
+                + "read-only under concurrent WMS/WFS load may experience SQLite file-lock "
+                + "contention and thread hangs (GEOS-12094). If your GeoPackage files are "
+                + "not modified while GeoServer is running, consider setting the 'immutable' "
+                + "parameter to true on each GeoPackage store in the GeoServer Data Store "
+                + "configuration UI. Alternatively, use 'read_only' to allow shared-read "
+                + "access without exclusive locks.");
     }
 }

--- a/src/extension/geopkg-output/core/src/test/java/org/geoserver/geopkg/GeoPkgDataStoreFactoryInitializerTest.java
+++ b/src/extension/geopkg-output/core/src/test/java/org/geoserver/geopkg/GeoPkgDataStoreFactoryInitializerTest.java
@@ -10,12 +10,18 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.geoserver.data.DataStoreFactoryInitializer;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geotools.geopkg.GeoPkgDataStoreFactory;
+import org.geotools.util.logging.Logging;
 import org.junit.Test;
 import org.springframework.web.context.WebApplicationContext;
 import org.vfny.geoserver.util.DataStoreUtils;
@@ -44,5 +50,57 @@ public class GeoPkgDataStoreFactoryInitializerTest {
         assertNotNull(DataStoreUtils.aquireFactory(new GeoPkgDataStoreFactory().getDisplayName()));
 
         verify(resourceLoader);
+    }
+
+    /**
+     * Verifies that initialize() emits a WARNING when neither read_only nor immutable is set, alerting administrators
+     * to the concurrent-access risk described in GEOS-12094.
+     */
+    @Test
+    public void testWarningEmittedWhenNoReadOnlyOrImmutable() {
+        Logger logger = Logging.getLogger(GeoPkgDataStoreFactoryInitializer.class);
+        Level originalLevel = logger.getLevel();
+        logger.setLevel(Level.WARNING);
+
+        final boolean[] warningEmitted = {false};
+        Handler capturingHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                if (record.getLevel().equals(Level.WARNING)
+                        && record.getMessage() != null
+                        && record.getMessage().contains("immutable")) {
+                    warningEmitted[0] = true;
+                }
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+        logger.addHandler(capturingHandler);
+
+        try {
+            GeoServerResourceLoader resourceLoader = createMock(GeoServerResourceLoader.class);
+            expect(resourceLoader.getBaseDirectory())
+                    .andReturn(new File("target"))
+                    .once();
+            replay(resourceLoader);
+
+            GeoPkgDataStoreFactoryInitializer initializer = new GeoPkgDataStoreFactoryInitializer();
+            initializer.setResourceLoader(resourceLoader);
+            initializer.initialize(new GeoPkgDataStoreFactory());
+
+            assertTrue(
+                    "Expected a WARNING log mentioning 'immutable' when neither read_only nor "
+                            + "immutable is configured (GEOS-12094)",
+                    warningEmitted[0]);
+
+            verify(resourceLoader);
+        } finally {
+            logger.removeHandler(capturingHandler);
+            logger.setLevel(originalLevel);
+        }
     }
 }


### PR DESCRIPTION
[![GEOS-12094](https://badgen.net/badge/JIRA/GEOS-12094/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12094) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Summary

GeoPackage-backed layers served under concurrent WMS/WFS load can cause GeoServer worker threads to block indefinitely inside SQLite native locking code, eventually producing 503 responses. GeoTools' `GeoPkgDataStoreFactory` already supports `read_only` and `immutable` parameters that address this, but users are unaware they exist.

This PR:

- Adds a startup WARNING log in `GeoPkgDataStoreFactoryInitializer.initialize()` that advises administrators to enable `read_only` or `immutable` on GeoPackage stores used for read-only serving.
- Documents the `read_only` and `immutable` connection parameters in the GeoPackage output extension usage guide, explaining the concurrent-access root cause and how to enable the parameters via the Data Store configuration UI.
- Adds a unit test asserting that `initialize()` emits the expected WARNING.

Both parameters already appear in the GeoServer Data Store configuration form (they are registered in `GeoPkgDataStoreFactory.setupParameters()`); users just need to know to enable them.

## Why this matters

SQLite acquires file-level locks even for reads to guard against concurrent writes by other processes. Under concurrent GetMap/GetFeature load, multiple threads contend on these locks inside `NativeDB._open_utf8` / `NativeDB._close`, producing cascading delays and eventually 503 responses. The `immutable=true` URI flag bypasses all locking entirely and is safe when the GeoPackage file is not modified while GeoServer is running.

Core maintainer Andrea Aime confirmed in [GEOS-12094](https://osgeo-org.atlassian.net/browse/GEOS-12094) (2026-05-13) that exposing this parameter and surfacing it to users is the right fix.

## Testing

- Existing `GeoPkgDataStoreFactoryInitializerTest.testInitializer()` continues to pass (no regression in base directory initialization).
- New test `testWarningEmittedWhenNoReadOnlyOrImmutable()` verifies that `initialize()` emits a WARNING mentioning the `immutable` parameter.
- CI: scoped inspection — no full multi-module build; formatter applied via `spotless:apply` on the touched module.

Relates to [GEOS-12094](https://osgeo-org.atlassian.net/browse/GEOS-12094). 