### PR TITLE
[GEOS-12165] GeoServer does not start when fileLockProvider is set: lock wait times out

### DIFF
--- a/src/main/src/test/java/org/geoserver/security/csp/CSPHeaderDAOTest.java
+++ b/src/main/src/test/java/org/geoserver/security/csp/CSPHeaderDAOTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.net.HttpHeaders;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -34,12 +35,15 @@ import org.geoserver.ows.ProxifyingURLMangler;
 import org.geoserver.ows.Request;
 import org.geoserver.ows.URLMangler;
 import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geoserver.platform.resource.FileLockProvider;
+import org.geoserver.platform.resource.FileSystemResourceStore;
 import org.geoserver.platform.resource.Resource;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -50,6 +54,9 @@ public class CSPHeaderDAOTest {
 
     @ClassRule
     public static TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder lockTestFolder = new TemporaryFolder();
 
     private static XStreamPersisterFactory xpf = null;
 
@@ -159,6 +166,35 @@ public class CSPHeaderDAOTest {
                 "csp_default.xml was not updated",
                 defaultLastModified,
                 defaultFile().lastmodified());
+    }
+
+    /**
+     * Updating an outdated csp.xml re-enters the resource lock: {@code configurationAction()} holds
+     * {@code resource.lock()} while {@code doSetConfig()} calls {@code resource.out()}, whose stream re-acquires the
+     * same lock key on {@code close()} to move the temp file into place. With a {@link FileLockProvider} configured,
+     * that nested acquire must not block for the full lock timeout.
+     */
+    @Test
+    public void testUpdateWithFileLockProvider() throws Exception {
+        File root = lockTestFolder.getRoot();
+        GeoServerDataDirectory lockDD = new GeoServerDataDirectory(root);
+
+        // seed an outdated csp.xml + csp_default.xml so the next construction takes the
+        // "Updating csp.xml" branch
+        new CSPHeaderDAO(null, lockDD, xpf);
+        Files.write(lockDD.getSecurity(CSPHeaderDAO.CONFIG_FILE_NAME).file().toPath(), "<config></config>".getBytes());
+        Files.write(
+                lockDD.getSecurity(CSPHeaderDAO.DEFAULT_CONFIG_FILE_NAME).file().toPath(),
+                "<config></config>".getBytes());
+
+        ((FileSystemResourceStore) lockDD.getResourceStore()).setLockProvider(new FileLockProvider(root));
+
+        long start = System.currentTimeMillis();
+        new CSPHeaderDAO(null, lockDD, xpf);
+        long duration = System.currentTimeMillis() - start;
+        assertTrue(
+                "CSPHeaderDAO init with FileLockProvider took too long (" + duration + "ms), nested lock likely hung",
+                duration < 5000);
     }
 
     @Test

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileLockProvider.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileLockProvider.java
@@ -19,6 +19,7 @@ import java.nio.channels.OverlappingFileLockException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,6 +49,7 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
 
     private static final class LockEntry {
         final ReentrantLock gate = new ReentrantLock();
+        final AtomicInteger counter = new AtomicInteger(0);
         FileOutputStream fos;
         FileLock lock;
     }
@@ -80,7 +82,11 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
         // below won't do that on its own: FileLock is documented as unsuitable for excluding
         // threads within the same JVM) and, being a ReentrantLock, also lets the thread that
         // already holds it re-enter without blocking
-        final LockEntry entry = lockEntries.computeIfAbsent(lockKey, k -> new LockEntry());
+        final LockEntry entry = lockEntries.compute(lockKey, (k, e) -> {
+            if (e == null) e = new LockEntry();
+            e.counter.incrementAndGet();
+            return e;
+        });
         final ReentrantLock gate = entry.gate;
         acquireGate(lockKey, gate);
 
@@ -170,7 +176,7 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
                 }
             }
             IOUtils.closeQuietly(currFos);
-            lockEntries.remove(lockKey, entry);
+            detach(lockKey, entry);
             gate.unlock();
             throw (e instanceof RuntimeException) ? (RuntimeException) e : new IllegalStateException(e);
         }
@@ -190,6 +196,8 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
                         releaseFileLock(lockKey, entry, file);
                     }
                 } finally {
+                    // Call detach() on every release
+                    detach(lockKey, entry);
                     gate.unlock();
                 }
             }
