### PR TITLE
[GEOS-12181] Update gs-web-app to jetty.ee11 for testing environment

### DIFF
--- a/src/community/ogcapi/ogcapi-processes/pom.xml
+++ b/src/community/ogcapi/ogcapi-processes/pom.xml
@@ -69,6 +69,7 @@
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.angus</groupId>

--- a/src/extension/wcs/wcs1_0/pom.xml
+++ b/src/extension/wcs/wcs1_0/pom.xml
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/src/extension/wcs/wcs1_1/pom.xml
+++ b/src/extension/wcs/wcs1_1/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
-
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1410,9 +1410,9 @@
           <version>0.8.14</version>
         </plugin>
         <plugin>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-maven-plugin</artifactId>
-          <version>11.0.26</version>
+          <groupId>org.eclipse.jetty.ee11</groupId>
+          <artifactId>jetty-ee11-maven-plugin</artifactId>
+          <version>${jetty.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -340,7 +340,7 @@
         <configuration>
           <warName>geoserver</warName>
           <webappDirectory>${project.build.directory}/geoserver</webappDirectory>
-          <packagingExcludes>WEB-INF/lib/javax.servlet-api*.jar,WEB-INF/lib/javax.activation-api*.jar</packagingExcludes>
+          <packagingExcludes>WEB-INF/lib/jarkarta.servlet-api*.jar,WEB-INF/lib/jarkarta.activation-api*.jar</packagingExcludes>
           <archive>
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -21,6 +21,7 @@
     <configDirectory>${basedir}/../../../data</configDirectory>
     <webappSourceDirectory>${basedir}/src/main/webapp</webappSourceDirectory>
     <jetty.port>8080</jetty.port>
+    <jetty.stopPort>9966</jetty.stopPort>
     <jetty.run.daemon>false</jetty.run.daemon>
   </properties>
   <dependencies>
@@ -340,7 +341,7 @@
         <configuration>
           <warName>geoserver</warName>
           <webappDirectory>${project.build.directory}/geoserver</webappDirectory>
-          <packagingExcludes>WEB-INF/lib/jarkarta.servlet-api*.jar,WEB-INF/lib/jarkarta.activation-api*.jar</packagingExcludes>
+          <packagingExcludes>WEB-INF/lib/jakarta.servlet-api*.jar</packagingExcludes>
           <archive>
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -234,14 +234,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-webapp</artifactId>
+      <groupId>org.eclipse.jetty.ee11</groupId>
+      <artifactId>jetty-ee11-webapp</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee11</groupId>
+      <artifactId>jetty-ee11-servlet</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
@@ -298,8 +298,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty.ee11</groupId>
+        <artifactId>jetty-ee11-maven-plugin</artifactId>
         <configuration>
           <webApp>
             <contextPath>/geoserver</contextPath>

--- a/src/web/app/src/test/java/org/geoserver/web/Start.java
+++ b/src/web/app/src/test/java/org/geoserver/web/Start.java
@@ -30,7 +30,7 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.ee11.webapp.WebAppContext;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.plus.jndi.Resource;
 import org.eclipse.jetty.server.Connector;

--- a/src/web/app/src/test/java/org/geoserver/web/WebXmlTest.java
+++ b/src/web/app/src/test/java/org/geoserver/web/WebXmlTest.java
@@ -14,7 +14,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
-import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.ee11.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.geotools.xml.XMLUtils;
 import org.junit.Test;

--- a/src/web/app/src/test/resources/jetty-context.xml
+++ b/src/web/app/src/test/resources/jetty-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure.dtd">
-<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+<Configure class="org.eclipse.jetty.ee11.webapp.WebAppContext">
  <Call name="setAttribute">
   <Arg>org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern</Arg>
   <Arg>^$</Arg>


### PR DESCRIPTION
[![GEOS-12181](https://badgen.net/badge/JIRA/GEOS-12181/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12181) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->

This address conflicts between jetty environment and `gs-web-app` transitive dependence on jakarata-servlet and jakarta-activation.

* [x] Correct the packagingExcludes in gs-web-app (was using `javax-`)
* [x] Double check `jakarta` are marked as provided to avoid conflict with application server such as jetty
* [x] Sync jetty-maven-plugin with `${jetty.version}` (`12.1.12` at time of writing)

These are build / packaging issues and not a functional change.

Functional change is here: https://github.com/geoserver/geoserver/pull/9882

Reference:

* https://jetty.org/docs/jetty/12.1/programming-guide/maven-jetty/jetty-maven-plugin.html

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 