### PR TITLE
Remind AI tools of disclosure policy direct in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,3 +63,5 @@ Disclosure policy:
 This represents a balance between transparency and participation that does not overwhelm participants. 
 Those seeking greater visibility are encouraged to volunteer with the geoserver-security list;
 or work with one of the [commercial support providers](https://geoserver.org/support/) who participate on behalf of their customers.
+
+We advise security researchers and national agencies that linking to or attempting to enforce their own disclosure policies or timelines is unwelcome and inappropriate conduct. The recommended course of action is to work with your clients on providing or resourcing a fix.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ If you encounter a security vulnerability in GeoServer please take care to repor
    Be advised that GeoServer is a community project with a clear coordinated vulnerability disclosure
    policy allowing the members of our community to update prior to public disclosure.
 
-   Reports assuming a vendor relationship, or linking to their own disclosure policy, are not appropriate.
+   Reports linking to their own disclosure policy are not appropriate.
 
 3. There are two options to report a security vulnerability:
 
@@ -64,4 +64,4 @@ This represents a balance between transparency and participation that does not o
 Those seeking greater visibility are encouraged to volunteer with the geoserver-security list;
 or work with one of the [commercial support providers](https://geoserver.org/support/) who participate on behalf of their customers.
 
-We advise security researchers and national agencies that linking to or attempting to enforce their own disclosure policies or timelines is unwelcome and inappropriate conduct. The recommended course of action is to work with your clients on providing or resourcing a fix.
+We advise security researchers and national agencies that linking to or attempting to enforce their own disclosure policies or timelines is unwelcome and inappropriate conduct. The recommended course of action is to direct your clients to collaborating on, providing, or resource a fix.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,11 @@ If you encounter a security vulnerability in GeoServer please take care to repor
 
 2. AI assistance to locate issues is allowed. Please read the [AI policy](https://geoserver.org/ai/) and make sure to follow it.
 
+   Be advised that GeoServer is a community project with a clear coordinated vulnerability disclosure
+   policy allowing the members of our community to update prior to public disclosure.
+
+   Reports assuming a vendor relationship, or linking to their own disclosure policy, is not appropriate.
+
 3. There are two options to report a security vulnerability:
 
    * To report via email:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,4 +64,5 @@ This represents a balance between transparency and participation that does not o
 Those seeking greater visibility are encouraged to volunteer with the geoserver-security list;
 or work with one of the [commercial support providers](https://geoserver.org/support/) who participate on behalf of their customers.
 
-We advise security researchers and national agencies that linking to or attempting to enforce their own disclosure policies or timelines is unwelcome and inappropriate conduct. The recommended course of action is to direct your clients to collaborating on, providing, or resource a fix.
+We advise security researchers and national agencies that linking to or attempting to enforce their own disclosure policies or timelines is unwelcome and inappropriate conduct.
+The recommended course of action is to direct your clients to collaborate on, provide, or resource a fix.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ If you encounter a security vulnerability in GeoServer please take care to repor
    Be advised that GeoServer is a community project with a clear coordinated vulnerability disclosure
    policy allowing the members of our community to update prior to public disclosure.
 
-   Reports assuming a vendor relationship, or linking to their own disclosure policy, is not appropriate.
+   Reports assuming a vendor relationship, or linking to their own disclosure policy, are not appropriate.
 
 3. There are two options to report a security vulnerability:
 


### PR DESCRIPTION
A large number of reports assume a vendor relationship, or link to a vendor security disclosure policy.

This clarification of SECURITY.md is to specifically remind users of AI tools that such an expectation is not appropriate.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.