### PR TITLE
[GEOS-12149] GeoServer WMTS capabilities put query parameters in the wrong place in generated URLs

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/ResponseUtilsURLMangler.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/ResponseUtilsURLMangler.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.gwc;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.geoserver.gwc.dispatch.GwcServiceDispatcherCallback;
 import org.geoserver.ows.URLMangler.URLType;
@@ -14,14 +17,63 @@ public class ResponseUtilsURLMangler implements URLMangler {
 
     @Override
     public String buildURL(String baseURL, String contextPath, String path) {
+        UrlParts urlParts = buildUrlParts(baseURL, contextPath, path);
+        return ResponseUtils.buildURL(urlParts.baseUrl(), urlParts.restPath(), null, URLType.SERVICE);
+    }
+
+    /**
+     * Resolves the GWC-specific base URL/path handling (see {@link #buildUrlParts}), then delegates to
+     * {@link ResponseUtils#buildURL(String, String, Map, URLType)} for the actual mangler dispatch, kvp encoding and
+     * query string composition, so that logic exists in a single authoritative place.
+     *
+     * <p>Callers of this method (GWC's WMTS capabilities/backlink generation) need the path and the query parameters
+     * kept apart, since capability templates still contain unresolved placeholders such as {@code {TileRow}} at the
+     * point the query string is appended. The full (already mangled and percent-encoded) URL produced by
+     * {@code ResponseUtils.buildURL} is split back into its path and query components: the query component is decoded
+     * into the returned {@link URLMangler.UrlAndParams#queryParameters()} and the path component becomes
+     * {@link URLMangler.UrlAndParams#url()}. The {@code queryParameters} argument itself is never mutated.
+     */
+    @Override
+    public UrlAndParams buildURL(String baseURL, String contextPath, String path, Map<String, String> queryParameters) {
+        UrlParts urlParts = buildUrlParts(baseURL, contextPath, path);
+
+        String fullUrl =
+                ResponseUtils.buildURL(urlParts.baseUrl(), urlParts.restPath(), queryParameters, URLType.SERVICE);
+
+        int queryIndex = fullUrl.indexOf('?');
+        if (queryIndex == -1) {
+            return new UrlAndParams(fullUrl, Collections.emptyMap());
+        }
+
+        Map<String, String> resultParameters = decodeQueryString(fullUrl.substring(queryIndex + 1));
+        return new UrlAndParams(fullUrl.substring(0, queryIndex), resultParameters);
+    }
+
+    private static Map<String, String> decodeQueryString(String queryString) {
+        Map<String, String> resultParameters = new LinkedHashMap<>();
+        for (String pair : queryString.split("&")) {
+            if (pair.isEmpty()) {
+                continue;
+            }
+            int eq = pair.indexOf('=');
+            String key = eq == -1 ? pair : pair.substring(0, eq);
+            String value = eq == -1 ? "" : pair.substring(eq + 1);
+            resultParameters.put(ResponseUtils.urlDecode(key), ResponseUtils.urlDecode(value));
+        }
+        return resultParameters;
+    }
+
+    private UrlParts buildUrlParts(String baseURL, String contextPath, String path) {
         // In order to allow GWC to dispatch the requests the GwcServiceDispatcherCallback
         // puts the local workspace in the servlet context, however to build correct backlinks we
-        // need to original base URL with the workspace stuck in the path so that the
-        // proxy base URL rewrite won't eat it away
+        // need the original base URL with the workspace stuck in the path so that the
+        // proxy base URL rewrite won't eat it away.
         final String originalBaseURL = GwcServiceDispatcherCallback.GWC_ORIGINAL_BASEURL.get();
         String base = originalBaseURL == null ? StringUtils.strip(baseURL, "/") : originalBaseURL;
         String cp = StringUtils.strip(contextPath, "/");
         String rest = cp + "/" + StringUtils.stripStart(path, "/");
-        return ResponseUtils.buildURL(base, rest, null, URLType.SERVICE);
+        return new UrlParts(base, rest);
     }
+
+    private record UrlParts(String baseUrl, String restPath) {}
 }

--- a/src/gwc/src/main/java/org/geoserver/gwc/ResponseUtilsURLMangler.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/ResponseUtilsURLMangler.java
@@ -4,76 +4,24 @@
  */
 package org.geoserver.gwc;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.geoserver.gwc.dispatch.GwcServiceDispatcherCallback;