@@ -215,12 +223,24 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
                 // should not happen: by the time release() calls into here, entry.lock was always
                 // set by this same thread's earlier successful acquire. Logged rather than thrown
                 // since lock usage is only there to prevent duplication of work, not correctness.
-                LOGGER.warning("Lock key " + lockKey + " had no valid OS lock to release; this should not happen");
+                LOGGER.warning(("Lock %s has no valid OS lock to release, current thread is: %d. This means the "
+                                + "lock was never acquired, or was released twice. Are you running two instances "
+                                + "in the same JVM using NIO locks? This case is not supported and will generate "
+                                + "exactly this error message")
+                        .formatted(lockKey, Thread.currentThread().getId()));
             }
         } catch (IOException e) {
             throw new IllegalStateException("Failure releasing lock " + lockKey, e);
-        } finally {
-            lockEntries.remove(lockKey, entry);
+        }
+    }
+
+    /**
+     * Undoes one {@code acquire()} call. Removes {@code entry} from the map once no caller is still attached to it
+     * (mirrors {@code MemoryLockProvider.LockAndCounter}).
+     */
+    private void detach(String lockKey, LockEntry entry) {
+        if (entry.counter.decrementAndGet() == 0) {
+            lockEntries.compute(lockKey, (k, e) -> (e == null || e.counter.get() == 0) ? null : e);
         }
     }
 

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileLockProvider.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileLockProvider.java
@@ -88,7 +88,14 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
             return e;
         });
         final ReentrantLock gate = entry.gate;
-        acquireGate(lockKey, gate);
+        try {
+            acquireGate(lockKey, gate);
+        } catch (RuntimeException e) {
+            // never got the gate, so this call never touches entry.lock/entry.fos; only undo
+            // the counter increment done above, so the entry doesn't leak in the map forever
+            detach(lockKey, entry);
+            throw e;
+        }
 
         final File file = getFile(lockKey);
         if (gate.getHoldCount() > 1) {
@@ -182,7 +189,7 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
         }
     }
 
