### PR TITLE
Docs: FIPS module status values are only in status.html, not status.json

### DIFF
--- a/doc/en/user/community/fips/running.md
+++ b/doc/en/user/community/fips/running.md
@@ -65,20 +65,20 @@ means the security subsystem will fail somewhere, and this table says which piec
 ## Reading the same values over REST
 
 The FIPS module reports itself among the module statuses, so the same values can be read without the
-user interface:
+user interface. Ask for the HTML form of the module status list:
 
 ```
-curl -u admin:geoserver "http://localhost:8080/geoserver/rest/about/status.json"
+curl -u admin:geoserver "http://localhost:8080/geoserver/rest/about/status.html"
 ```
 
-The entry to look for is the one with module `gs-fips-provider`. Its `message` holds one line per
-item of the first table, then one line per required algorithm:
+The entry to look for is the one whose **Module** is `gs-fips-provider`. Its **Message** holds one
+line per item of the first table, then one line per required algorithm:
 
 ```
 Crypto module: READY
 Approved-only mode: on
 Operating system FIPS mode: yes
-Crypto provider: BCFIPS 2.1.0
+Crypto provider: BCFIPS 2.0102
 Provider position: first
 Keystore format: BCFKS
 Config password encoder: AES-GCM
@@ -91,8 +91,12 @@ SecretKeyFactory PBKDF2WithHmacSHA256: yes
 MessageDigest SHA-256: yes
 ```
 
-The same entry has two boolean fields: `isAvailable` is true when the module self tests passed,
-`isEnabled` when approved-only mode is on.
+The same entry has two boolean fields: **Available** is true when the module self tests passed,
+**Enabled** when approved-only mode is on.
+
+!!! note
+    The `json` and `xml` forms of `rest/about/status` list module names and links only, with no
+    message, so none of the values above can be read there.
 
 ## Limitations
 


### PR DESCRIPTION
Quick doc fix after testing.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] I have read and applied the [AI policy](https://geoserver.org/ai)
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.