### PR TITLE
[GEOS-12144] "application/vnd.ogc.fg+json" output format fails when requesting non-geographical datasets

### DIFF
--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriter.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriter.java
@@ -120,6 +120,7 @@ public class JSONFGFeatureWriter<T extends FeatureType, F extends Feature> exten
     }
 
     private String getCRSURI(CoordinateReferenceSystem crs) {
+        if (crs == null) return null;
         try {
             // prefer EPSG authority if possible, more commonly understood
             String epsgIdentifier = CRS.lookupIdentifier(Citations.EPSG, crs, false);

--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriter.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriter.java
@@ -112,6 +112,7 @@ public class JSONFGFeatureWriter<T extends FeatureType, F extends Feature> exten
     }
 
     private void writeCoordRefSys(GeoJSONBuilder jsonWriter, CoordinateReferenceSystem crs) {
+        if (crs == null) return;
         // write the CRS block only if needed
         if (!CRS.equalsIgnoreMetadata(DefaultGeographicCRS.WGS84, crs)) {
             jsonWriter.key(JSONFGFeaturesResponse.COORD_REF_SYS);
@@ -120,7 +121,6 @@ public class JSONFGFeatureWriter<T extends FeatureType, F extends Feature> exten
     }
 
     private String getCRSURI(CoordinateReferenceSystem crs) {
-        if (crs == null) return null;
         try {
             // prefer EPSG authority if possible, more commonly understood
             String epsgIdentifier = CRS.lookupIdentifier(Citations.EPSG, crs, false);

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
@@ -7,6 +7,8 @@ package org.geoserver.ogcapi.v1.features;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.internal.JsonContext;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
@@ -72,7 +72,8 @@ public class JSONFGFeatureWriterTest {
 
         toTest.write(geoCollection(), out, BigInteger.TEN, false);
 
-        assertThat(out.toString(), containsString("\"type\":\"FeatureCollection\""));
+        JsonContext json = (JsonContext) JsonPath.parse(out.toString());
+        assertEquals("FeatureCollection", json.read("$.type", String.class));
     }
 
     @Test

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.ogcapi.v1.features;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.ByteArrayOutputStream;

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
@@ -4,7 +4,8 @@
  */
 package org.geoserver.ogcapi.v1.features;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
@@ -82,6 +82,7 @@ public class JSONFGFeatureWriterTest {
 
         toTest.write(nonGeoCollection(), out, BigInteger.TEN, false);
 
-        assertThat(out.toString(), containsString("\"geometry\":null"));
+        assertEquals("FeatureCollection", JsonPath.parse(out.toString()).read("$.type", String.class));
+        assertNull(JsonPath.parse(out.toString()).read("$.features[0].geometry", String.class));
     }
 }

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
@@ -57,8 +57,7 @@ public class JSONFGFeatureWriterTest {
         return List.of(featureCollection);
     }
 
-    private List<FeatureCollection<SimpleFeatureType, SimpleFeature>> nonGeoCollection()
-            throws SchemaException, ParseException {
+    private List<FeatureCollection<SimpleFeatureType, SimpleFeature>> nonGeoCollection() throws SchemaException {
         SimpleFeatureType TYPE = DataUtilities.createType("places", "name:String,population:Integer");
         DefaultFeatureCollection featureCollection = new DefaultFeatureCollection("internal", TYPE);
 
@@ -79,7 +78,7 @@ public class JSONFGFeatureWriterTest {
     }
 
     @Test
-    public void testFeatureWriterNonGeo() throws SchemaException, IOException, ParseException {
+    public void testFeatureWriterNonGeo() throws SchemaException, IOException {
         OutputStream out = new ByteArrayOutputStream();
 
         toTest.write(nonGeoCollection(), out, BigInteger.TEN, false);

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
@@ -37,7 +37,7 @@ public class JSONFGFeatureWriterTest {
         gs.setCatalog(new CatalogImpl());
     }
 
-    JSONFGFeatureWriter toTest = new JSONFGFeatureWriter(gs, null, null) {
+    JSONFGFeatureWriter<SimpleFeatureType, SimpleFeature> toTest = new JSONFGFeatureWriter<>(gs, null, null) {
         @Override
         protected boolean isFeatureBounding() {
             return false;
@@ -46,23 +46,23 @@ public class JSONFGFeatureWriterTest {
 
     private List<FeatureCollection<SimpleFeatureType, SimpleFeature>> geoCollection()
             throws SchemaException, ParseException {
-        SimpleFeatureType TYPE = DataUtilities.createType("location", "geom:Point:srid=4326,name:String");
-        DefaultFeatureCollection featureCollection = new DefaultFeatureCollection("internal", TYPE);
+        SimpleFeatureType type = DataUtilities.createType("location", "geom:Point:srid=4326,name:String");
+        DefaultFeatureCollection featureCollection = new DefaultFeatureCollection("internal", type);
 
         WKTReader2 wkt = new WKTReader2();
 
-        featureCollection.add(SimpleFeatureBuilder.build(TYPE, new Object[] {wkt.read("POINT(1 2)"), "poi1"}, null));
-        featureCollection.add(SimpleFeatureBuilder.build(TYPE, new Object[] {wkt.read("POINT(4 4)"), "poi2"}, null));
+        featureCollection.add(SimpleFeatureBuilder.build(type, new Object[] {wkt.read("POINT(1 2)"), "poi1"}, null));
+        featureCollection.add(SimpleFeatureBuilder.build(type, new Object[] {wkt.read("POINT(4 4)"), "poi2"}, null));
 
         return List.of(featureCollection);
     }
 
     private List<FeatureCollection<SimpleFeatureType, SimpleFeature>> nonGeoCollection() throws SchemaException {
-        SimpleFeatureType TYPE = DataUtilities.createType("places", "name:String,population:Integer");
-        DefaultFeatureCollection featureCollection = new DefaultFeatureCollection("internal", TYPE);
+        SimpleFeatureType type = DataUtilities.createType("places", "name:String,population:Integer");
+        DefaultFeatureCollection featureCollection = new DefaultFeatureCollection("internal", type);
 
-        featureCollection.add(SimpleFeatureBuilder.build(TYPE, new Object[] {"Canada", 40_518_860}, null));
-        featureCollection.add(SimpleFeatureBuilder.build(TYPE, new Object[] {"France", 69_082_000}, null));
+        featureCollection.add(SimpleFeatureBuilder.build(type, new Object[] {"Canada", 40_518_860}, null));
+        featureCollection.add(SimpleFeatureBuilder.build(type, new Object[] {"France", 69_082_000}, null));
 
         return List.of(featureCollection);
     }

--- a/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
+++ b/src/extension/ogcapi/ogcapi-features/src/test/java/org/geoserver/ogcapi/v1/features/JSONFGFeatureWriterTest.java
@@ -1,0 +1,86 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.v1.features;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.util.List;
+import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.impl.GeoServerImpl;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.data.DataUtilities;
+import org.geotools.feature.DefaultFeatureCollection;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.SchemaException;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.geometry.jts.WKTReader2;
+import org.junit.Test;
+import org.locationtech.jts.io.ParseException;
+
+public class JSONFGFeatureWriterTest {
+
+    private static GeoServer gs;
+
+    static {
+        gs = new GeoServerImpl();
+        gs.setCatalog(new CatalogImpl());
+    }
+
+    JSONFGFeatureWriter toTest = new JSONFGFeatureWriter(gs, null, null) {
+        @Override
+        protected boolean isFeatureBounding() {
+            return false;
+        }
+    };
+
+    private List<FeatureCollection<SimpleFeatureType, SimpleFeature>> geoCollection()
+            throws SchemaException, ParseException {
+        SimpleFeatureType TYPE = DataUtilities.createType("location", "geom:Point:srid=4326,name:String");
+        DefaultFeatureCollection featureCollection = new DefaultFeatureCollection("internal", TYPE);
+
+        WKTReader2 wkt = new WKTReader2();
+
+        featureCollection.add(SimpleFeatureBuilder.build(TYPE, new Object[] {wkt.read("POINT(1 2)"), "poi1"}, null));
+        featureCollection.add(SimpleFeatureBuilder.build(TYPE, new Object[] {wkt.read("POINT(4 4)"), "poi2"}, null));
+
+        return List.of(featureCollection);
+    }
+
+    private List<FeatureCollection<SimpleFeatureType, SimpleFeature>> nonGeoCollection()
+            throws SchemaException, ParseException {
+        SimpleFeatureType TYPE = DataUtilities.createType("places", "name:String,population:Integer");
+        DefaultFeatureCollection featureCollection = new DefaultFeatureCollection("internal", TYPE);
+
+        featureCollection.add(SimpleFeatureBuilder.build(TYPE, new Object[] {"Canada", 40_518_860}, null));
+        featureCollection.add(SimpleFeatureBuilder.build(TYPE, new Object[] {"France", 69_082_000}, null));
+
+        return List.of(featureCollection);
+    }
+
+    @Test
+    public void testFeatureWriterGeo() throws SchemaException, ParseException, IOException {
+        OutputStream out = new ByteArrayOutputStream();
+
+        toTest.write(geoCollection(), out, BigInteger.TEN, false);
+
+        assertThat(out.toString(), containsString("\"type\":\"FeatureCollection\""));
+    }
+
+    @Test
+    public void testFeatureWriterNonGeo() throws SchemaException, IOException, ParseException {
+        OutputStream out = new ByteArrayOutputStream();
+
+        toTest.write(nonGeoCollection(), out, BigInteger.TEN, false);
+
+        assertThat(out.toString(), containsString("\"geometry\":null"));
+    }
+}


### PR DESCRIPTION
[![GEOS-12144](https://badgen.net/badge/JIRA/GEOS-12144/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12144) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->

Attempt to fix GEOS-12144: avoid to raise a NullPointerException when requesting a non-geographical dataset from the ogcapi as geojson output format.

The NPE is being thrown when GS tries to calculate the URL to the CRS (which is irrelevant considering non-geo datasets).

This has been manually/runtime tested.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 