### PR TITLE
Docs: fix leftover 'attributes of features' on Publishing a GeoTIFF q…

### DIFF
--- a/doc/en/user/gettingstarted/image-quickstart/index.md
+++ b/doc/en/user/gettingstarted/image-quickstart/index.md
@@ -170,7 +170,7 @@ In order to verify that the `tutorial:shaded` layer is published correctly, we c
 
 3.  An OpenLayers map will load in a new tab and display the imagery with the default raster style.
 
-    You can use this preview map to zoom and pan around the dataset, as well as display the attributes of features.
+    You can use this preview map to zoom and pan around the dataset, as well as click on the map to display the value stored at that pixel.
 
     ![](images/openlayers.png)
 


### PR DESCRIPTION
## What
Fixes a leftover in the "Publishing a GeoTIFF" quickstart (`image-quickstart/index.md`), in the "Previewing the layer" section.

## Why
The sentence "as well as display the attributes of features" applies to vector layers. Since this tutorial covers a raster GeoTIFF — clicking the OpenLayers preview instead returns the pixel value via GetFeatureInfo.