### PR TITLE
[GEOS-12184] WCS Img coverage encoders subtly depend on gt-image

### DIFF
--- a/src/wcs/src/main/java/org/geoserver/wcs/responses/IMGCoverageResponseDelegate.java
+++ b/src/wcs/src/main/java/org/geoserver/wcs/responses/IMGCoverageResponseDelegate.java
@@ -11,19 +11,16 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.imagen.media.range.NoDataContainer;
 import org.geoserver.config.GeoServer;
 import org.geoserver.platform.ServiceException;
-import org.geoserver.util.IOUtils;
-import org.geotools.api.coverage.grid.Format;
-import org.geotools.api.parameter.ParameterValue;
-import org.geotools.api.parameter.ParameterValueGroup;
 import org.geotools.coverage.grid.GridCoverage2D;
-import org.geotools.gce.image.WorldImageWriter;
+import org.geotools.coverage.util.CoverageUtilities;
+import org.geotools.image.ImageWorker;
 
 /**
- * Encodes coverages in "world image" formats, png, jpeg and gif.
- *
- * <p>Notice that depending on the underlying coverage structure this is not always possible.
+ * Encodes coverages as plain PNG and JPEG images. The output carries no georeferencing: the client gets the pixels
+ * only.
  *
  * @author $Author: Alessio Fabiani (alessio.fabiani@gmail.com) $ (last modification)
  * @author $Author: Simone Giannecchini (simboss1@gmail.com) $ (last modification)
@@ -51,39 +48,29 @@ public class IMGCoverageResponseDelegate extends BaseCoverageResponseDelegate im
     }
 
     @Override
-    @SuppressWarnings("PMD.UseTryWithResources")
     public void encode(
             GridCoverage2D sourceCoverage,
             String outputFormat,
-            Map<String, String> econdingParameters,
+            Map<String, String> encodingParameters,
             OutputStream output)
             throws ServiceException, IOException {
         if (sourceCoverage == null) {
             throw new IllegalStateException("It seems prepare() has not been called or has not succeed");
         }
 
-        final WorldImageWriter writer = new WorldImageWriter(output);
-
-        // writing parameters for Image
-        final Format writerParams = writer.getFormat();
-        final ParameterValueGroup writeParameters = writerParams.getWriteParameters();
-        final ParameterValue<?> format = writeParameters.parameter("Format");
-        format.setValue(getFileExtension(outputFormat));
-
         try {
-            // writing
-            writer.write(sourceCoverage, format);
-            output.flush();
-        } finally {
-
-            // freeing everything
-            IOUtils.closeQuietly(output);
-
-            try {
-                writer.dispose();
-            } catch (Throwable e) {
-                // eat me
+            ImageWorker worker = new ImageWorker(sourceCoverage.getRenderedImage());
+            worker.setROI(CoverageUtilities.getROIProperty(sourceCoverage));
+            NoDataContainer noData = CoverageUtilities.getNoDataProperty(sourceCoverage);
+            worker.setNoData(noData != null ? noData.getAsRange() : null);
+            if ("jpeg".equals(getFileExtension(outputFormat))) {
+                // 0.75 is the JPEG quality the JDK writer uses by default
+                worker.writeJPEG(output, "JPEG", 0.75f);
+            } else {
+                // writePNG ignores the compression arguments, it always uses the writer defaults
+                worker.writePNG(output, "FILTERED", 0.75f, false);
             }
+        } finally {
             sourceCoverage.dispose(true);
         }
     }

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/GetCoverageTest.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/GetCoverageTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -43,6 +44,7 @@ import org.geotools.api.referencing.operation.MathTransform;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.io.GridCoverage2DReader;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.image.test.ImageAssert;
 import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
@@ -305,5 +307,41 @@ public class GetCoverageTest extends WCSTestSupport {
         assertNotNull(gridCoverage);
         assertTrue(hasCoverage);
         scheduleForCleaning(gridCoverage);
+    }
+
+    /** The PNG output carries no georeferencing, but must hold the same pixels as the GeoTIFF one. */
+    @Test
+    public void testPNGOutput() throws Exception {
+        BufferedImage tiff = getResponseAsImage(getCoverage("image/tiff"), "tif");
+        MockHttpServletResponse response = getCoverage("image/png");
+        assertEquals("image/png", getBaseMimeType(response.getContentType()));
+        BufferedImage png = getResponseAsImage(response, "png");
+
+        assertEquals(tiff.getWidth(), png.getWidth());
+        assertEquals(tiff.getHeight(), png.getHeight());
+        assertEquals(3, png.getSampleModel().getNumBands());
+        ImageAssert.assertEquals(tiff, png, 0);
+    }
+
+    /**
+     * JPEG is lossy, but at the default quality the difference against the GeoTIFF output stays below what the
+     * perceptual comparison in {@link ImageAssert} counts as a mismatch (writing at quality 0.05 gives 10 mismatches).
+     */
+    @Test
+    public void testJPEGOutput() throws Exception {
+        BufferedImage tiff = getResponseAsImage(getCoverage("image/tiff"), "tif");
+        MockHttpServletResponse response = getCoverage("image/jpeg");
+        assertEquals("image/jpeg", getBaseMimeType(response.getContentType()));
+        BufferedImage jpeg = getResponseAsImage(response, "jpeg");
+
+        assertEquals(tiff.getWidth(), jpeg.getWidth());
+        assertEquals(tiff.getHeight(), jpeg.getHeight());
+        assertEquals(3, jpeg.getSampleModel().getNumBands());
+        ImageAssert.assertEquals(tiff, jpeg, 0);
+    }
+
+    private MockHttpServletResponse getCoverage(String format) throws Exception {
+        return getAsServletResponse(
+                "wcs?request=GetCoverage&service=WCS&version=2.0.1&coverageId=wcs__BlueMarble&format=" + format);
     }
 }