-    /** No finally block deleting the file here, it's done in the returned lock's {@code release()}. */
+    /** The file removal is done in returned lock's {@code release()}. */
     private Resource.Lock newLock(String lockKey, LockEntry entry, File file, ReentrantLock gate) {
         return new Resource.Lock() {
             boolean released;
@@ -190,6 +197,9 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
             @Override
             public void release() {
                 if (released) return;
+                if (!gate.isHeldByCurrentThread()) {
+                    throw new IllegalStateException("Lock " + lockKey + " must be released by the acquiring thread");
+                }
                 released = true;
                 try {
                     if (gate.getHoldCount() == 1) {
@@ -252,6 +262,11 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
         // to defend against asteroids levelling your data center instead of worrying about lock collisions
         String sha1 = DigestUtils.sha256Hex(lockKey);
         return new File(locks, sha1 + ".lock");
+    }
+
+    /** Number of keys currently tracked, zero when every acquisition has been released. For tests. */
+    int getTrackedKeyCount() {
+        return lockEntries.size();
     }
 
     @Override

--- a/src/platform/src/main/java/org/geoserver/platform/resource/FileLockProvider.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/FileLockProvider.java
@@ -16,6 +16,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -25,7 +29,9 @@ import org.geotools.util.logging.Logging;
 import org.springframework.web.context.ServletContextAware;
 
 /**
- * A lock provider based on file system locks
+ * A lock provider based on file system locks. Reentrant: a thread that already holds the lock for a given key can
+ * acquire it again (e.g. via a nested call), and the underlying OS lock is only released once all nested acquisitions
+ * on that thread have released.
  *
  * @author Andrea Aime - GeoSolutions
  */
@@ -38,7 +44,13 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
     /** The wait to occur in case the lock cannot be acquired */
     int waitBeforeRetry = 20;
 
-    MemoryLockProvider memoryProvider = new MemoryLockProvider();
+    private final ConcurrentMap<String, LockEntry> lockEntries = new ConcurrentHashMap<>();
+
+    private static final class LockEntry {
+        final ReentrantLock gate = new ReentrantLock();
+        FileOutputStream fos;
+        FileLock lock;
+    }
 
     public FileLockProvider() {
         // base directory obtained from servletContext
@@ -63,14 +75,49 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
     }
 
     @Override
-    @SuppressWarnings({"PMD.CloseResource"})
     public Resource.Lock acquire(final String lockKey) {
-        // first off, synchronize among threads in the same jvm (the nio locks won't lock
-        // threads in the same JVM)
-        final Resource.Lock memoryLock = memoryProvider.acquire(lockKey);
-        final File file = getFile(lockKey);
+        // gate serializes access to this key among threads in the same JVM (the nio lock
+        // below won't do that on its own: FileLock is documented as unsuitable for excluding
+        // threads within the same JVM) and, being a ReentrantLock, also lets the thread that
+        // already holds it re-enter without blocking
+        final LockEntry entry = lockEntries.computeIfAbsent(lockKey, k -> new LockEntry());
+        final ReentrantLock gate = entry.gate;
+        acquireGate(lockKey, gate);
 
-        // Track these to ensure cleanup on failure
+        final File file = getFile(lockKey);
+        if (gate.getHoldCount() > 1) {
+            // nested acquire on the same thread: the OS lock is already held
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine("Lock " + lockKey + " re-entered by thread "
+                        + Thread.currentThread().getId() + ", hold count " + gate.getHoldCount());
+            }
+        } else {
+            acquireOsLock(lockKey, entry, file, gate);
+        }
+
+        return newLock(lockKey, entry, file, gate);
+    }
+
+    /** Blocks (up to {@link #timeoutSeconds}) until {@code gate} is acquired by the current thread. */
+    private void acquireGate(String lockKey, ReentrantLock gate) {
+        try {
+            if (!gate.tryLock(timeoutSeconds, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Failed to get in-process lock on " + lockKey + " after "
+                        + (timeoutSeconds * 1000L) + "ms (another thread in this JVM is holding it)");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while trying to acquire lock for key " + lockKey, e);
+        }
+    }
+
+    /**
+     * First acquire of this key by this thread: takes the real OS lock and stores it in {@code entry}. On failure,
+     * cleans up and releases {@code gate} before rethrowing (the caller won't get a {@link Resource.Lock} to release it
+     * through).
+     */
+    @SuppressWarnings({"PMD.CloseResource"})
+    private void acquireOsLock(String lockKey, LockEntry entry, File file, ReentrantLock gate) {
         FileOutputStream currFos = null;
         FileLock currLock = null;
 
@@ -112,50 +159,8 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
                         + file);
             }
 
-            final FileOutputStream finalFos = currFos;
-            final FileLock finalLock = currLock;
-
-            return new Resource.Lock() {
-                boolean released;
-
-                @Override
-                public void release() {
-                    if (released) return;
-                    try {
-                        released = true;
-                        if (finalLock.isValid()) {
-                            finalLock.release();
-                            IOUtils.closeQuietly(finalFos);
-                            file.delete(); // Proper place for deletion
-
-                            if (LOGGER.isLoggable(Level.FINE)) {
-                                LOGGER.fine("Lock "
-                                        + lockKey
-                                        + " mapped onto "
-                                        + file
-                                        + " released by thread "
-                                        + Thread.currentThread().getId());
-                            }
-                        } else {
-                            // do not crap out, locks usage is only there to prevent duplication
-                            // of work
-                            if (LOGGER.isLoggable(Level.FINE)) {
-                                LOGGER.fine(("Lock key %s for releasing lock is unknown, it means this lock was never"
-                                                + " acquired, or was released twice. Current thread is: %d. Are you"
-                                                + " running two instances in the same JVM using NIO locks? This case is"
-                                                + " not supported and will generate exactly this error message")
-                                        .formatted(
-                                                lockKey, Thread.currentThread().getId()));
-                            }
-                        }
-
-                    } catch (IOException e) {
-                        throw new IllegalStateException("Failure releasing lock " + lockKey, e);
-                    } finally {
-                        memoryLock.release();
-                    }
-                }
-            };
+            entry.fos = currFos;
+            entry.lock = currLock;
         } catch (Exception e) {
             // If we get here, acquisition failed or timed out
             if (currLock != null) {
@@ -165,10 +170,58 @@ public class FileLockProvider implements LockProvider, ServletContextAware {
                 }
             }
             IOUtils.closeQuietly(currFos);
-            memoryLock.release(); // Must release memory lock on failure
+            lockEntries.remove(lockKey, entry);
+            gate.unlock();
             throw (e instanceof RuntimeException) ? (RuntimeException) e : new IllegalStateException(e);
         }
-        // Note: No finally block deleting the file here, it's done in the returned lock
+    }
+
+    /** No finally block deleting the file here, it's done in the returned lock's {@code release()}. */
+    private Resource.Lock newLock(String lockKey, LockEntry entry, File file, ReentrantLock gate) {
+        return new Resource.Lock() {
+            boolean released;
+
+            @Override
+            public void release() {
+                if (released) return;
+                released = true;
+                try {
+                    if (gate.getHoldCount() == 1) {
+                        releaseFileLock(lockKey, entry, file);
+                    }
+                } finally {
+                    gate.unlock();
+                }
+            }
+        };
+    }
+
+    /**
+     * Drops the OS-level lock, closes the channel and deletes the lock file. Only called on the last nested release,
+     * i.e. once {@code entry.gate.getHoldCount()} is about to drop to 0.
+     */
+    private void releaseFileLock(String lockKey, LockEntry entry, File file) {
+        try {
+            if (entry.lock != null && entry.lock.isValid()) {
+                entry.lock.release();
+                IOUtils.closeQuietly(entry.fos);
+                file.delete(); // Proper place for deletion
+
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine("Lock " + lockKey + " mapped onto " + file + " released by thread "
+                            + Thread.currentThread().getId());
+                }
+            } else {
+                // should not happen: by the time release() calls into here, entry.lock was always
+                // set by this same thread's earlier successful acquire. Logged rather than thrown
+                // since lock usage is only there to prevent duplication of work, not correctness.
+                LOGGER.warning("Lock key " + lockKey + " had no valid OS lock to release; this should not happen");
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failure releasing lock " + lockKey, e);
+        } finally {
+            lockEntries.remove(lockKey, entry);
+        }
     }
 
     private File getFile(String lockKey) {

--- a/src/platform/src/main/java/org/geoserver/platform/resource/MemoryLockProvider.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/MemoryLockProvider.java
@@ -48,7 +48,13 @@ public class MemoryLockProvider implements LockProvider {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            // never got the lock, so undo the counter increment done above, or this key leaks
+            detach(lockKey, lockAndCounter);
             throw new RuntimeException("Interrupted while trying to acquire lock for key " + lockKey, e);
+        } catch (RuntimeException e) {
+            // same as above: the timeout case just thrown, never got the lock
+            detach(lockKey, lockAndCounter);
+            throw e;
         }
 
         if (LOGGER.isLoggable(Level.FINE)) LOGGER.fine("Acquired lock key " + lockKey);
@@ -61,27 +67,30 @@ public class MemoryLockProvider implements LockProvider {
             public void release() {
                 if (!released) {
                     released = true;
-
-                    LockAndCounter lockAndCounter = lockAndCounters.get(lockKey);
                     lockAndCounter.lock.unlock();
-
-                    // Attempt to remove lock if no other thread is waiting for it
-                    if (lockAndCounter.counter.decrementAndGet() == 0) {
-
-                        // Try to remove the lock, but we have to check the count AGAIN inside of "compute" so that we
-                        // know it hasn't been incremented since the if-statement above was evaluated
-                        lockAndCounters.compute(lockKey, (key, existingLockAndCounter) -> {
-                            if (existingLockAndCounter == null || existingLockAndCounter.counter.get() == 0) {
-                                return null;
-                            }
-                            return existingLockAndCounter;
-                        });
-                    }
-
+                    detach(lockKey, lockAndCounter);
                     if (LOGGER.isLoggable(Level.FINE)) LOGGER.fine("Released lock key " + lockKey);
                 }
             }
         };
+    }
+
+    /**
+     * Undoes one {@code acquire()} call. Removes {@code lockAndCounter} from the map once no caller is still attached
+     * to it.
+     */
+    private void detach(String lockKey, LockAndCounter lockAndCounter) {
+        // Attempt to remove the lock if no other thread is waiting for it
+        if (lockAndCounter.counter.decrementAndGet() == 0) {
+            // Check the count again inside "compute" so we know it hasn't been incremented since the
+            // if-statement above was evaluated
+            lockAndCounters.compute(lockKey, (key, existingLockAndCounter) -> {
+                if (existingLockAndCounter == null || existingLockAndCounter.counter.get() == 0) {
+                    return null;
+                }
+                return existingLockAndCounter;
+            });
+        }
     }
 
     @Override

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileLockProviderTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileLockProviderTest.java
@@ -8,6 +8,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -232,6 +233,43 @@ public class FileLockProviderTest {
         }
 
         assertEquals("hello", IOUtils.toString(resource.in(), StandardCharsets.UTF_8));
+    }
+
+    /**
+     * A thread wait for the lock, then get it right after the other thread releases it. This thread must then be able
+     * to acquire the same lock again, like any other thread that holds the lock.
+     */
+    @Test
+    public void testNestedAcquireAfterWait() throws Exception {
+        String key = "waiting-thread-key";
+        Resource.Lock outer = provider.acquire(key);
+
+        CountDownLatch waiterStarted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Throwable> future = executor.submit(() -> {
+                waiterStarted.countDown();
+                Resource.Lock locked = provider.acquire(key); // blocks until outer releases
+                try {
+                    Resource.Lock nested = provider.acquire(key); // must not hang or throw
+                    nested.release();
+                    return null;
+                } catch (Throwable t) {
+                    return t;
+                } finally {
+                    locked.release();
+                }
+            });
+
+            assertTrue("Waiter thread failed to start", waiterStarted.await(2, SECONDS));
+            Thread.sleep(300); // make sure the waiter is parked on the gate before releasing
+            outer.release();
+
+            Throwable failure = future.get(5, SECONDS);
+            assertNull("Nested acquire after handoff must not fail: " + failure, failure);
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     private File getLockFile(String key) {

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileLockProviderTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileLockProviderTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
@@ -20,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.apache.commons.io.IOUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,12 +37,22 @@ public class FileLockProviderTest {
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
     private FileLockProvider provider;
+    // Long timeout, used where a test must interrupt a thread while it's still blocked
+    // acquiring the gate, without racing the short TEST_TIMEOUT_SECONDS timeout of "provider"
+    private FileLockProvider patientProvider;
     private File root;
 
     @Before
     public void setUp() throws Exception {
         root = tempFolder.newFolder("lockRoot");
         provider = new FileLockProvider(root, TEST_TIMEOUT_SECONDS);
+        patientProvider = new FileLockProvider(root, 60);
+    }
+
+    @After
+    public void assertNoLeakedEntries() {
+        assertEquals("Leaked lock entries", 0, provider.getTrackedKeyCount());
+        assertEquals("Leaked lock entries", 0, patientProvider.getTrackedKeyCount());
     }
 
     @Test
@@ -57,6 +69,19 @@ public class FileLockProviderTest {
         await().atMost(2, SECONDS).until(() -> !lockFile.exists());
     }
 
+    /** Calling {@code release()} a second time on an already-released lock must be a no-op. */
+    @Test
+    public void testReleaseIsIdempotent() throws Exception {
+        String key = "double-release-key";
+        Resource.Lock lock = provider.acquire(key);
+
+        File lockFile = getLockFile(key);
+        lock.release();
+        lock.release(); // must not throw, double-unlock the gate, or double-detach the entry
+
+        await().atMost(2, SECONDS).until(() -> !lockFile.exists());
+    }
+
     @Test
     public void testLockTimeoutThrowsException() throws Exception {
         String key = "timeout-key";
@@ -69,7 +94,7 @@ public class FileLockProviderTest {
             CountDownLatch threadAHold = new CountDownLatch(1);
             CountDownLatch releaseThreadA = new CountDownLatch(1);
 
-            executor.submit(() -> {
+            Future<?> threadA = executor.submit(() -> {
                 Resource.Lock lock = provider.acquire(key);
                 threadAHold.countDown();
                 try {
@@ -95,6 +120,7 @@ public class FileLockProviderTest {
             } finally {
                 releaseThreadA.countDown();
             }
+            threadA.get(2, SECONDS); // wait for thread A's lock.release() to actually complete
         } finally {
             executor.shutdownNow();
         }
@@ -232,7 +258,9 @@ public class FileLockProviderTest {
             lock.release();
         }
 
-        assertEquals("hello", IOUtils.toString(resource.in(), StandardCharsets.UTF_8));
+        try (InputStream in = resource.in()) {
+            assertEquals("hello", IOUtils.toString(in, StandardCharsets.UTF_8));
+        }
     }
 
     /**
@@ -242,16 +270,19 @@ public class FileLockProviderTest {
     @Test
     public void testNestedAcquireAfterWait() throws Exception {
         String key = "waiting-thread-key";
-        Resource.Lock outer = provider.acquire(key);
+        // Use patientProvider: this test waits on real thread scheduling (not on the gate
+        // timing out), and a busy CI runner could delay the release past a short timeout,
+        // failing the test for a reason unrelated to what it actually checks
+        Resource.Lock outer = patientProvider.acquire(key);
 
         CountDownLatch waiterStarted = new CountDownLatch(1);
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
             Future<Throwable> future = executor.submit(() -> {
                 waiterStarted.countDown();
-                Resource.Lock locked = provider.acquire(key); // blocks until outer releases
+                Resource.Lock locked = patientProvider.acquire(key); // blocks until outer releases
                 try {
-                    Resource.Lock nested = provider.acquire(key); // must not hang or throw
+                    Resource.Lock nested = patientProvider.acquire(key); // must not hang or throw
                     nested.release();
                     return null;
                 } catch (Throwable t) {
@@ -270,6 +301,80 @@ public class FileLockProviderTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    /**
+     * An {@code acquire()} call that times out waiting for the gate must not leak its {@link FileLockProvider} entry.
+     */
+    @Test
+    public void testNoEntryLeakOnAcquireTimeout() throws Exception {
+        String key = "timeout-leak-key";
+        Resource.Lock held = provider.acquire(key);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Boolean> timedOut = executor.submit(() -> {
+                try {
+                    provider.acquire(key).release();
+                    return false;
+                } catch (IllegalStateException e) {
+                    return true;
+                }
+            });
+            assertTrue("Acquire should have timed out", timedOut.get(5, SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        held.release();
+    }
+
+    /**
+     * An {@code acquire()} call interrupted while waiting for the gate must not leak its {@link FileLockProvider}
+     * entry.
+     */
+    @Test
+    public void testNoEntryLeakOnInterruptedAcquire() throws Exception {
+        String key = "interrupt-leak-key";
+        Resource.Lock held = patientProvider.acquire(key);
+
+        Thread waiter = new Thread(() -> {
+            try {
+                patientProvider.acquire(key).release();
+            } catch (IllegalStateException expected) {
+                // interrupted while waiting on the gate
+            }
+        });
+        waiter.start();
+        waiter.interrupt();
+        waiter.join(5000);
+        assertFalse("Waiter did not terminate", waiter.isAlive());
+
+        held.release();
+    }
+
+    /** {@code release()} must only be called by the thread that acquired the lock. */
+    @Test
+    public void testReleaseFromDifferentThreadThrows() throws Exception {
+        String key = "wrong-thread-key";
+        Resource.Lock lock = provider.acquire(key);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Boolean> releasedByOtherThread = executor.submit(() -> {
+                try {
+                    lock.release();
+                    return false;
+                } catch (IllegalStateException e) {
+                    return true;
+                }
+            });
+            assertTrue("Release from another thread must throw", releasedByOtherThread.get(2, SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        lock.release(); // release from the acquiring thread, so nothing leaks
     }
 
     private File getLockFile(String key) {

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileLockProviderTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileLockProviderTest.java
@@ -6,23 +6,25 @@ package org.geoserver.platform.resource;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-/**
- * The file lock provider is actually not reentrant (not possible with Java) but the keys for meta-tile caching are
- * different, so we don't really need it to handle nested locks on the same key.
- */
+/** Tests for {@link FileLockProvider}, including reentrant (nested) locking on the same thread. */
 public class FileLockProviderTest {
 
     /** Small timeout for testing failure cases quickly */
@@ -57,8 +59,8 @@ public class FileLockProviderTest {
     @Test
     public void testLockTimeoutThrowsException() throws Exception {
         String key = "timeout-key";
-        // Create a second provider instance pointing to the same root
-        // This ensures they don't share the same MemoryLockProvider
+        // A second provider instance has its own gate, so contention between the two can only
+        // be enforced by the real OS-level file lock, as would happen across two processes
         FileLockProvider provider2 = new FileLockProvider(root, TEST_TIMEOUT_SECONDS);
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -121,6 +123,115 @@ public class FileLockProviderTest {
         assertFalse("Thread should have terminated after interruption", testThread.isAlive());
 
         firstLock.release();
+    }
+
+    /**
+     * A thread that already holds the lock for a key must be able to acquire it again without blocking or throwing, and
+     * the lock file must still be cleaned up once both acquisitions are released.
+     */
+    @Test
+    public void testReentrantAcquire() throws Exception {
+        String key = "nested-key";
+
+        Resource.Lock outer = provider.acquire(key);
+        try {
+            // must return immediately, not throw OverlappingFileLockException nor wait
+            // for the timeout, since the same thread already holds the lock
+            Resource.Lock inner = provider.acquire(key);
+            inner.release();
+        } finally {
+            outer.release();
+        }
+
+        File lockFile = getLockFile(key);
+        await().atMost(2, SECONDS).until(() -> !lockFile.exists());
+    }
+
+    /**
+     * When a lock is acquired twice on the same thread, releasing only the inner (nested) acquisition must not drop the
+     * underlying OS lock; the lock file is only removed once every acquisition on that key has been released.
+     */
+    @Test
+    public void testReentrantAcquireHoldCount() throws Exception {
+        String key = "nested-balanced-key";
+
+        Resource.Lock outer = provider.acquire(key);
+        Resource.Lock inner = provider.acquire(key);
+
+        File lockFile = getLockFile(key);
+        assertTrue("Lock file should still exist while outer hold is active", lockFile.exists());
+
+        inner.release();
+        assertTrue("Releasing only the nested acquire must not drop the OS lock", lockFile.exists());
+
+        outer.release();
+        await().atMost(2, SECONDS).until(() -> !lockFile.exists());
+    }
+
+    /** Locks on different keys must not interfere with each other. */
+    @Test
+    public void testIndependentKeys() throws Exception {
+        Resource.Lock lockA = provider.acquire("key-a");
+        Resource.Lock lockB = provider.acquire("key-b");
+
+        assertTrue(getLockFile("key-a").exists());
+        assertTrue(getLockFile("key-b").exists());
+
+        lockA.release();
+        lockB.release();
+    }
+
+    /**
+     * Reentrancy must only apply within a single thread: a different thread trying to acquire an already-held key must
+     * still block on the gate and eventually time out, exactly as before this change.
+     */
+    @Test
+    public void testConcurrentAcquireOnSameKeyBlocks() throws Exception {
+        String key = "contention-key";
+        Resource.Lock firstLock = provider.acquire(key);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            long start = System.currentTimeMillis();
+            Future<Boolean> future = executor.submit(() -> {
+                try {
+                    provider.acquire(key);
+                    return false; // should not have succeeded while firstLock is held
+                } catch (IllegalStateException e) {
+                    return true; // expected: timed out waiting for the other thread
+                }
+            });
+
+            assertTrue("A different thread must not be granted the same key while it is held", future.get(5, SECONDS));
+            long duration = System.currentTimeMillis() - start;
+            assertTrue("Timeout was too fast: " + duration, duration >= 1000);
+        } finally {
+            firstLock.release();
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * A resource can be locked and, while the lock is held, written to and closed on the same thread: closing the
+     * output stream re-acquires the same lock key internally (to atomically move the temp file into place), which is
+     * exactly the nested-acquire scenario this class must support.
+     */
+    @Test
+    public void testWriteWhileLockHeld() throws Exception {
+        FileSystemResourceStore store = new FileSystemResourceStore(root);
+        store.setLockProvider(provider);
+        Resource resource = store.get("nested/resource.txt");
+
+        Resource.Lock lock = resource.lock();
+        try {
+            try (OutputStream out = resource.out()) {
+                out.write("hello".getBytes(StandardCharsets.UTF_8));
+            }
+        } finally {
+            lock.release();
+        }
+
+        assertEquals("hello", IOUtils.toString(resource.in(), StandardCharsets.UTF_8));
     }
 
     private File getLockFile(String key) {

--- a/src/platform/src/test/java/org/geoserver/platform/resource/MemoryLockProviderTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/MemoryLockProviderTest.java
@@ -256,6 +256,10 @@ public class MemoryLockProviderTest {
 
             allowHolderToRelease.countDown();
             awaitFuture(holder);
+
+            // the failed acquire() above must not have left its own counter increment stuck: once the
+            // real holder also releases, the entry must be fully cleaned up
+            awaitForLockCleanup(provider, "k");
         } finally {
             shutdownNow(exec);
         }


### PR DESCRIPTION
[![GEOS-12165](https://badgen.net/badge/JIRA/GEOS-12165/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12165) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

https://osgeo-org.atlassian.net/browse/GEOS-12165

This PR refactors the FileLockProvider class to allow same thread re-entrant lock acquisition.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 