-import org.geoserver.ows.URLMangler.URLType;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geowebcache.util.URLMangler;
 
+/** Adapts GeoWebCache URL callbacks to GeoServer's URL mangling implementation. */
 public class ResponseUtilsURLMangler implements URLMangler {
 
     @Override
-    public String buildURL(String baseURL, String contextPath, String path) {
-        UrlParts urlParts = buildUrlParts(baseURL, contextPath, path);
-        return ResponseUtils.buildURL(urlParts.baseUrl(), urlParts.restPath(), null, URLType.SERVICE);
+    public void mangleURL(StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLMangler.URLType type) {
+        String originalBaseURL = GwcServiceDispatcherCallback.GWC_ORIGINAL_BASEURL.get();
+        String base = originalBaseURL == null ? StringUtils.strip(baseURL.toString(), "/") : originalBaseURL;
+        org.geoserver.ows.URLMangler.URLType geoServerType = org.geoserver.ows.URLMangler.URLType.valueOf(type.name());
+        String result = ResponseUtils.buildURL(base, path.toString(), kvp, geoServerType);
+        baseURL.setLength(0);
+        baseURL.append(result);
+        path.setLength(0);
+        kvp.clear();
     }
-
-    /**
-     * Resolves the GWC-specific base URL/path handling (see {@link #buildUrlParts}), then delegates to
-     * {@link ResponseUtils#buildURL(String, String, Map, URLType)} for the actual mangler dispatch, kvp encoding and
-     * query string composition, so that logic exists in a single authoritative place.
-     *
-     * <p>Callers of this method (GWC's WMTS capabilities/backlink generation) need the path and the query parameters
-     * kept apart, since capability templates still contain unresolved placeholders such as {@code {TileRow}} at the
-     * point the query string is appended. The full (already mangled and percent-encoded) URL produced by
-     * {@code ResponseUtils.buildURL} is split back into its path and query components: the query component is decoded
-     * into the returned {@link URLMangler.UrlAndParams#queryParameters()} and the path component becomes
-     * {@link URLMangler.UrlAndParams#url()}. The {@code queryParameters} argument itself is never mutated.
-     */
-    @Override
-    public UrlAndParams buildURL(String baseURL, String contextPath, String path, Map<String, String> queryParameters) {
-        UrlParts urlParts = buildUrlParts(baseURL, contextPath, path);
-
-        String fullUrl =
-                ResponseUtils.buildURL(urlParts.baseUrl(), urlParts.restPath(), queryParameters, URLType.SERVICE);
-
-        int queryIndex = fullUrl.indexOf('?');
-        if (queryIndex == -1) {
-            return new UrlAndParams(fullUrl, Collections.emptyMap());
-        }
-
-        Map<String, String> resultParameters = decodeQueryString(fullUrl.substring(queryIndex + 1));
-        return new UrlAndParams(fullUrl.substring(0, queryIndex), resultParameters);
-    }
-
-    private static Map<String, String> decodeQueryString(String queryString) {
-        Map<String, String> resultParameters = new LinkedHashMap<>();
-        for (String pair : queryString.split("&")) {
-            if (pair.isEmpty()) {
-                continue;
-            }
-            int eq = pair.indexOf('=');
-            String key = eq == -1 ? pair : pair.substring(0, eq);
-            String value = eq == -1 ? "" : pair.substring(eq + 1);
-            resultParameters.put(ResponseUtils.urlDecode(key), ResponseUtils.urlDecode(value));
-        }
-        return resultParameters;
-    }
-
-    private UrlParts buildUrlParts(String baseURL, String contextPath, String path) {
-        // In order to allow GWC to dispatch the requests the GwcServiceDispatcherCallback
-        // puts the local workspace in the servlet context, however to build correct backlinks we
-        // need the original base URL with the workspace stuck in the path so that the
-        // proxy base URL rewrite won't eat it away.
-        final String originalBaseURL = GwcServiceDispatcherCallback.GWC_ORIGINAL_BASEURL.get();
-        String base = originalBaseURL == null ? StringUtils.strip(baseURL, "/") : originalBaseURL;
-        String cp = StringUtils.strip(contextPath, "/");
-        String rest = cp + "/" + StringUtils.stripStart(path, "/");
-        return new UrlParts(base, rest);
-    }
-
-    private record UrlParts(String baseUrl, String restPath) {}
 }

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -90,7 +90,9 @@ import org.geoserver.gwc.wmts.WMTSInfo;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.LocalWorkspace;
 import org.geoserver.ows.Request;
+import org.geoserver.ows.URLMangler;
 import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geoserver.util.DimensionWarning;
@@ -1851,6 +1853,102 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
                                 + WMTSService.REST_PATH
                                 + "/WMTSCapabilities.xml'])",
                         doc));
