### PR TITLE
Docs: Update version selector for consistent presentation of latest and stable

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,19 +54,14 @@ jobs:
 
           if [ "$BRANCH" = "main" ]; then
             echo "version=latest" >> $GITHUB_OUTPUT
-            echo "title=main (Latest)" >> $GITHUB_OUTPUT
-            echo "aliases=main 3.1.x" >> $GITHUB_OUTPUT
+            echo "title=3.1.x (Latest) main" >> $GITHUB_OUTPUT
+            echo "aliases=3.1.x main" >> $GITHUB_OUTPUT
             echo "is_default=false" >> $GITHUB_OUTPUT
           elif [ "$BRANCH" = "3.0.x" ]; then
-            echo "version=3.0.x" >> $GITHUB_OUTPUT
-            echo "title=3.0.x" >> $GITHUB_OUTPUT
-            echo "aliases=stable" >> $GITHUB_OUTPUT
+            echo "version=stable" >> $GITHUB_OUTPUT
+            echo "title=3.0.x (Stable)" >> $GITHUB_OUTPUT
+            echo "aliases=3.0.x" >> $GITHUB_OUTPUT
             echo "is_default=true" >> $GITHUB_OUTPUT
-          elif [ "$BRANCH" = "2.28.x" ]; then
-            echo "version=2.28.x" >> $GITHUB_OUTPUT
-            echo "title=2.28.x" >> $GITHUB_OUTPUT
-            echo "aliases=" >> $GITHUB_OUTPUT
-            echo "is_default=false" >> $GITHUB_OUTPUT
           else
             echo "version=$BRANCH" >> $GITHUB_OUTPUT
             echo "title=$BRANCH" >> $GITHUB_OUTPUT

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,9 +58,9 @@ jobs:
             echo "aliases=3.1.x main" >> $GITHUB_OUTPUT
             echo "is_default=false" >> $GITHUB_OUTPUT
           elif [ "$BRANCH" = "3.0.x" ]; then
-            echo "version=stable" >> $GITHUB_OUTPUT
+            echo "version=3.0.x" >> $GITHUB_OUTPUT
             echo "title=3.0.x (Stable)" >> $GITHUB_OUTPUT
-            echo "aliases=3.0.x" >> $GITHUB_OUTPUT
+            echo "aliases=stable" >> $GITHUB_OUTPUT
             echo "is_default=true" >> $GITHUB_OUTPUT
           else
             echo "version=$BRANCH" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Now that I have both `main` and `3.0.x` deploying to https://docs.geoserver.org/ - I notice the version selector is inconsistent. The default is `3.0.0 stable` which is great.

<img width="474" height="45" alt="image" src="https://github.com/user-attachments/assets/56cd1296-0380-4760-a17a-e4077add34a8" />

The dropdown has different title presentation of `main (Latest) main` and `3.0.x` and `2.28.x' (Maintenance):

<img width="213" height="166" alt="image" src="https://github.com/user-attachments/assets/b88432a2-72a7-455d-ab2c-2acb39eb9106" />

Recommendation:
```
3.1.x (Latest) main
3.0.x (Stable)
2.28.x (Maintenance)
```

The URL version selector mapping is inconsistent with `3.0.x` and `latest`. The other alias are available by direct link (for example from release announcement):

* `https://docs.geoserver.org/3.0.x/` - Selector
* `https://docs.geoserver.org/stable/` 
* `https://docs.geoserver.org/3.1.x/` 
* `https://docs.geoserver.org/latest/` - Selector
* `https://docs.geoserver.org/main/`
* `https://docs-archive.geoserver.org/2.28.x/en/user/` - Selector
* `https://docs-archive.geoserver.org/maintain/en/user/`

The default has changed between `3.0.x` and `main` over the course of writing so I believe the different branches are changing the default each time they publish!

Option 1: Choose `stable` and `latest` as the version selector targets, with `stable` as default. This is consistent.

Option 2: Choose `3.0.x` and `3.1.x` as the version selector targets, with `3.0.x` as default. This is consistent.

Option 3: choose `3.0.x` and `latest` as version selector targets, with `3.0.x` as the default.

Not sure if `main` provides value as a duplicate of `latest`.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.