### PR TITLE
[GEOS-12143] Cannot create a tiled layer from the tile caching layer tab any longer

### DIFF
--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.html
@@ -6,6 +6,12 @@
       <div class="gs-panel-GeoServerTileLayerEditor">
         <div class="gs-form">
           <div class="gs-list-item-class" wicket:id="container">
+            <div class="gs-form">
+              <div class="choiceItem">
+                <input id="createTileLayer" wicket:id="createTileLayer" type="checkbox"/>
+                <label for="createTileLayer" wicket:id="createTileLayerLabel">Create a cached Layer for this Layer/Group</label>
+              </div>
+            </div>
             <div wicket:id="configs">
               <fieldset>
                 <legend>
@@ -14,10 +20,6 @@
                   </span>
                 </legend>
                 <div class="gs-form">
-                  <div class="choiceItem">
-                    <input id="createTileLayer" wicket:id="createTileLayer" type="checkbox"/>
-                    <label for="createTileLayer" wicket:id="createTileLayerLabel">Create a cached Layer for this Layer/Group</label>
-                  </div>
                   <div class="choiceItem">
                     <input id="tileCacheEnabled" wicket:id="enabled" type="checkbox"/>
                     <label for="enabled">

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/layer/GeoServerTileLayerEditor.java
@@ -204,13 +204,13 @@ class GeoServerTileLayerEditor extends FormComponentPanel<GeoServerTileLayerInfo
         container.setOutputMarkupId(true);
         add(container);
 
+        container.add(new Label("createTileLayerLabel", createTileLayerLabelModel));
+        container.add(createLayer = new CheckBox("createTileLayer", new Model<>(doCreateTileLayer)));
+        createLayer.add(new AttributeModifier("title", new ResourceModel("createTileLayer.title")));
+
         configs = new WebMarkupContainer("configs");
         configs.setOutputMarkupId(true);
         container.add(configs);
-
-        configs.add(new Label("createTileLayerLabel", createTileLayerLabelModel));
-        configs.add(createLayer = new CheckBox("createTileLayer", new Model<>(doCreateTileLayer)));
-        createLayer.add(new AttributeModifier("title", new ResourceModel("createTileLayer.title")));
 
         enabled = new CheckBox("enabled", new PropertyModel<>(getModel(), "enabled"));
         enabled.add(new AttributeModifier("title", new ResourceModel("enabled.title")));

--- a/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/LayerCacheOptionsTabPanelTest.java
+++ b/src/web/gwc/src/test/java/org/geoserver/gwc/web/layer/LayerCacheOptionsTabPanelTest.java
@@ -196,11 +196,13 @@ public class LayerCacheOptionsTabPanelTest extends GeoServerWicketTestSupport {
 
         // Avoid saving the Layer
         FormTester formTester = tester.newFormTester("form");
-        formTester.setValue("panel:tileLayerEditor:container:configs:createTileLayer", false);
+        formTester.setValue("panel:tileLayerEditor:container:createTileLayer", false);
 
-        tester.executeAjaxEvent("form:panel:tileLayerEditor:container:configs:createTileLayer", "change");
+        tester.executeAjaxEvent("form:panel:tileLayerEditor:container:createTileLayer", "change");
 
         tester.isInvisible("form:panel:tileLayerEditor:container:configs");
+        // the master checkbox must stay visible so caching can be re-enabled (GEOS regression)
+        tester.assertVisible("form:panel:tileLayerEditor:container:createTileLayer");
 
         LayerCacheOptionsTabPanel panel =
                 (LayerCacheOptionsTabPanel) tester.getComponentFromLastRenderedPage("form:panel");
@@ -251,7 +253,7 @@ public class LayerCacheOptionsTabPanelTest extends GeoServerWicketTestSupport {
         // mimic what the editor does to remove a tile layer associated with a layer info
         // print(tester.getComponentFromLastRenderedPage("form:panel"), true, true);
         FormTester formTester = tester.newFormTester("form");
-        formTester.setValue("panel:tileLayerEditor:container:configs:createTileLayer", false);
+        formTester.setValue("panel:tileLayerEditor:container:createTileLayer", false);
 
         formTester.submit();
 


### PR DESCRIPTION
[![GEOS-12143](https://badgen.net/badge/JIRA/GEOS-12143/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12143) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

See ticket for details

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 