### PR TITLE
fix: Do not load complete catalog in workspace-scoped requests

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/LocalWorkspaceCatalog.java
@@ -128,6 +128,13 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
 
     @Override
     public List<FeatureTypeInfo> getFeatureTypes() {
+        WorkspaceInfo localWorkspace = LocalWorkspace.get();
+        if (localWorkspace != null) {
+            NamespaceInfo ns = super.getNamespaceByPrefix(localWorkspace.getName());
+            if (ns != null) {
+                return getFeatureTypesByNamespace(ns);
+            }
+        }
         return wrapFeatureTypesListIfNeeded(super.getFeatureTypes());
     }
 
@@ -147,8 +154,14 @@ public class LocalWorkspaceCatalog extends AbstractCatalogDecorator implements C
 
     @Override
     public List<CoverageInfo> getCoverages() {
-        List<CoverageInfo> coverages = super.getCoverages();
-        return wrapCoverageListIfNeeded(coverages);
+        WorkspaceInfo localWorkspace = LocalWorkspace.get();
+        if (localWorkspace != null) {
+            NamespaceInfo ns = super.getNamespaceByPrefix(localWorkspace.getName());
+            if (ns != null) {
+                return getCoveragesByNamespace(ns);
+            }
+        }
+        return wrapCoverageListIfNeeded(super.getCoverages());
     }
 
     @Override

--- a/src/main/src/test/java/org/geoserver/catalog/impl/LocalWorkspaceCatalogTest.java
+++ b/src/main/src/test/java/org/geoserver/catalog/impl/LocalWorkspaceCatalogTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
@@ -102,6 +103,16 @@ public class LocalWorkspaceCatalogTest {
         expect(ft2.getNamespace()).andReturn(ns2).anyTimes();
         replay(ft2);
 
+        CoverageInfo cov1 = createNiceMock(CoverageInfo.class);
+        expect(cov1.getName()).andReturn("c1").anyTimes();
+        expect(cov1.getNamespace()).andReturn(ns1).anyTimes();
+        replay(cov1);
+
+        CoverageInfo cov2 = createNiceMock(CoverageInfo.class);
+        expect(cov2.getName()).andReturn("c2").anyTimes();
+        expect(cov2.getNamespace()).andReturn(ns2).anyTimes();
+        replay(cov2);
+
         LayerInfo l2 = createNiceMock(LayerInfo.class);
         expect(l2.getName()).andReturn("ws2:l2").anyTimes();
         expect(l2.getResource()).andReturn(ft2).anyTimes();
@@ -127,6 +138,19 @@ public class LocalWorkspaceCatalogTest {
         expect(cat.getWorkspaceByName("ws2")).andReturn(ws2).anyTimes();
         expect(cat.getNamespaceByPrefix("ws1")).andReturn(ns1).anyTimes();
         expect(cat.getNamespaceByPrefix("ws2")).andReturn(ns2).anyTimes();
+
+        // Full-catalog lookups (what a workspace-scoped request should NOT use) vs the
+        // namespace-scoped lookups that should be used when a LocalWorkspace is set.
+        expect(cat.getFeatureTypes()).andReturn(Arrays.asList(ft1, ft2)).anyTimes();
+        expect(cat.getFeatureTypesByNamespace(ns1))
+                .andReturn(Arrays.asList(ft1))
+                .anyTimes();
+        expect(cat.getFeatureTypesByNamespace(ns2))
+                .andReturn(Arrays.asList(ft2))
+                .anyTimes();
+        expect(cat.getCoverages()).andReturn(Arrays.asList(cov1, cov2)).anyTimes();
+        expect(cat.getCoveragesByNamespace(ns1)).andReturn(Arrays.asList(cov1)).anyTimes();
+        expect(cat.getCoveragesByNamespace(ns2)).andReturn(Arrays.asList(cov2)).anyTimes();
 
         expect(cat.getStyleByName("ws1", "s1")).andReturn(s1).anyTimes();
         expect(cat.getStyleByName(ws1, "s1")).andReturn(s1).anyTimes();
@@ -184,6 +208,40 @@ public class LocalWorkspaceCatalogTest {
     @After
     public void tearDown() {
         LocalWorkspace.remove();
+    }
+
+    @Test
+    public void testGetFeatureTypesScopedToLocalWorkspace() {
+        // Without a local workspace (e.g. global capabilities) all feature types are returned.
+        assertEquals(2, catalog.getFeatureTypes().size());
+
+        // Under a local (virtual service) workspace, getFeatureTypes() must return only that
+        // workspace's feature types, looked up by namespace, rather than loading every feature
+        // type in the catalog and discarding all but those from the relevant workspace.
+        WorkspaceInfo ws1 = catalog.getWorkspaceByName("ws1");
+        LocalWorkspace.set(ws1);
+        try {
+            List<FeatureTypeInfo> scoped = catalog.getFeatureTypes();
+            assertEquals(1, scoped.size());
+            assertEquals("l1", scoped.get(0).getName());
+        } finally {
+            LocalWorkspace.remove();
+        }
+    }
+
+    @Test
+    public void testGetCoveragesScopedToLocalWorkspace() {
+        assertEquals(2, catalog.getCoverages().size());
+
+        WorkspaceInfo ws2 = catalog.getWorkspaceByName("ws2");
+        LocalWorkspace.set(ws2);
+        try {
+            List<CoverageInfo> scoped = catalog.getCoverages();
+            assertEquals(1, scoped.size());
+            assertEquals("c2", scoped.get(0).getName());
+        } finally {
+            LocalWorkspace.remove();
+        }
     }
 
     @Test


### PR DESCRIPTION
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

# Description

We noticed that simple workspace-scoped requests like 

```
/my_workspace/ows?service=wfs&version=2.0.0&request=GetCapabilities
``` 

can take a long time even on small workspaces because the `LocalWorkspaceCatalog` loads all featuretypes first before filtering them down to the virtual service's workspace. 

On core Geoserver, this is not a big issue, as the catalog lives in-memory, but on geoserver-cloud with the pgconfig backend and a large catalog of ~40k layers, a single request can take ~30s, even for small workspaces. The reason is that the complete catalog needs to be loaded into memory and filtered. This PR fixes this by loading only the relevant featuretypes from the local workspace in the first place (which is an efficient filtered db query on the pgconfig backend).