### PR TITLE
[Backport 3.0.x]  chore(deps): bump org.springframework:spring-framework-bom in /src

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -96,7 +96,7 @@
     <!-- ================================ -->
     <gt.version>35-SNAPSHOT</gt.version>
     <gwc.version>2.0-SNAPSHOT</gwc.version>
-    <spring.version>7.0.8</spring.version>
+    <spring.version>7.0.9</spring.version>
     <spring.security.version>7.1.0</spring.security.version>
     <spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
     <spring.ldap.version>4.1.0</spring.ldap.version>


### PR DESCRIPTION
Backport #9846


Bumps [org.springframework:spring-framework-bom](https://github.com/spring-projects/spring-framework) in `/src` from 7.0.8 to 7.0.9.