### PR TITLE
[GEOS-12183] CSS can trigger a bean loading circularity during startup

### DIFF
--- a/src/extension/css/src/main/java/org/geoserver/community/css/web/CssHandler.java
+++ b/src/extension/css/src/main/java/org/geoserver/community/css/web/CssHandler.java
@@ -69,14 +69,14 @@ public class CssHandler extends StyleHandler implements ModuleStatus {
         }
     }
 
-    private final List<ZoomContextFinder> zoomContextFinders;
+    private final GeoServerExtensions extensions;
 
     private SLDHandler sldHandler;
 
     public CssHandler(GeoServerExtensions extensions, SLDHandler sldHandler) {
         super("CSS", FORMAT);
         this.sldHandler = sldHandler;
-        this.zoomContextFinders = extensions.extensions(ZoomContextFinder.class);
+        this.extensions = extensions;
     }
 
     @Override
@@ -138,7 +138,9 @@ public class CssHandler extends StyleHandler implements ModuleStatus {
     private StyledLayerDescriptor convertToSLD(Reader cssReader) throws IOException {
         Stylesheet styleSheet = CssParser.parse(IOUtils.toString(cssReader));
         CssTranslator translator = new CssTranslator();
-        translator.setZoomContextFinders(zoomContextFinders);
+        // Do not look this up in the constructor: it builds the GWC gridset beans, and through them
+        // the catalog, while this bean is still being created, and Spring fails on the circular reference.
+        translator.setZoomContextFinders(extensions.extensions(ZoomContextFinder.class));
         StyledLayerDescriptor sld = translator.translateMultilayer(styleSheet);
         return sld;
     }

--- a/src/extension/css/src/test/java/org/geoserver/community/css/web/CssHandlerZoomFinderTest.java
+++ b/src/extension/css/src/test/java/org/geoserver/community/css/web/CssHandlerZoomFinderTest.java
@@ -1,0 +1,71 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.community.css.web;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import org.geoserver.catalog.SLDHandler;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.platform.GeoServerExtensionsHelper;
+import org.geotools.api.style.NamedLayer;
+import org.geotools.api.style.StyledLayerDescriptor;
+import org.geotools.styling.zoom.ListZoomContext;
+import org.geotools.styling.zoom.ZoomContext;
+import org.geotools.styling.zoom.ZoomContextFinder;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Checks that the CSS handler picks up zoom context finders registered after it was built. Looking them up in the
+ * constructor makes GeoServer fail with a circular bean reference at startup.
+ */
+public class CssHandlerZoomFinderTest {
+
+    /** Scale denominators of the test tile matrix set, far from any real gridset. */
+    private static final List<Double> SCALES = List.of(1000d, 500d, 250d);
+
+    @Rule
+    public GeoServerExtensionsHelper.ExtensionsHelperRule extensions =
+            new GeoServerExtensionsHelper.ExtensionsHelperRule();
+
+    @Test
+    public void testZoomFinderRegisteredAfterConstruction() throws Exception {
+        CssHandler handler = new CssHandler(new GeoServerExtensions(), new SLDHandler());
+
+        extensions.singleton("testZoomContextFinder", new TestZoomContextFinder(), ZoomContextFinder.class);
+
+        StyledLayerDescriptor sld = handler.convertToSLD("@tileMatrixSet 'testGrid'; [@z = 1] {stroke: black}");
+        org.geotools.api.style.Rule rule = ((NamedLayer) sld.getStyledLayers()[0])
+                .getStyles()[0]
+                .featureTypeStyles()
+                .get(0)
+                .rules()
+                .get(0);
+        assertEquals(353.5, rule.getMinScaleDenominator(), 0.1);
+        assertEquals(707.1, rule.getMaxScaleDenominator(), 0.1);
+    }
+
+    private static class TestZoomContextFinder implements ZoomContextFinder {
+
+        private final ZoomContext context = new ListZoomContext(SCALES);
+
+        @Override
+        public ZoomContext get(String name) {
+            return "testGrid".equals(name) ? context : null;
+        }
+
+        @Override
+        public Set<String> getNames() {
+            return Set.of("testGrid");
+        }
+
+        @Override
+        public Set<String> getCanonicalNames() {
+            return getNames();
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-12183](https://badgen.net/badge/JIRA/GEOS-12183/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12183) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

A stack trace, innocuous but long and annoying, can be triggered during startup while the CSS handler is loaded in parallel with the catalog loading. This change eliminates it.
Update: in some cases that will lead to a startup deadlock too.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 