### PR TITLE
dependabot: Some dependencies require Java 21 so these must be skipped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,9 @@ updates:
       # JUnit 6 dropped junit-vintage-engine; all GeoServer tests are JUnit 4.
       - dependency-name: "org.junit:junit-bom"
         versions: [ "[6.0.0,)" ]
+      # dependency requires Java 21
+      - dependency-name: "org.apereo.cas.client:cas-client-core"
+        versions: [ "[4.1.0,)" ]
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,9 @@ updates:
       # JUnit 6 dropped junit-vintage-engine; all GeoServer tests are JUnit 4.
       - dependency-name: "org.junit:junit-bom"
         versions: [ "[6.0.0,)" ]
-      # dependency requires Java 21
+      # require Java 21 
+      - dependency-name: "com.github.librepdf:openpdf"
+        versions: [ "[2.1.0,)" ]
       - dependency-name: "org.apereo.cas.client:cas-client-core"
         versions: [ "[4.1.0,)" ]
 


### PR DESCRIPTION
- https://github.com/geoserver/geoserver/pull/9797 failed with `class file has wrong version 65.0, should be 61.0`
- https://github.com/geoserver/geoserver/pull/9631 initially failed with `class file has wrong version 65.0, should be 61.0`

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.