### PR TITLE
[GEOS-12145] Added spatial filter in GeoFenceAccessManager SQL query when only CLIPping.

### DIFF
--- a/src/extension/geofence/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
+++ b/src/extension/geofence/geofence/src/main/java/org/geoserver/geofence/GeofenceAccessManager.java
@@ -611,12 +611,13 @@ public class GeofenceAccessManager implements ResourceAccessManager, DispatcherC
         CatalogMode catalogMode = getCatalogMode(accessInfo, resultLimits);
         LOGGER.log(Level.FINE, "Returning mode {0} for resource {1}", new Object[] {catalogMode, info});
 
-        AccessLimits accessLimits = null;
+        AccessLimits accessLimits;
         if (info instanceof FeatureTypeInfo) {
             // merge the area among the filters
-            if (intersectsArea != null) {
-                Filter areaFilter = FF.intersects(FF.property(""), FF.literal(intersectsArea));
-                if (clipArea != null) {
+            if (intersectsArea != null || clipArea != null) {
+                Geometry filterArea = intersectsArea != null ? intersectsArea : clipArea;
+                Filter areaFilter = FF.intersects(FF.property(""), FF.literal(filterArea));
+                if (intersectsArea != null && clipArea != null) {
                     Filter intersectClipArea = FF.intersects(FF.property(""), FF.literal(clipArea));
                     areaFilter = FF.or(areaFilter, intersectClipArea);
                 }

--- a/src/extension/geofence/geofence/src/test/java/org/geoserver/geofence/GeofenceAccessManagerTest.java
+++ b/src/extension/geofence/geofence/src/test/java/org/geoserver/geofence/GeofenceAccessManagerTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
@@ -19,6 +20,8 @@ import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
 import org.geoserver.catalog.impl.LayerInfoImpl;
 import org.geoserver.catalog.impl.WorkspaceInfoImpl;
 import org.geoserver.data.test.MockData;
+import org.geoserver.geofence.core.model.enums.GrantType;
+import org.geoserver.geofence.services.dto.AccessInfo;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.security.CoverageAccessLimits;
@@ -225,6 +228,31 @@ public class GeofenceAccessManagerTest extends GeofenceBaseTest {
 
         assertEquals(filter, vl.getReadFilter());
         assertEquals(filter, vl.getWriteFilter());
+    }
+
+    /**
+     * This test ensures that, with a CLIP-only rule (no intersects area set), the read and write filters produced by
+     * {@code buildResourceAccessLimits} include an INTERSECTS restriction built from the clip area.
+     */
+    @Test
+    public void testClipOnlyAddsSpatialFilter() throws Exception {
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+        FeatureTypeInfo resource = (FeatureTypeInfo)
+                catalog.getLayerByName(getLayerId(MockData.GENERICENTITY)).getResource();
+
+        AccessInfo accessInfo = new AccessInfo(GrantType.LIMIT);
+        accessInfo.setClipAreaWkt("MULTIPOLYGON(((48 62, 48 63, 49 63, 49 62, 48 62)))");
+
+        VectorAccessLimits vl =
+                (VectorAccessLimits) accessManager.buildResourceAccessLimits(resource, accessInfo, null);
+
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        Geometry clip = new WKTReader().read("MULTIPOLYGON(((48 62, 48 63, 49 63, 49 62, 48 62)))");
+        Filter expected = ff.intersects(ff.property(""), ff.literal(clip));
+
+        assertEquals(expected, vl.getReadFilter());
+        assertEquals(expected, vl.getWriteFilter());
+        assertEquals(clip, vl.getClipVectorFilter());
     }
 
     /**

--- a/src/security/security-tests/src/test/java/org/geoserver/security/decorators/SecuredFeatureSourceTest.java
+++ b/src/security/security-tests/src/test/java/org/geoserver/security/decorators/SecuredFeatureSourceTest.java
@@ -6,9 +6,11 @@
 package org.geoserver.security.decorators;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -19,6 +21,9 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import org.easymock.Capture;
+import org.geoserver.security.CatalogMode;
+import org.geoserver.security.VectorAccessLimits;
 import org.geoserver.security.WrapperPolicy;
 import org.geoserver.security.impl.SecureObjectsTest;
 import org.geotools.api.data.DataAccess;
@@ -163,5 +168,42 @@ public class SecuredFeatureSourceTest extends SecureObjectsTest {
         } finally {
             logger.removeHandler(customLogHandler);
         }
+    }
+
+    /**
+     * This test ensures that the query sent to the delegate feature source carries both the security read filter and
+     * the caller's pagination parameters (startIndex/maxFeatures).
+     */
+    @Test
+    public void testGetFeaturesMergesPaginationWithSecurityFilter() throws Exception {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+        Filter securityFilter = ff.equals(ff.property("name"), ff.literal("foo"));
+        VectorAccessLimits limits =
+                new VectorAccessLimits(CatalogMode.HIDE, null, securityFilter, null, securityFilter);
+
+        SimpleFeatureType schema = createNiceMock(SimpleFeatureType.class);
+        replay(schema);
+        SimpleFeatureCollection fc = createNiceMock(SimpleFeatureCollection.class);
+        expect(fc.getSchema()).andReturn(schema).anyTimes();
+        replay(fc);
+
+        SimpleFeatureSource fs = createNiceMock(SimpleFeatureSource.class);
+        Capture<Query> queryCapture = Capture.newInstance();
+        expect(fs.getFeatures(capture(queryCapture))).andReturn(fc).anyTimes();
+        replay(fs);
+
+        SecuredFeatureSource<SimpleFeatureType, SimpleFeature> secured =
+                new SecuredFeatureSource<>(fs, WrapperPolicy.readOnlyHide(limits));
+
+        Query userQuery = new Query();
+        userQuery.setStartIndex(5);
+        userQuery.setMaxFeatures(10);
+
+        secured.getFeatures(userQuery);
+
+        Query mixed = queryCapture.getValue();
+        assertEquals(Integer.valueOf(5), mixed.getStartIndex());
+        assertEquals(10, mixed.getMaxFeatures());
+        assertEquals(securityFilter, mixed.getFilter());
     }
 }


### PR DESCRIPTION
[![GEOS-12145](https://badgen.net/badge/JIRA/GEOS-12145/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12145) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

When no other feature filtering is present beside CLIP, GeoFenceAccessManager is ignoring this information querying for all the features.
This causes not only poor performances, but also wrong results when pagination is applied, because the subsequent in-memory clipping will not be performed on the actual features, but on the ones returned from the unrestricted query.

These changes introduce the correct spatial filter when CLIP is the only filter applied.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [X] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [X] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 