### PR TITLE
Fix Elasticsearch community plugin fails to load on GeoServer 3.0.x

### DIFF
--- a/src/community/elasticsearch/src/assembly/assembly.xml
+++ b/src/community/elasticsearch/src/assembly/assembly.xml
@@ -22,7 +22,7 @@
         <include>grumpy-core*</include>
         <include>gs-web-elasticsearch*</include>
         <include>gt-elasticsearch*</include>
-        <include>httpcore-nio*</include>
+        <include>httpclient-4*</include>
         <include>httpasyncclient*</include>
         <include>httpcore-nio*</include>
         <include>jackson-databind*</include>


### PR DESCRIPTION
[GeoServer User Forum Topic ](https://discourse.osgeo.org/t/elasticsearch-community-plugin-fails-to-load-on-geoserver-3-0-x-due-to-missing-httpclient-4-library/154946)

The Elasticsearch community plugin fails to load with GeoServer >= 3.x due to missing HttpClient 4 library, which is required by the GeoTools `ElasticDataStoreFactory`.

The reason seems to be a duplicate include-line in the [Elasticsearch plugin assembly descriptor](https://github.com/geoserver/geoserver/blob/3.0.1/src/community/elasticsearch/src/assembly/assembly.xml#L25-L27)

In GeoServer versions before 3.0.x, httpclient-4.5.14.jar was already included in the main GeoServer distribution. Its absence from the Elasticsearch plugin package therefore did not cause a problem.

GeoServer 3.0.x now uses Apache HttpClient 5. The legacy `httpclient-4.5.14.jar` is consequently no longer present in WEB-INF/lib. However, the GeoTools Elasticsearch data store still uses HttpClient 4 classes under the org.apache.http.* packages. HttpClient 5 cannot provide these classes because it uses the org.apache.hc.* packages.

**Changes**

- add `httpclient-4*` to assembly includes
- remove duplicate `httpcore-nio*` include

**Tested:** Verified that `httpclient-4.5.14.jar` is included in the result `geoserver-3.1.0-SNAPSHOT-elasticsearch-plugin.zip` after the assembly of the module

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [x] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).