--- a/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCSTestSupport.java
+++ b/src/wcs2_0/src/test/java/org/geoserver/wcs2_0/WCSTestSupport.java
@@ -16,17 +16,23 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
 import jakarta.mail.internet.MimeMessage;
 import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
 import javax.imageio.metadata.IIOMetadataNode;
+import javax.imageio.stream.ImageInputStream;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
@@ -417,6 +423,27 @@ public abstract class WCSTestSupport extends GeoServerSystemTestSupport {
             }
         }
         return null;
+    }
+
+    /**
+     * Decodes the response body as an image, checking that the bytes are really in the expected format (the format name
+     * an ImageIO reader reports for them, lower case, e.g. "png", "jpeg", "tif").
+     */
+    protected BufferedImage getResponseAsImage(MockHttpServletResponse response, String expectedFormat)
+            throws IOException {
+        byte[] bytes = response.getContentAsByteArray();
+        try (ImageInputStream is = ImageIO.createImageInputStream(new ByteArrayInputStream(bytes))) {
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(is);
+            assertTrue("No image reader found for the response bytes", readers.hasNext());
+            ImageReader reader = readers.next();
+            try {
+                assertEquals(expectedFormat, reader.getFormatName().toLowerCase(Locale.ROOT));
+                reader.setInput(is);
+                return reader.read(0);
+            } finally {
+                reader.dispose();
+            }
+        }
     }
 
     protected void setInputLimit(int kbytes) {


### PR DESCRIPTION
[![GEOS-12184](https://badgen.net/badge/JIRA/GEOS-12184/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12184) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

The img encoders are not working in 3.x anymore because worldimage was removed, but they are still passing builds and working at runtime until one tries to actually encode any image.

There was never a reason to use gt-image to start with though, as those encoders would return a plain PNG/JPEG file anyways, so that can be done using ImageWorker instead.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [x] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 