### PR TITLE
[GEOS-12159] Fix ClassCastException reprojecting per-feature geometry…

### DIFF
--- a/src/main/src/main/java/org/geoserver/feature/ReprojectingFeatureCollection.java
+++ b/src/main/src/main/java/org/geoserver/feature/ReprojectingFeatureCollection.java
@@ -20,7 +20,6 @@ import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.MathTransform;
-import org.geotools.api.referencing.operation.MathTransform2D;
 import org.geotools.api.referencing.operation.OperationNotFoundException;
 import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.api.util.ProgressListener;
@@ -243,10 +242,10 @@ public class ReprojectingFeatureCollection extends DecoratingSimpleFeatureCollec
                         if (transformer == null) {
                             transformer = new GeometryCoordinateSequenceTransformer();
 
-                            MathTransform2D tx;
+                            MathTransform tx;
 
                             try {
-                                tx = (MathTransform2D) ReferencingFactoryFinder.getCoordinateOperationFactory(hints)
+                                tx = ReferencingFactoryFinder.getCoordinateOperationFactory(hints)
                                         .createOperation(crs, target)
                                         .getMathTransform();
                             } catch (Exception e) {

--- a/src/main/src/test/java/org/geoserver/feature/ReprojectingFeatureCollectionTest.java
+++ b/src/main/src/test/java/org/geoserver/feature/ReprojectingFeatureCollectionTest.java
@@ -47,20 +47,7 @@ public class ReprojectingFeatureCollectionTest {
         }
     }
 
-    /**
-     * reproject(SimpleFeature) resolves a per-feature transform (via the geometry's own user data CRS, not the
-     * collection's cached default-source transform) through a code path that casts the result to MathTransform2D. That
-     * cast is safe whenever the transform happens to be 2-dimensional, but throws ClassCastException for a genuine
-     * 3D-to-3D coordinate operation - e.g. between two different Geographic 3D CRSs (EPSG:4979 WGS84 3D and EPSG:4937
-     * ETRS89 3D here), where latitude, longitude and ellipsoidal height are all axes of the CRS itself, not a 2D CRS
-     * with a Z ordinate merely riding along on the geometry.
-     *
-     * <p>This is exactly what happens in practice when a WFS-T feature's geometry carries an explicit CRS (e.g. one a
-     * client resolved from a GetCapabilities document) that differs from the feature type's own declared CRS, for a
-     * genuinely 3-dimensional CRS pair - the per-feature transformer has to be built for the first time (a cache miss),
-     * taking this cast path, rather than reusing the constructor's own already-cached, correctly uncast transformer for
-     * the feature type's declared CRS.
-     */
+    /** Per-feature reprojection between two 3D CRSs must not throw ClassCastException (GEOS-12159). */
     @Test
     public void testReprojectPerFeatureCRSWithGenuine3DCRS() throws Exception {
         CoordinateReferenceSystem geometryCrs = CRS.decode("EPSG:4979"); // WGS84 3D
@@ -68,18 +55,13 @@ public class ReprojectingFeatureCollectionTest {
 
         SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
         tb.setName("threeDimensional");
-        // Deliberately matches the *target* CRS, not the per-feature geometry CRS below: the
-        // constructor primes its transformer cache keyed by this schema CRS, using the safe
-        // (uncast) MathTransform path. If this matched the geometry's own CRS instead, that
-        // priming step would satisfy reproject()'s cache lookup before ever reaching its own,
-        // separately-cast, per-feature transformer construction - masking the bug entirely.
+        // Schema CRS matches the target, not the per-feature geometry CRS, so the per-feature
+        // transform is built fresh (cache miss) rather than reusing the constructor's transform.
         tb.setSRS("EPSG:4937");
         tb.add("geom", Point.class);
 
         SimpleFeatureBuilder b = new SimpleFeatureBuilder(tb.buildFeatureType());
         Point point = (Point) new WKTReader().read("POINT(10 20 123)");
-        // The per-feature CRS on the geometry's own user data - not the feature type's CRS -
-        // is what reproject() actually consults first (see its own javadoc).
         point.setUserData(geometryCrs);
         b.add(point);
         SimpleFeature f = b.buildFeature("f1");
@@ -90,11 +72,6 @@ public class ReprojectingFeatureCollectionTest {
         ReprojectingFeatureCollection reprojected = new ReprojectingFeatureCollection(features, targetCrs);
         try (FeatureIterator it = reprojected.features()) {
             assertTrue(it.hasNext());
-            // Must not throw - previously failed with:
-            // java.io.IOException: Could not transform for crs: ...
-            // Caused by: java.lang.ClassCastException: class
-            // org.geotools.referencing.operation.transform.ConcatenatedTransformDirect cannot be cast to class
-            // org.geotools.api.referencing.operation.MathTransform2D
             it.next();
         }
     }

--- a/src/main/src/test/java/org/geoserver/feature/ReprojectingFeatureCollectionTest.java
+++ b/src/main/src/test/java/org/geoserver/feature/ReprojectingFeatureCollectionTest.java
@@ -6,8 +6,10 @@
 package org.geoserver.feature;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -42,6 +44,58 @@ public class ReprojectingFeatureCollectionTest {
                 new ReprojectingFeatureCollection(features, CRS.decode("EPSG:3005"));
         try (FeatureIterator it = reprojected.features()) {
             assertEquals("bar", it.next().getUserData().get("foo"));
+        }
+    }
+
+    /**
+     * reproject(SimpleFeature) resolves a per-feature transform (via the geometry's own user data CRS, not the
+     * collection's cached default-source transform) through a code path that casts the result to MathTransform2D. That
+     * cast is safe whenever the transform happens to be 2-dimensional, but throws ClassCastException for a genuine
+     * 3D-to-3D coordinate operation - e.g. between two different Geographic 3D CRSs (EPSG:4979 WGS84 3D and EPSG:4937
+     * ETRS89 3D here), where latitude, longitude and ellipsoidal height are all axes of the CRS itself, not a 2D CRS
+     * with a Z ordinate merely riding along on the geometry.
+     *
+     * <p>This is exactly what happens in practice when a WFS-T feature's geometry carries an explicit CRS (e.g. one a
+     * client resolved from a GetCapabilities document) that differs from the feature type's own declared CRS, for a
+     * genuinely 3-dimensional CRS pair - the per-feature transformer has to be built for the first time (a cache miss),
+     * taking this cast path, rather than reusing the constructor's own already-cached, correctly uncast transformer for
+     * the feature type's declared CRS.
+     */
+    @Test
+    public void testReprojectPerFeatureCRSWithGenuine3DCRS() throws Exception {
+        CoordinateReferenceSystem geometryCrs = CRS.decode("EPSG:4979"); // WGS84 3D
+        CoordinateReferenceSystem targetCrs = CRS.decode("EPSG:4937"); // ETRS89 3D - different datum
+
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.setName("threeDimensional");
+        // Deliberately matches the *target* CRS, not the per-feature geometry CRS below: the
+        // constructor primes its transformer cache keyed by this schema CRS, using the safe
+        // (uncast) MathTransform path. If this matched the geometry's own CRS instead, that
+        // priming step would satisfy reproject()'s cache lookup before ever reaching its own,
+        // separately-cast, per-feature transformer construction - masking the bug entirely.
+        tb.setSRS("EPSG:4937");
+        tb.add("geom", Point.class);
+
+        SimpleFeatureBuilder b = new SimpleFeatureBuilder(tb.buildFeatureType());
+        Point point = (Point) new WKTReader().read("POINT(10 20 123)");
+        // The per-feature CRS on the geometry's own user data - not the feature type's CRS -
+        // is what reproject() actually consults first (see its own javadoc).
+        point.setUserData(geometryCrs);
+        b.add(point);
+        SimpleFeature f = b.buildFeature("f1");
+
+        DefaultFeatureCollection features = new DefaultFeatureCollection(null, b.getFeatureType());
+        features.add(f);
+
+        ReprojectingFeatureCollection reprojected = new ReprojectingFeatureCollection(features, targetCrs);
+        try (FeatureIterator it = reprojected.features()) {
+            assertTrue(it.hasNext());
+            // Must not throw - previously failed with:
+            // java.io.IOException: Could not transform for crs: ...
+            // Caused by: java.lang.ClassCastException: class
+            // org.geotools.referencing.operation.transform.ConcatenatedTransformDirect cannot be cast to class
+            // org.geotools.api.referencing.operation.MathTransform2D
+            it.next();
         }
     }
 }


### PR DESCRIPTION
[![GEOS-12159](https://badgen.net/badge/JIRA/GEOS-12159/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12159) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

… between 3D CRSs

ReprojectingFeatureCollection.reproject() builds a per-feature coordinate transform (used when a feature's geometry carries its own CRS, distinct from the collection's cached default-source transform) and casts the result to MathTransform2D. That cast is only safe when the transform happens to be 2-dimensional; for a genuine 3D-to-3D operation between two Geographic 3D CRSs (e.g. EPSG:4979 and EPSG:4937, where latitude, longitude and ellipsoidal height are all axes of the CRS itself, not a Z ordinate riding along on the geometry), the transform is not a MathTransform2D and the cast throws.

The constructor's own default-source transform (a few lines earlier in the same class) already performs the identical lookup without this cast, since GeometryCoordinateSequenceTransformer.setMathTransform() accepts a plain MathTransform. The per-feature path narrows the type for no reason.

Added a regression test reproducing the ClassCastException against two real Geographic 3D CRSs before the fix, passing after it.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 