+    }
+
+    /**
+     * Verifies that a workspace-prefixed WMTS GetCapabilities response keeps the workspace path in place and appends
+     * the propagated token after the existing query parameters in every backlink.
+     */
+    @Test
+    public void testGetCapabilitiesQueryParametersPlacementWorkspace() throws Exception {
+        GeoServerExtensionsHelper.singleton(
+                "projecttokenMangler",
+                new URLMangler() {
+                    @Override
+                    public void mangleURL(
+                            StringBuilder baseURL,
+                            StringBuilder path,
+                            Map<String, String> kvp,
+                            URLMangler.URLType type) {
+                        kvp.put("projecttoken", "abc123");
+                    }
+                },
+                URLMangler.class);
+
+        try {
+            Document doc = getAsDOM(CITE_PREFIX + "/gwc/service/wmts?request=GetCapabilities");
+            assertProjectTokenPlacement(doc, "/" + CITE_PREFIX, "BasicPolygons");
+        } finally {
+            GeoServerExtensionsHelper.clear();
+        }
+    }
+
+    /**
+     * Verifies that the global WMTS GetCapabilities response keeps the service path in place and appends the propagated
+     * token after the existing query parameters in every backlink.
+     */
+    @Test
+    public void testGetCapabilitiesQueryParametersPlacementGlobal() throws Exception {
+        GeoServerExtensionsHelper.singleton(
+                "projecttokenMangler",
+                new URLMangler() {
+                    @Override
+                    public void mangleURL(
+                            StringBuilder baseURL,
+                            StringBuilder path,
+                            Map<String, String> kvp,
+                            URLMangler.URLType type) {
+                        kvp.put("projecttoken", "abc123");
+                    }
+                },
+                URLMangler.class);
+
+        try {
+            Document doc = getAsDOM("/gwc/service/wmts?request=GetCapabilities");
+            assertProjectTokenPlacement(doc, "", CITE_PREFIX + ":BasicPolygons");
+        } finally {
+            GeoServerExtensionsHelper.clear();
+        }
+    }
+
+    private void assertProjectTokenPlacement(Document doc, String servicePrefix, String layerPathSegment)
+            throws Exception {
+        String serviceRoot = "http://localhost:8080/geoserver"
+                + (servicePrefix.isEmpty() ? "" : servicePrefix)
+                + "/gwc/service/wmts";
+
+        assertEquals(
+                serviceRoot
+                        + "/rest/"
+                        + layerPathSegment
+                        + "/{style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}?format=image/png&projecttoken=abc123",
+                WMTS_XPATH_10.evaluate(
+                        "//wmts:Contents/wmts:Layer[ows:Title='BasicPolygons']"
+                                + "/wmts:ResourceURL[@resourceType='tile' and @format='image/png']/@template",
+                        doc));
+        assertEquals(
+                serviceRoot
+                        + "/rest/"
+                        + layerPathSegment
+                        + "/{style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}/{J}/{I}?format=text/plain&projecttoken=abc123",
+                WMTS_XPATH_10.evaluate(
+                        "//wmts:Contents/wmts:Layer[ows:Title='BasicPolygons']"
+                                + "/wmts:ResourceURL[@resourceType='FeatureInfo' and @format='text/plain']/@template",
+                        doc));
+        assertEquals(
+                "1",
+                WMTS_XPATH_10.evaluate(
+                        "count(//wmts:Capabilities/wmts:ServiceMetadataURL[@xlink:href='"
+                                + serviceRoot
+                                + "/rest/WMTSCapabilities.xml?projecttoken=abc123'])",
+                        doc));
+        assertEquals(
+                "0",
+                WMTS_XPATH_10.evaluate("count(//wmts:ResourceURL[contains(@template,'?projecttoken=abc123/')])", doc));
+        assertEquals(
+                "0",
+                WMTS_XPATH_10.evaluate(
+                        "count(//wmts:ServiceMetadataURL[contains(@xlink:href,'?projecttoken=abc123/')])", doc));
     }
 
     @Test

