### PR TITLE
[2.28.x] Pin monitor-kafka avro-maven-plugin to 1.11.4 for build stability

### DIFF
--- a/src/community/monitor-kafka/pom.xml
+++ b/src/community/monitor-kafka/pom.xml
@@ -79,6 +79,7 @@
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
+        <version>1.11.4</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>


### PR DESCRIPTION
I am having some build stability problems due to `monitor-kafka` not providing a version number for `avro-maven-plugin` - as it results it pulls in the "latest" causing compile problem due to transitive dependencies changing (sigh).

The result is the code generator making something that cannot be compiled because we cannot have nice things:
```
cannot find symbol: class JsonSchemaParser, location: package org.apache.avro
```

This is not an issue on `main` branch which which uses a newer version.
So the problem is specific to 2.28.x and 2.27.x.

This is a non-functional change so I have not provided a JIRA ticket.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.