### PR TITLE
[CI] Update stCarolas/setup-maven action to v5.1

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'        # only build the oldest Java version, but below run against the matrix of LTS versions
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.16
       - name: Maven repository caching

--- a/.github/workflows/assembly.yml
+++ b/.github/workflows/assembly.yml
@@ -32,7 +32,7 @@ jobs:
         java-version: ${{ matrix.jdk }}
         distribution: ${{ matrix.dist }}
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.16
     - name: Maven repository caching

--- a/.github/workflows/cite.yml
+++ b/.github/workflows/cite.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'        # only build the oldest Java version, but below run against the matrix of LTS versions
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.16
       - name: Maven repository caching

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -34,7 +34,7 @@ jobs:
         java-version: ${{ matrix.jdk }}
         distribution: ${{ matrix.dist }}
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.16
     - name: Maven repository caching

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
         java-version: ${{ matrix.jdk }}
         distribution: ${{ matrix.dist }}
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.16
     - name: Maven repository caching

--- a/.github/workflows/linux_locales.yml
+++ b/.github/workflows/linux_locales.yml
@@ -40,7 +40,7 @@ jobs:
         java-version: ${{ matrix.jdk }}
         distribution: ${{ matrix.dist }}
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.16
     - name: Maven repository caching

--- a/.github/workflows/linux_timezone.yml
+++ b/.github/workflows/linux_timezone.yml
@@ -39,7 +39,7 @@ jobs:
         java-version: ${{ matrix.jdk }}
         distribution: ${{ matrix.dist }}
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.16
     - name: Maven repository caching

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
         java-version: 17
         distribution: 'temurin'
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.16
     - name: Maven repository caching

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -26,7 +26,7 @@ jobs:
         java-version: 17
         distribution: 'temurin'
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.16
     - name: Maven repository caching

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,7 @@ jobs:
         java-version: 17
         distribution: 'temurin'
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.16
     - name: Maven repository caching


### PR DESCRIPTION
This will fix the following warning on all builds:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: stCarolas/setup-maven@v5.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.