--- a/src/gwc/src/test/java/org/geoserver/gwc/ResponseUtilsURLManglerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/ResponseUtilsURLManglerTest.java
@@ -4,6 +4,10 @@
  */
 package org.geoserver.gwc;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.geoserver.gwc.dispatch.GwcServiceDispatcherCallback;
+import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geowebcache.util.URLMangler;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,5 +38,69 @@ public class ResponseUtilsURLManglerTest {
     public void testBuildNoLeadingSlashes() throws Exception {
         String url = urlMangler.buildURL("http://foo.example.com/", "foo/", "bar");
         Assert.assertEquals("http://foo.example.com/foo/bar", url);
+    }
+
+    /**
+     * Verifies that the 4-arg URL mangler keeps the returned URL path only while still allowing the query map to be
+     * enriched by GeoServer URL manglers.
+     */
+    @Test
+    public void testBuildURLWithQueryParameters() throws Exception {
+        GeoServerExtensionsHelper.singleton(
+                "projecttokenMangler",
+                new org.geoserver.ows.URLMangler() {
+                    @Override
+                    public void mangleURL(
+                            StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLType type) {
+                        kvp.put("projecttoken", "abc123");
+                    }
+                },
+                org.geoserver.ows.URLMangler.class);
+
+        try {
+            Map<String, String> queryParameters = new LinkedHashMap<>();
+            queryParameters.put("format", "image/png");
+
+            URLMangler.UrlAndParams result =
+                    urlMangler.buildURL("http://foo.example.com/", "/foo/", "/bar", queryParameters);
+
+            Assert.assertEquals("http://foo.example.com/foo/bar", result.url());
+            Assert.assertEquals("image/png", result.queryParameters().get("format"));
+            Assert.assertEquals("abc123", result.queryParameters().get("projecttoken"));
+        } finally {
+            GeoServerExtensionsHelper.clear();
+        }
+    }
+
+    /**
+     * Verifies that the original base URL thread-local still takes precedence when building a URL with propagated query
+     * parameters.
+     */
+    @Test
+    public void testBuildURLWithOriginalBaseUrl() throws Exception {
+        GeoServerExtensionsHelper.singleton(
+                "projecttokenMangler",
+                new org.geoserver.ows.URLMangler() {
+                    @Override
+                    public void mangleURL(
+                            StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLType type) {
+                        kvp.put("projecttoken", "abc123");
+                    }
+                },
+                org.geoserver.ows.URLMangler.class);
+
+        GwcServiceDispatcherCallback.GWC_ORIGINAL_BASEURL.set("http://proxy.example.com/geoserver");
+        try {
+            Map<String, String> queryParameters = new LinkedHashMap<>();
+
+            URLMangler.UrlAndParams result =
+                    urlMangler.buildURL("http://foo.example.com/", "/foo/", "/bar", queryParameters);
+
+            Assert.assertEquals("http://proxy.example.com/geoserver/foo/bar", result.url());
+            Assert.assertEquals("abc123", result.queryParameters().get("projecttoken"));
+        } finally {
+            GwcServiceDispatcherCallback.GWC_ORIGINAL_BASEURL.remove();
+            GeoServerExtensionsHelper.clear();
+        }
     }
 }

--- a/src/gwc/src/test/java/org/geoserver/gwc/ResponseUtilsURLManglerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/ResponseUtilsURLManglerTest.java
@@ -4,11 +4,10 @@
  */
 package org.geoserver.gwc;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.geoserver.gwc.dispatch.GwcServiceDispatcherCallback;
 import org.geoserver.platform.GeoServerExtensionsHelper;
 import org.geowebcache.util.URLMangler;
+import org.geowebcache.util.URLManglerUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,89 +17,51 @@ public class ResponseUtilsURLManglerTest {
     private URLMangler urlMangler;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         urlMangler = new ResponseUtilsURLMangler();
     }
 
     @Test
     public void testBuildURL() {
-        String url = urlMangler.buildURL("http://foo.example.com", "/foo", "/bar");
-        Assert.assertEquals("http://foo.example.com/foo/bar", url);
+        Assert.assertEquals(
+                "http://foo.example.com/foo/bar",
+                URLManglerUtils.buildURL(
+                        "http://foo.example.com", "/foo", "/bar", null, urlMangler, URLMangler.URLType.SERVICE));
     }
 
+    /** Verifies GeoServer-provided query parameters are appended after an existing URL query. */
     @Test
-    public void testBuildTrailingSlashes() throws Exception {
-        String url = urlMangler.buildURL("http://foo.example.com/", "/foo/", "/bar");
-        Assert.assertEquals("http://foo.example.com/foo/bar", url);
-    }
-
-    @Test
-    public void testBuildNoLeadingSlashes() throws Exception {
-        String url = urlMangler.buildURL("http://foo.example.com/", "foo/", "bar");
-        Assert.assertEquals("http://foo.example.com/foo/bar", url);
-    }
-
-    /**
-     * Verifies that the 4-arg URL mangler keeps the returned URL path only while still allowing the query map to be
-     * enriched by GeoServer URL manglers.
-     */
-    @Test
-    public void testBuildURLWithQueryParameters() throws Exception {
+    public void testBuildURLWithQueryParameters() {
         GeoServerExtensionsHelper.singleton(
                 "projecttokenMangler",
-                new org.geoserver.ows.URLMangler() {
-                    @Override
-                    public void mangleURL(
-                            StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLType type) {
-                        kvp.put("projecttoken", "abc123");
-                    }
-                },
+                (org.geoserver.ows.URLMangler) (base, path, kvp, type) -> kvp.put("projecttoken", "abc123"),
                 org.geoserver.ows.URLMangler.class);
-
         try {
-            Map<String, String> queryParameters = new LinkedHashMap<>();
-            queryParameters.put("format", "image/png");
-
-            URLMangler.UrlAndParams result =
-                    urlMangler.buildURL("http://foo.example.com/", "/foo/", "/bar", queryParameters);
-
-            Assert.assertEquals("http://foo.example.com/foo/bar", result.url());
-            Assert.assertEquals("image/png", result.queryParameters().get("format"));
-            Assert.assertEquals("abc123", result.queryParameters().get("projecttoken"));
+            Assert.assertEquals(
+                    "http://foo.example.com/foo/bar?format=image/png&projecttoken=abc123",
+                    URLManglerUtils.buildURL(
+                            "http://foo.example.com/",
+                            "/foo",
+                            "/bar?format=image/png",
+                            null,
+                            urlMangler,
+                            URLMangler.URLType.SERVICE));
         } finally {
             GeoServerExtensionsHelper.clear();
         }
     }
 
-    /**
-     * Verifies that the original base URL thread-local still takes precedence when building a URL with propagated query
-     * parameters.
-     */
+    /** Verifies the dispatcher callback's original base URL is preserved by the adapter. */
     @Test
-    public void testBuildURLWithOriginalBaseUrl() throws Exception {
-        GeoServerExtensionsHelper.singleton(
-                "projecttokenMangler",
-                new org.geoserver.ows.URLMangler() {
-                    @Override
-                    public void mangleURL(
-                            StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLType type) {
-                        kvp.put("projecttoken", "abc123");
-                    }
-                },
-                org.geoserver.ows.URLMangler.class);
-
+    public void testBuildURLWithOriginalBaseUrl() {
         GwcServiceDispatcherCallback.GWC_ORIGINAL_BASEURL.set("http://proxy.example.com/geoserver");
         try {
-            Map<String, String> queryParameters = new LinkedHashMap<>();
-
-            URLMangler.UrlAndParams result =
-                    urlMangler.buildURL("http://foo.example.com/", "/foo/", "/bar", queryParameters);
-
-            Assert.assertEquals("http://proxy.example.com/geoserver/foo/bar", result.url());
-            Assert.assertEquals("abc123", result.queryParameters().get("projecttoken"));
+            Assert.assertEquals(
+                    "http://proxy.example.com/geoserver/foo/bar",
+                    URLManglerUtils.buildURL(
+                            "http://foo.example.com/", "/foo", "/bar", null, urlMangler, URLMangler.URLType.SERVICE));
         } finally {
             GwcServiceDispatcherCallback.GWC_ORIGINAL_BASEURL.remove();
-            GeoServerExtensionsHelper.clear();
         }
     }
 }


### PR DESCRIPTION
[![GEOS-12149](https://badgen.net/badge/JIRA/GEOS-12149/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12149) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

https://osgeo-org.atlassian.net/browse/GEOS-12149

This PR fixes GeoServer’s WMTS `GetCapabilities` responses so propagated query parameters, are appended at the end of generated backlinks instead of being inserted before unresolved REST path segments.

This PR depends on GeoWebCache PR:
https://github.com/GeoWebCache/geowebcache/pull/1554

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 