### PR TITLE
[Backport-2.28.x][GEOS-12180]: GWC Multilayer cache support

### DIFF
--- a/doc/en/user/source/geowebcache/webadmin/defaults.rst
+++ b/doc/en/user/source/geowebcache/webadmin/defaults.rst
@@ -105,6 +105,27 @@ Automatically configure a GeoWebCache layer for each new layer or layer group
 
 This setting, enabled by default, determines how layers in GeoServer are handled via the embedded GeoWebCache. When this setting is enabled, an entry in the GeoWebCache layer listing will be created whenever a new layer or layer group is published in GeoServer. Use this setting to keep the GeoWebCache catalog in sync. (This is enabled by default.)
 
+Enable multi-layer tile caching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, GeoWebCache only caches a tiled ``GetMap`` request that names a single layer: a request whose ``LAYERS`` parameter lists more than one layer (a coalesced request) is always rendered live and never cached. When this setting is enabled, GeoServer instead caches each layer of a coalesced request independently, using its existing per-layer tile cache, and combines the cached tiles into the final image.
+
+Each member layer is still subject to the usual caching requirements (cacheable parameters, matching gridset, and so on); a member that does not qualify falls back to a live render for that member only, spliced into the result. The whole request falls back to a live combined render, exactly as if this setting were disabled, when:
+
+* the request is not tiled
+* any member's style draws labels, or applies compositing/blending, at the requested scale (these effects depend on the full layer stack and cannot be reproduced from independently-cached tiles)
+* combining the member tiles would exceed the configured maximum WMS request memory
+
+This setting is disabled by default.
+
+A layer group named in ``LAYERS`` alongside anything else does not use the group's own tile cache:
+
+* ``LAYERS=groupA`` (a single layer group, no comma) is not a coalesced request, so this setting does not apply to it: it uses the group's own tile cache directly.
+* ``LAYERS=groupA,layerB`` (a layer group combined with anything else) is a coalesced request, and the group is resolved to its own member layers before this setting's logic runs: ``groupA``'s layers are then cached and stacked individually, each under its own name, using their own caches rather than the group's.
+* The exception is a request that also carries per-layer parameters (``CQL_FILTER``, ``STYLES``, ``FILTER``, ``SORTBY``, ``INTERPOLATIONS``, ``VIEWPARAMS``), since those are given one value per entry in ``LAYERS`` and can no longer be matched to the layers a group resolved to. Such a request renders live and is not cached, exactly as if this setting were disabled. A group holding a single layer resolves without changing the layer count, so it keeps working even with these parameters.
+
+How much this setting speeds up a coalesced request depends on the cost of rendering each member versus the cost of reading and decoding its cached PNG tile. The gain is largest when a member's data comes from a slow or contended source, such as a database or a remote service, where fetching and rendering the data is more expensive than reading a small PNG from disk and decoding it. For members backed by simple, fast-rendering data (for example, a small vector layer with a plain style, or a raster already stored as tiles), the gain shrinks, since PNG decoding and disk I/O may cost more relative to the render itself; a cache miss still falls back to a live render for that member, so enabling this setting should not make a coalesced request slower than it already was, only less beneficial for cheap-to-render members.
+
 Automatically cache non-default styles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/gwc/src/main/java/org/geoserver/gwc/CoalescedRequestSplitter.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/CoalescedRequestSplitter.java
@@ -1,0 +1,693 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.logging.Level;
+import org.eclipse.imagen.PlanarImage;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.util.CaseInsensitiveMap;
+import org.geoserver.ows.util.KvpUtils;
+import org.geoserver.platform.ServiceException;
+import org.geoserver.wms.GetMap;
+import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.MapLayerInfo;
+import org.geoserver.wms.RasterCleaner;
+import org.geoserver.wms.WMS;
+import org.geoserver.wms.WMSMapContent;
+import org.geoserver.wms.WebMap;
+import org.geoserver.wms.map.RenderedImageMap;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.sort.SortBy;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.style.FeatureTypeStyle;
+import org.geotools.api.style.Rule;
+import org.geotools.api.style.Style;
+import org.geotools.api.style.Symbolizer;
+import org.geotools.api.style.TextSymbolizer;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geowebcache.GeoWebCacheException;
+import org.geowebcache.conveyor.Conveyor;
+import org.geowebcache.conveyor.ConveyorTile;
+import org.geowebcache.grid.OutsideCoverageException;
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.io.codec.ImageDecoderContainer;
+import org.geowebcache.io.codec.ImageEncoderContainer;
+import org.geowebcache.layer.TileLayer;
+
+/**
+ * Splits a coalesced (comma-separated {@code LAYERS}) tiled {@code GetMap} request into per-member cached tiles and
+ * contiguous live-render runs, and assembles the result. A Spring singleton with no per-request state: the {@link GWC}
+ * mediator it delegates security/tile-layer lookups to is passed in by each call instead.
+ */
+class CoalescedRequestSplitter {
+
+    /** Log message prefix for multi-layer tile coalescing, so these lines are easy to grep out on their own. */
+    static final String MULTI_LAYER_LOG_PREFIX = "GWC MultiLayer >> ";
+
+    private final ImageDecoderContainer decoders;
+
+    private final ImageEncoderContainer encoders;
+
+    private final GetMap getMap;
+
+    CoalescedRequestSplitter(ImageDecoderContainer decoders, ImageEncoderContainer encoders, GetMap getMap) {
+        this.decoders = decoders;
+        this.encoders = encoders;
+        this.getMap = getMap;
+    }
+
+    /**
+     * Splits {@code request} into per-member cached/live segments, assembles them into one tile, and returns it.
+     *
+     * @return the assembled tile, or {@code null} if the request is not eligible for multi-layer caching, with the
+     *     reason appended to {@code requestMismatchTarget}
+     */
+    ConveyorTile dispatchCoalesced(GWC gwc, GetMapRequest request, StringBuilder requestMismatchTarget) {
+        long deadline = computeRenderingDeadline();
+
+        List<Segment> segments = classifyCoalescedMembers(gwc, request, requestMismatchTarget);
+        if (segments == null) {
+            return null;
+        }
+        CachedSegment firstCached = segments.stream()
+                .filter(CachedSegment.class::isInstance)
+                .map(CachedSegment.class::cast)
+                .findFirst()
+                .orElse(null);
+        if (firstCached == null) {
+            // nothing in the request is actually cacheable: no per-member tile to key the assembled result on,
+            // and nothing gained over just falling all the way back to a plain live render
+            requestMismatchTarget.append("no member of the coalesced request is cacheable");
+            return null;
+        }
+
+        if (exceedsMaxRequestMemory(request)) {
+            requestMismatchTarget.append("coalesced tile would exceed max request memory");
+            return null;
+        }
+
+        byte[] assembled;
+        try {
+            TileStackAssembler assembler = new TileStackAssembler(decoders, encoders);
+            assembled = assembler.assemble(
+                    this, gwc, request, segments, firstCached.member().tile().getMimeType(), deadline);
+        } catch (OutsideCoverageException e) {
+            // routine for a sparse member layer, not an error: same handling as the single-layer path
+            final String msg = e.getMessage() != null ? e.getMessage() : "tile outside coverage";
+            requestMismatchTarget.append(msg);
+            GWC.log.log(Level.FINE, msg);
+            return null;
+        } catch (Exception e) {
+            // Re-checking our own deadline, rather than inspecting the exception, tells if it has genuinely passed
+            // In that case, a live re-render would just hit the same wall, so fail hard with no fallback.
+            // anything else falls back like any other member fetch/render error
+            if (deadline > 0 && System.currentTimeMillis() > deadline) {
+                String msg = "This request used more time than allowed and has been forcefully stopped.";
+                throw e instanceof ServiceException se ? se : new ServiceException(msg, e);
+            }
+            GWC.log.log(Level.INFO, "Error assembling coalesced tile", e);
+            requestMismatchTarget.append("error assembling coalesced tile: ").append(e.getMessage());
+            return null;
+        } finally {
+            // renderLiveSegment hands its coverages to RasterCleaner, which normally drains as a dispatcher
+            // callback; with no request on this thread nothing would ever free them (same reason as
+            // GeoServerTileLayer#withRasterCleaner). Only once assemble() has encoded: a segment image may share a
+            // coverage's raster, so disposing any earlier would pull it out from under the canvas
+            if (Dispatcher.REQUEST.get() == null) {
+                RasterCleaner.cleanup();
+            }
+        }
+
+        ConveyorTile firstMemberTile = firstCached.member().tile();
+        // Cache-Control/Expires are computed separately by CachingWebMapService via WMS#cacheMaxAge over every
+        // member's MapLayerInfo, matching the live multi-layer path exactly, deliberately not
+        // GWC#setCacheControlHeaders, which is per-single-layer and driven by the GWC layer's getExpireClients.
+        // geowebcache-cache-result is signaled here (see GWC#COALESCED_CACHE_RESULT_KEY); the secondary
+        // geowebcache-layer/-gridset/-tile-bounds headers still describe only the first member. Mutable, not
+        // Collections.singletonMap: TileObject.createQueryTileObject stores this reference as-is (no defensive
+        // copy), and CachingWebMapService removes the key again once it has read it
+        Map<String, String> signaling = new HashMap<>();
+        signaling.put(GWC.COALESCED_CACHE_RESULT_KEY, coalescedCacheResultHeader(segments));
+        // never persisted itself: only the per-member tiles it stacks are cached
+        ConveyorTile assembledTile = new ConveyorTile(
+                null,
+                request.getRawKvp().get("LAYERS"),
+                firstMemberTile.getGridSetId(),
+                firstMemberTile.getTileIndex(),
+                firstMemberTile.getMimeType(),
+                signaling,
+                null,
+                null);
+        assembledTile.setBlob(new ByteArrayResource(assembled));
+        assembledTile.setTileLayer(firstCached.member().tileLayer());
+        // GWC.setConditionalGetHeaders reads this to answer If-Modified-Since; TileObject.createQueryTileObject
+        // (used by the ConveyorTile constructor above) leaves it at 0, which would report the tile as unchanged
+        // since 1970. A live-rendered segment makes the assembled image only as fresh as this render; an
+        // all-cached assembly changes whenever its newest constituent member does
+        assembledTile.getStorageObject().setCreated(assembledTileCreated(segments));
+        return assembledTile;
+    }
+
+    /**
+     * @return the wall-clock time now, if any segment was live-rendered; otherwise the most recent {@code TSCreated}
+     *     among the cached segments, since the assembled image changes whenever its newest constituent member does
+     */
+    private static long assembledTileCreated(List<Segment> segments) {
+        if (segments.stream().anyMatch(LiveSegment.class::isInstance)) {
+            return System.currentTimeMillis();
+        }
+        return segments.stream()
+                .filter(CachedSegment.class::isInstance)
+                .map(CachedSegment.class::cast)
+                .mapToLong(s -> s.member().tile().getTSCreated())
+                .max()
+                .orElse(0L);
+    }
+
+    /**
+     * Wall-clock deadline for {@link TileStackAssembler#assemble}, mirroring the WMS {@code maxRenderingTime} contract.
+     *
+     * @return {@code System.currentTimeMillis()} plus the configured {@code maxRenderingTime}, or {@code -1} if
+     *     unlimited
+     */
+    long computeRenderingDeadline() {
+        int maxRenderingTime = WMS.get().getServiceInfo().getMaxRenderingTime();
+        return maxRenderingTime > 0 ? System.currentTimeMillis() + maxRenderingTime * 1000L : -1;
+    }
+
+    /**
+     * Whether assembling a coalesced tile at {@code request}'s size would exceed WMS's configured
+     * {@code maxRequestMemory}; always {@code false} when unlimited.
+     *
+     * <p>Covers the assembly itself only. A {@link LiveSegment} renders through the normal WMS pipeline
+     * ({@link #renderLiveSegment}, via {@code GetMap.run}), which enforces {@code maxRequestMemory} against the full
+     * budget on its own (see {@code RenderedImageMapOutputFormat.produceMap}) with no way to tell it that the canvas is
+     * already held - {@code maxRequestMemory} has no per-request override the way {@code maxRenderingTime} does. So a
+     * request mixing cached and live segments can peak at {@code maxRequestMemory} plus one canvas ({@code width *
+     * height * 4} bytes), and the overshoot is not reported here: it surfaces, if at all, as the live segment's own
+     * render failing.
+     */
+    boolean exceedsMaxRequestMemory(GetMapRequest request) {
+        int maxRequestMemoryKB = WMS.get().getServiceInfo().getMaxRequestMemory();
+        if (maxRequestMemoryKB <= 0) {
+            return false;
+        }
+        // the output canvas plus one cached segment's decode buffer, whatever the member count: the caller only gets
+        // here with at least one cached segment, and TileStackAssembler.assemble decodes and draws them one at a
+        // time, flushing each before decoding the next, so one decoded raster at most is ever live beside the canvas
+        long peakBytes = 2L * request.getWidth() * request.getHeight() * 4;
+        return peakBytes > (long) maxRequestMemoryKB * 1024;
+    }
+
+    /**
+     * {@code HIT} if every original {@code LAYERS} member is a cache hit, {@code MISS} if none is, else {@code PARTIAL
+     * n/N}; every member of a {@link LiveSegment} run counts as a miss, since none of them was served from its own
+     * cache.
+     */
+    private static String coalescedCacheResultHeader(List<Segment> segments) {
+        int hits = 0;
+        int total = 0;
+        for (Segment segment : segments) {
+            if (segment instanceof CachedSegment cached) {
+                total++;
+                if (cached.member().tile().getCacheResult() == Conveyor.CacheResult.HIT) {
+                    hits++;
+                }
+            } else {
+                total += ((LiveSegment) segment).memberIndices().size();
+            }
+        }
+        if (hits == total) {
+            return Conveyor.CacheResult.HIT.toString();
+        }
+        if (hits == 0) {
+            return Conveyor.CacheResult.MISS.toString();
+        }
+        return "PARTIAL " + hits + "/" + total;
+    }
+
+    /** A {@code LAYERS} member of a coalesced request, split into its own single-layer prepared tile request. */
+    record TileLayerMember(TileLayer tileLayer, ConveyorTile tile) {}
+
+    /**
+     * One drawing-order segment of a coalesced request: either a single cacheable member ({@link CachedSegment}), or a
+     * maximal run of consecutive members that must be rendered live ({@link LiveSegment}) because none of them can be
+     * served from their own cache for this request (see {@link #classifyCoalescedMembers}).
+     */
+    interface Segment {}
+
+    record CachedSegment(TileLayerMember member) implements Segment {}
+
+    /**
+     * @param memberIndices positions (into the original {@code LAYERS} list) of this run's members, in order
+     * @param reason why the run's first member could not be served from cache; representative of the whole run
+     */
+    record LiveSegment(List<Integer> memberIndices, String reason) implements Segment {}
+
+    /**
+     * Renders a {@link LiveSegment}'s members as a single in-process {@code GetMap}, bypassing GWC's own
+     * {@code WebMapService} interceptor so a live segment cannot recurse back into tile caching.
+     *
+     * @param deadline the coalesced request's own deadline (see {@link #computeRenderingDeadline}), shared with this
+     *     live render via the {@code timeout} format option so a slow segment can't each get its own full
+     *     {@code maxRenderingTime} budget
+     * @throws ServiceException if {@code deadline} has already passed before this segment's render could even start
+     */
+    BufferedImage renderLiveSegment(GetMapRequest request, LiveSegment segment, long deadline) throws Exception {
+        if (GWC.log.isLoggable(Level.FINER)) {
+            GWC.log.finer(MULTI_LAYER_LOG_PREFIX + "Live-rendering coalesced segment members " + segment.memberIndices()
+                    + ": " + segment.reason());
+        }
+        long remainingMillis = 0;
+        if (deadline > 0) {
+            remainingMillis = deadline - System.currentTimeMillis();
+            if (remainingMillis <= 0) {
+                throw new ServiceException("This request used more time than allowed and has been forcefully stopped.");
+            }
+        }
+        GetMapRequest subRequest = sliceLiveSegment(request, segment.memberIndices(), remainingMillis);
+        WebMap webMap = getMap.run(subRequest);
+        try {
+            if (!(webMap instanceof RenderedImageMap renderedImageMap)) {
+                throw new IllegalStateException(
+                        "Live render of a coalesced segment did not produce a raster: " + webMap);
+            }
+            RenderedImage image = renderedImageMap.getImage();
+            if (image instanceof BufferedImage bufferedImage) {
+                return bufferedImage;
+            }
+            return PlanarImage.wrapRenderedImage(image).getAsBufferedImage();
+        } finally {
+            // webMap.dispose() does not release renderedCoverages (see RenderedImageMap.disposeInternal), so hand
+            // them to RasterCleaner ourselves, same as RenderedImageMapResponse.write does for a normal GetMap
+            if (webMap instanceof RenderedImageMap renderedImageMap) {
+                renderedImageMap.getRenderedCoverages().forEach(RasterCleaner::addCoverage);
+            }
+            webMap.dispose();
+        }
+    }
+
+    /**
+     * @param remainingMillis this segment's share of the coalesced request's own deadline, or {@code <= 0} for no
+     *     deadline; passed through as the {@code timeout} format option, the only way to shrink a single in-process
+     *     {@code GetMap}'s own {@code maxRenderingTime} below the server-wide setting
+     */
+    private static GetMapRequest sliceLiveSegment(
+            GetMapRequest request, List<Integer> memberIndices, long remainingMillis) {
+        GetMapRequest subRequest = (GetMapRequest) request.clone();
+        subRequest.setLayers(pickByIndex(request.getLayers(), memberIndices));
+        subRequest.setStyles(pickByIndex(request.getStyles(), memberIndices));
+        List<Filter> cqlFilters = request.getCQLFilter();
+        if (cqlFilters != null) {
+            subRequest.setCQLFilter(pickByIndex(cqlFilters, memberIndices));
+        }
+        List<Filter> filters = request.getFilter();
+        if (filters != null) {
+            subRequest.setFilter(pickByIndex(filters, memberIndices));
+        }
+        List<List<SortBy>> sortBys = request.getSortBy();
+        if (sortBys != null) {
+            subRequest.setSortBy(pickByIndex(sortBys, memberIndices));
+        }
+        List<Map<String, String>> viewParams = request.getViewParams();
+        if (viewParams != null) {
+            subRequest.setViewParams(pickByIndex(viewParams, memberIndices));
+        }
+        if (remainingMillis > 0) {
+            // GetMapRequest.clone() shares the formatOptions map with the original request; copy it before writing
+            Map<String, Object> formatOptions = new CaseInsensitiveMap<>(new HashMap<>(request.getFormatOptions()));
+            formatOptions.put("timeout", remainingMillis);
+            subRequest.setFormatOptions(formatOptions);
+        }
+        return subRequest;
+    }
+
+    private static <T> List<T> pickByIndex(List<T> list, List<Integer> indices) {
+        List<T> picked = new ArrayList<>(indices.size());
+        for (int index : indices) {
+            picked.add(list.get(index));
+        }
+        return picked;
+    }
+
+    /**
+     * Classifies each {@code LAYERS} member as cacheable or as needing a live render, grouping consecutive
+     * non-cacheable members into one {@link LiveSegment} per member run.
+     *
+     * @return the ordered segments, or {@code null} if the whole request is ineligible, with the reason appended to
+     *     {@code requestMismatchTarget}
+     */
+    List<Segment> classifyCoalescedMembers(GWC gwc, GetMapRequest request, StringBuilder requestMismatchTarget) {
+        if (!gwc.getConfig().isMultiLayerCachingEnabled()) {
+            requestMismatchTarget.append("multi-layer tile caching disabled");
+            return null;
+        }
+        if (!"image/png".equals(request.getFormat()) || !request.isTransparent()) {
+            requestMismatchTarget.append("multi-layer tile caching requires transparent image/png");
+            return null;
+        }
+        if (request.getRawKvp().get("FEATUREID") != null) {
+            // FEATUREID fids are matched to a layer by their "typename.fid" prefix, not by LAYERS position (see
+            // GetMapKvpRequestReader.parseFilters/getFilter), so it can't be positionally sliced per member like the
+            // other per-layer KVPs; request-wide gate is the safe first cut
+            requestMismatchTarget.append("multi-layer tile caching does not support FEATUREID");
+            return null;
+        }
+
+        final Map<String, String> rawKvp = request.getRawKvp();
+        // KNOWN LIMITATION: LAYERS=groupA (a single layer group, no comma) never reaches this method at all -
+        // GWC.dispatch checks the raw LAYERS KVP for a comma before any group expansion happens, so that request
+        // takes the ordinary single-layer path and hits groupA's own tile cache exactly as always.
+        // LAYERS=groupA,layerB DOES reach this method, but request.getLayers() has ALREADY been flattened by
+        // GetMapKvpRequestReader by then: groupA is expanded into its own members (say g1, g2), so this method
+        // sees three independent layers - g1, g2, layerB - with no marker that g1/g2 came from a group. The
+        // per-member slicing below is positional over the raw KVP, so it cannot survive that: the guard right
+        // after this bails out to a live render when the expansion changed the member count AND the request
+        // carries a per-layer KVP to slice. Without any such KVP the expanded members are cached individually as
+        // usual, and so is a group holding exactly one layer (it expands 1:1, keeping the mapping intact). Either
+        // way the group's own tile cache is not consulted, only its members'.
+        final List<MapLayerInfo> layers = request.getLayers();
+        if (KvpUtils.readFlat(rawKvp.get("LAYERS")).size() != layers.size() && hasPerLayerKvp(rawKvp)) {
+            // a LAYERS slot was expanded (a layer group), so raw token index i no longer lines up with member i and
+            // the per-layer KVPs sliced below would be assigned to the wrong member, drawing and caching each of
+            // them with someone else's value. Not recoverable from raw text alone (see the group limitation
+            // above), so drop to the live render. Only when such a KVP is actually present: with none of them
+            // there is nothing to misalign, and the expanded members can be cached individually as usual
+            requestMismatchTarget.append("a LAYERS entry was expanded, per-member parameters cannot be sliced");
+            return null;
+        }
+        final List<Style> styles = request.getStyles();
+        if (styles == null || styles.size() != layers.size()) {
+            // GetMapKvpRequestReader pads STYLES out to one entry per layer; anything else means the positional
+            // slicing below would hand a member someone else's style instead of failing
+            requestMismatchTarget.append("STYLES does not line up with LAYERS");
+            return null;
+        }
+        final List<Filter> cqlFilters = request.getCQLFilter();
+        final List<Filter> filters = request.getFilter();
+        final List<List<SortBy>> sortBys = request.getSortBy();
+        final List<Map<String, String>> viewParams = request.getViewParams();
+        final List<String> viewParamTokens;
+        {
+            String rawViewParams = rawKvp.get("VIEWPARAMS");
+            if (rawViewParams == null) {
+                viewParamTokens = null;
+            } else {
+                List<String> tokens = KvpUtils.escapedTokens(rawViewParams, ',');
+                if (tokens.size() == layers.size()) {
+                    viewParamTokens = tokens;
+                } else if (tokens.size() == 1 && layers.size() > 1) {
+                    // GetMapKvpRequestReader.applyViewParams replicates a single group over every layer when the
+                    // client supplies just one; mirror that here so the raw-KVP mirror used for cache-key
+                    // derivation matches what was actually rendered, instead of leaving members 1..N keyed as if
+                    // VIEWPARAMS were absent while they were in fact rendered with the replicated value
+                    viewParamTokens = Collections.nCopies(layers.size(), tokens.get(0));
+                } else {
+                    // any other count (e.g. one group per originally-requested layer-group slot, expanded
+                    // differently than LAYERS) can't be reliably realigned to per-member positions from raw text
+                    // alone - same class of problem as the LAYERS/layer-group limitation above, so bail out
+                    // rather than risk a silently wrong cache key
+                    requestMismatchTarget.append("VIEWPARAMS text cannot be sliced per member");
+                    return null;
+                }
+            }
+        }
+        final List<String> cqlFilterTokens;
+        {
+            String rawCql = rawKvp.get("CQL_FILTER");
+            if (rawCql == null) {
+                cqlFilterTokens = null;
+            } else {
+                List<String> tokens = splitCqlFilters(rawCql);
+                // the ';' scanner above is an approximation of the CQL grammar (it does not implement a full CQL
+                // parser); if its token count disagrees with the already-parsed filter count, the tokens cannot
+                // be trusted to line up with the members, so bail out rather than risk a silently wrong cache key
+                if (tokens.size() != layers.size()) {
+                    requestMismatchTarget.append("CQL_FILTER text cannot be sliced per member");
+                    return null;
+                }
+                cqlFilterTokens = tokens;
+            }
+        }
+        final double scaleDenominator = computeScaleDenominator(request);
+        // the raw multi-layer request is authorized nowhere else, so each member needs its own coarse gate
+        final ReferencedEnvelope securityBbox;
+        try {
+            securityBbox =
+                    gwc.getConfig().isSecurityEnabled() ? gwc.parseRequestBbox(request, rawKvp.get("LAYERS")) : null;
+        } catch (RuntimeException e) {
+            requestMismatchTarget.append("invalid request for access check: ").append(e.getMessage());
+            return null;
+        }
+
+        final List<Segment> segments = new ArrayList<>();
+        List<Integer> liveRunIndices = null;
+        String liveRunReason = null;
+        String gridSetId = null;
+        long[] tileIndex = null;
+
+        for (int i = 0; i < layers.size(); i++) {
+            String layerName = layers.get(i).getName();
+
+            // cross-stack correctness gates: apply regardless of this member's own cacheability, and abort the
+            // whole request, since a live-rendered member can't be composited to fix a label/compositing conflict
+            // with a DIFFERENT, already-cached member
+            if (gwc.getConfig().isSecurityEnabled()) {
+                try {
+                    gwc.verifyAccessLayer(layerName, securityBbox);
+                } catch (org.geotools.ows.ServiceException | SecurityException e) {
+                    requestMismatchTarget.append('\'').append(layerName).append("' access denied");
+                    return null;
+                }
+            }
+            if (isIneligibleAtScale(styles.get(i), scaleDenominator)) {
+                requestMismatchTarget
+                        .append('\'')
+                        .append(layerName)
+                        .append("' draws labels or composites with layers beneath it at this scale");
+                return null;
+            }
+
+            String liveReason = null;
+            TileLayer tileLayer = null;
+            if (!gwc.tld.layerExists(layerName)) {
+                liveReason = "'" + layerName + "' is not a tile layer";
+            } else {
+                try {
+                    tileLayer = gwc.tld.getTileLayer(layerName);
+                } catch (GeoWebCacheException e) {
+                    throw new RuntimeException(e);
+                }
+                if (!tileLayer.isEnabled()) {
+                    liveReason = "'" + layerName + "' tile layer disabled";
+                    tileLayer = null;
+                }
+            }
+
+            ConveyorTile memberTile = null;
+            if (tileLayer != null) {
+                GetMapRequest memberRequest = (GetMapRequest) request.clone();
+                memberRequest.setLayers(Collections.singletonList(layers.get(i)));
+                memberRequest.setStyles(Collections.singletonList(styles.get(i)));
+                Map<String, String> memberKvp = new CaseInsensitiveMap<>(new HashMap<>(rawKvp));
+                memberKvp.put("LAYERS", layerName);
+                // forward the client's own text unchanged: getModifiableParameters derives the cache key from
+                // memberKvp and GWC.filterApplies matches parameter filters against it
+                putRawMemberToken(memberKvp, "STYLES", rawKvp.get("STYLES"), i, KvpUtils.INNER_DELIMETER);
+                putRawMemberToken(
+                        memberKvp, "INTERPOLATIONS", rawKvp.get("INTERPOLATIONS"), i, KvpUtils.INNER_DELIMETER);
+                if (cqlFilterTokens != null) {
+                    memberKvp.put("CQL_FILTER", cqlFilterTokens.get(i));
+                }
+                putRawMemberToken(memberKvp, "FILTER", rawKvp.get("FILTER"), i, KvpUtils.OUTER_DELIMETER);
+                putRawMemberToken(memberKvp, "SORTBY", rawKvp.get("SORTBY"), i, KvpUtils.OUTER_DELIMETER);
+                if (viewParamTokens != null) {
+                    memberKvp.put("VIEWPARAMS", viewParamTokens.get(i));
+                }
+                memberRequest.setRawKvp(memberKvp);
+                if (cqlFilters != null && i < cqlFilters.size()) {
+                    memberRequest.setCQLFilter(Collections.singletonList(cqlFilters.get(i)));
+                }
+                if (filters != null && i < filters.size()) {
+                    memberRequest.setFilter(Collections.singletonList(filters.get(i)));
+                }
+                if (sortBys != null && i < sortBys.size()) {
+                    memberRequest.setSortBy(Collections.singletonList(sortBys.get(i)));
+                }
+                if (viewParams != null && i < viewParams.size()) {
+                    memberRequest.setViewParams(Collections.singletonList(viewParams.get(i)));
+                }
+
+                // isolated: a failure here must not leak into requestMismatchTarget unless this run ends up being
+                // the one reported, since this member may simply join a live segment rather than abort anything
+                StringBuilder memberMismatch = new StringBuilder();
+                memberTile = gwc.prepareRequest(tileLayer, memberRequest, memberMismatch);
+                if (memberTile == null) {
+                    liveReason = "'" + layerName + "': " + memberMismatch;
+                } else if (gridSetId == null) {
+                    gridSetId = memberTile.getGridSetId();
+                    tileIndex = memberTile.getTileIndex();
+                } else if (!gridSetId.equals(memberTile.getGridSetId())
+                        || !Arrays.equals(tileIndex, memberTile.getTileIndex())) {
+                    // members share one footprint, gridloc and zoom: TileStackAssembler stacks raw pixels with no
+                    // knowledge of gridset identity, so a mismatch here would silently misalign the assembled tile
+                    liveReason = "'" + layerName + "' resolved to a different gridset/tile than the other members";
+                    memberTile = null;
+                }
+            }
+
+            if (memberTile != null) {
+                if (liveRunIndices != null) {
+                    segments.add(new LiveSegment(liveRunIndices, liveRunReason));
+                    liveRunIndices = null;
+                }
+                segments.add(new CachedSegment(new TileLayerMember(tileLayer, memberTile)));
+            } else {
+                if (liveRunIndices == null) {
+                    liveRunIndices = new ArrayList<>();
+                    liveRunReason = liveReason;
+                }
+                liveRunIndices.add(i);
+            }
+        }
+        if (liveRunIndices != null) {
+            segments.add(new LiveSegment(liveRunIndices, liveRunReason));
+        }
+        return segments;
+    }
+
+    /**
+     * Computes the request's scale denominator the way a live render would; mirrors
+     * {@link org.geoserver.wms.FeatureInfoRequestParameters}'s equivalent computation.
+     */
+    private static double computeScaleDenominator(GetMapRequest request) {
+        CoordinateReferenceSystem crs = request.getCrs() != null ? request.getCrs() : DefaultGeographicCRS.WGS84;
+        WMSMapContent mapContent = new WMSMapContent(request);
+        try {
+            mapContent.getViewport().setBounds(new ReferencedEnvelope(request.getBbox(), crs));
+            mapContent.setMapWidth(request.getWidth());
+            mapContent.setMapHeight(request.getHeight());
+            mapContent.setAngle(request.getAngle());
+            return mapContent.getScaleDenominator(true);
+        } finally {
+            mapContent.dispose();
+        }
+    }
+
+    /** The {@code LAYERS}-aligned KVPs that {@link #classifyCoalescedMembers} slices positionally per member. */
+    private static final List<String> PER_LAYER_KVPS =
+            List.of("STYLES", "FILTER", "SORTBY", "INTERPOLATIONS", "CQL_FILTER", "VIEWPARAMS");
+
+    /** Whether {@code rawKvp} carries any {@link #PER_LAYER_KVPS} entry with a value to slice. */
+    private static boolean hasPerLayerKvp(Map<String, String> rawKvp) {
+        return PER_LAYER_KVPS.stream().map(rawKvp::get).anyMatch(value -> value != null && !value.isEmpty());
+    }
+
+    /**
+     * Writes {@code memberKvp[key]} to the {@code index}-th token of {@code raw}, tokenized with {@code tokenizer};
+     * writes nothing when {@code raw} itself is {@code null}, so a per-member value absent from the client's request
+     * stays absent from the member's own KVP view.
+     */
+    private static void putRawMemberToken(
+            Map<String, String> memberKvp, String key, String raw, int index, KvpUtils.Tokenizer tokenizer) {
+        if (raw == null) {
+            return;
+        }
+        putMemberToken(memberKvp, key, index, KvpUtils.readFlat(raw, tokenizer));
+    }
+
+    /**
+     * Writes {@code memberKvp[key]} to {@code tokens[index]}, or to {@code ""} if {@code index} has no token. Written
+     * even when the token is empty (e.g. {@code STYLES=,labeled} leaves member 0 with the default style):
+     * {@code memberKvp} starts as a copy of the whole combined {@code rawKvp}, so skipping an empty token would leave
+     * the OTHER members' combined text on this one instead, keying this member's cache entry partly on their settings.
+     */
+    private static void putMemberToken(Map<String, String> memberKvp, String key, int index, List<String> tokens) {
+        memberKvp.put(key, index < tokens.size() ? tokens.get(index) : "");
+    }
+
+    /**
+     * Splits a {@code CQL_FILTER} value on {@code ;} outside string literals and double-quoted property names, so a
+     * {@code ;} embedded in a filter's own text (e.g. {@code NAME='a;b'}) does not get mistaken for the separator
+     * between two members' clauses. An approximation of the CQL grammar, not a full parser: callers must still
+     * cross-check the resulting token count against the already-parsed filter count before trusting it.
+     */
+    private static List<String> splitCqlFilters(String raw) {
+        List<String> tokens = new ArrayList<>();
+        int start = 0;
+        char quote = 0; // 0 outside a quoted region, otherwise the quote character that opened it
+        for (int i = 0; i < raw.length(); i++) {
+            char c = raw.charAt(i);
+            if (quote != 0) {
+                if (c == quote) {
+                    quote = 0; // a doubled '' closes and immediately reopens, which is the right outcome
+                }
+            } else if (c == '\'' || c == '"') {
+                quote = c;
+            } else if (c == ';') {
+                tokens.add(raw.substring(start, i));
+                start = i + 1;
+            }
+        }
+        tokens.add(raw.substring(start));
+        return tokens;
+    }
+
+    /** Mirrors the private rule scale-range check in {@code org.geotools.renderer.lite.StreamingRenderer}. */
+    private static final double SCALE_TOLERANCE = 1e-6;
+
+    private static boolean isWithinScale(Rule rule, double scaleDenominator) {
+        return rule.getMinScaleDenominator() - SCALE_TOLERANCE <= scaleDenominator
+                && rule.getMaxScaleDenominator() + SCALE_TOLERANCE > scaleDenominator;
+    }
+
+    /**
+     * Whether {@code style} draws labels, or blends with the layers beneath it, in any {@code FeatureTypeStyle} active
+     * at {@code scaleDenominator}: a per-layer cached tile bakes either in without the rest of the stack, so it can't
+     * reproduce what a live render of the whole stack would draw.
+     */
+    private static boolean isIneligibleAtScale(Style style, double scaleDenominator) {
+        for (FeatureTypeStyle fts : style.featureTypeStyles()) {
+            boolean active = false;
+            boolean labels = false;
+            for (Rule rule : fts.rules()) {
+                if (!isWithinScale(rule, scaleDenominator)) {
+                    continue;
+                }
+                active = true;
+                for (Symbolizer symbolizer : rule.symbolizers()) {
+                    if (symbolizer instanceof TextSymbolizer) {
+                        labels = true;
+                    }
+                }
+            }
+            if (!active) {
+                continue;
+            }
+            if (fts.getOptions().containsKey(FeatureTypeStyle.COMPOSITE)
+                    || fts.getOptions().containsKey(FeatureTypeStyle.COMPOSITE_BASE)) {
+                return true; // ineligible: composites with the layers beneath it at this scale
+            }
+            if (labels) {
+                return true; // ineligible: draws labels at this scale
+            }
+        }
+        return false;
+    }
+
+    Executor getMetaTilingExecutor(GWC gwc) {
+        return gwc.getMetaTilingExecutor();
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/GWC.java
@@ -186,7 +186,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     /** @see #getResponseEncoder(MimeType, RenderedImageMap) */
     private Map<String, Response> cachedTileEncoders = new HashMap<>();
 
-    private final TileLayerDispatcher tld;
+    final TileLayerDispatcher tld;
 
     private final StorageBroker storageBroker;
 
@@ -232,6 +232,8 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
 
     private ExecutorService metaTilingExecutor;
 
+    private final CoalescedRequestSplitter coalescedRequestSplitter;
+
     /**
      * Constructor for the GWC mediator
      *
@@ -247,6 +249,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
      * @param jdbcConfigurationStorage GeoServer integrator for GeoWebCache DiskQuota {@link JDBCConfiguration}
      * @param blobStoreAggregator GeoWebCache BlobStore Aggregator
      * @param gwcSynchEnv GeoServer integrator for GeoWebCache environment synchronization
+     * @param coalescedRequestSplitter splits and assembles multi-layer coalesced tile requests
      */
     public GWC(
             final GWCConfigPersister gwcConfigPersister,
@@ -261,7 +264,8 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
             final DefaultStorageFinder storageFinder,
             final JDBCConfigurationStorage jdbcConfigurationStorage,
             final BlobStoreAggregator blobStoreAggregator,
-            final GWCSynchEnv gwcSynchEnv) {
+            final GWCSynchEnv gwcSynchEnv,
+            final CoalescedRequestSplitter coalescedRequestSplitter) {
 
         this.gwcConfigPersister = gwcConfigPersister;
         this.tld = tld;
@@ -284,6 +288,7 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         this.jdbcConfigurationStorage = jdbcConfigurationStorage;
         this.blobStoreAggregator = blobStoreAggregator;
         this.gwcSynchEnv = gwcSynchEnv;
+        this.coalescedRequestSplitter = coalescedRequestSplitter;
 
         this.metaTilingExecutor = buildMetaTilingExecutor(getConfig().getMetaTilingThreads());
     }
@@ -725,6 +730,16 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
     }
 
     /**
+     * Whether {@code request}'s {@code LAYERS} KVP names more than one layer, the single condition both
+     * {@link #dispatch} and {@code CachingWebMapService} use to decide whether a request is a coalesced multi-layer
+     * one.
+     */
+    public static boolean isCoalescedLayers(GetMapRequest request) {
+        String layerName = request.getRawKvp().get("LAYERS");
+        return layerName != null && layerName.indexOf(',') != -1;
+    }
+
+    /**
      * Tries to dispatch a tile request represented by a GeoServer WMS {@link GetMapRequest} through GeoWebCache, and
      * returns the {@link ConveyorTile} if succeeded or {@code null} if it wasn't possible.
      *
@@ -746,9 +761,12 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
          * use request.getLayers() because in the event that a layerGroup was requested, the request
          * parser turned it into a list of actual Layers
          */
-        if (layerName.indexOf(',') != -1) {
-            requestMistmatchTarget.append("more than one layer requested");
-            return null;
+        if (isCoalescedLayers(request)) {
+            if (!getConfig().isMultiLayerCachingEnabled()) {
+                requestMistmatchTarget.append("more than one layer requested");
+                return null;
+            }
+            return coalescedRequestSplitter.dispatchCoalesced(this, request, requestMistmatchTarget);
         }
 
         // GEOS-9431 acquire prefixed name if not prefixed already
@@ -771,23 +789,8 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         }
 
         if (getConfig().isSecurityEnabled()) {
-            String bboxstr = request.getRawKvp().get("BBOX");
-            String srs = request.getRawKvp().get("SRS");
-            ReferencedEnvelope bbox = null;
             try {
-                bbox = (ReferencedEnvelope) new BBoxKvpParser().parse(bboxstr);
-            } catch (Exception e) {
-                throw new RuntimeException("Invalid bbox for layer '" + layerName + "': " + bboxstr);
-            }
-            if (srs != null) {
-                try {
-                    bbox = new ReferencedEnvelope(bbox, CRS.decode(srs));
-                } catch (Exception e) {
-                    throw new RuntimeException("Can't decode SRS for layer '" + layerName + "': " + srs);
-                }
-            }
-            try {
-                verifyAccessLayer(layerName, bbox);
+                verifyAccessLayer(layerName, parseRequestBbox(request, layerName));
             } catch (ServiceException | SecurityException e) {
                 return null;
             }
@@ -809,6 +812,38 @@ public class GWC implements DisposableBean, InitializingBean, ApplicationContext
         }
         return tileResp;
     }
+
+    /**
+     * Parses the request-wide {@code BBOX}/{@code SRS} KVP into a {@link ReferencedEnvelope} for
+     * {@link #verifyAccessLayer}.
+     */
+    ReferencedEnvelope parseRequestBbox(GetMapRequest request, String layerNameForErrors) {
+        String bboxstr = request.getRawKvp().get("BBOX");
+        String srs = request.getRawKvp().get("SRS");
+        ReferencedEnvelope bbox;
+        try {
+            bbox = (ReferencedEnvelope) new BBoxKvpParser().parse(bboxstr);
+        } catch (Exception e) {
+            throw new RuntimeException("Invalid bbox for layer '" + layerNameForErrors + "': " + bboxstr);
+        }
+        if (srs != null) {
+            try {
+                bbox = new ReferencedEnvelope(bbox, CRS.decode(srs));
+            } catch (Exception e) {
+                throw new RuntimeException("Can't decode SRS for layer '" + layerNameForErrors + "': " + srs);
+            }
+        }
+        return bbox;
+    }
+
+    /**
+     * Internal signaling channel from {@link CoalescedRequestSplitter#dispatchCoalesced} to
+     * {@link org.geoserver.gwc.wms.CachingWebMapService}: the assembled {@code ConveyorTile}'s
+     * {@code geowebcache-cache-result} value, computed per member ({@code HIT}, {@code MISS}, or {@code PARTIAL n/N}),
+     * since {@link Conveyor.CacheResult} has no such value. Piggybacks on the unused filtering-parameters map of a tile
+     * that is never itself persisted or looked up.
+     */
+    public static final String COALESCED_CACHE_RESULT_KEY = "gwc.coalesced.cacheResult";
 
     private String getPrefixedName(String layerName) {
         PublishedInfo info = catalog.getLayerByName(layerName);

--- a/src/gwc/src/main/java/org/geoserver/gwc/TileStackAssembler.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/TileStackAssembler.java
@@ -1,0 +1,184 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.platform.ServiceException;
+import org.geoserver.wms.GetMapRequest;
+import org.geotools.util.logging.Logging;
+import org.geowebcache.conveyor.ConveyorTile;
+import org.geowebcache.io.codec.ImageDecoderContainer;
+import org.geowebcache.io.codec.ImageEncoderContainer;
+import org.geowebcache.mime.MimeType;
+
+/**
+ * Assembles one coalesced tile by fetching each {@code LAYERS} member's own tile and stacking them alpha-over in
+ * request order. Single-use, single-threaded: build one instance per tile request.
+ */
+class TileStackAssembler {
+
+    private static final Logger LOGGER = Logging.getLogger(TileStackAssembler.class);
+
+    private final ImageDecoderContainer decoders;
+
+    private final ImageEncoderContainer encoders;
+
+    TileStackAssembler(ImageDecoderContainer decoders, ImageEncoderContainer encoders) {
+        this.decoders = decoders;
+        this.encoders = encoders;
+    }
+
+    /**
+     * Fetches every cached segment's tile, rendering on a cache miss exactly like a single-layer request, and
+     * live-renders every non-cacheable run as a single sub-request; draws each segment's image onto a shared canvas in
+     * {@code LAYERS} order, then encodes the result.
+     *
+     * @param deadline wall-clock time (as per {@link System#currentTimeMillis()}) by which encoding must start, or
+     *     {@code <= 0} for no deadline; matches the WMS {@code maxRenderingTime} contract, which no single member's own
+     *     render can enforce on its own since it only sees its own elapsed time, not this whole operation's
+     * @return the assembled tile, encoded as {@code outputFormat}
+     * @throws ServiceException if {@code deadline} has already passed on entry, or by the time encoding starts
+     */
+    byte[] assemble(
+            CoalescedRequestSplitter splitter,
+            GWC gwc,
+            GetMapRequest request,
+            List<CoalescedRequestSplitter.Segment> segments,
+            MimeType outputFormat,
+            long deadline)
+            throws Exception {
+        // before the peek, not just after the draw loop: classifyCoalescedMembers can burn the whole budget on a
+        // wide stack, and an all-cached assembly has no other entry check (renderLiveSegment guards its own)
+        if (deadline > 0 && System.currentTimeMillis() > deadline) {
+            throw new ServiceException("This request used more time than allowed and has been forcefully stopped.");
+        }
+        peekCachedSegments(splitter, gwc, segments);
+
+        BufferedImage canvas = null;
+        Graphics2D graphics = null;
+        try {
+            for (CoalescedRequestSplitter.Segment segment : segments) {
+                BufferedImage segmentImage = segment instanceof CoalescedRequestSplitter.CachedSegment cached
+                        ? decodeCachedSegment(cached)
+                        : splitter.renderLiveSegment(request, (CoalescedRequestSplitter.LiveSegment) segment, deadline);
+
+                if (canvas == null) {
+                    canvas = new BufferedImage(
+                            segmentImage.getWidth(), segmentImage.getHeight(), BufferedImage.TYPE_INT_ARGB);
+                    graphics = canvas.createGraphics();
+                } else if (segmentImage.getWidth() != canvas.getWidth()
+                        || segmentImage.getHeight() != canvas.getHeight()) {
+                    // members share one footprint, gridloc and zoom (enforced in
+                    // CoalescedRequestSplitter.classifyCoalescedMembers); a
+                    // live segment's own render is the one segment kind that isn't grid-checked, so a mismatch here
+                    // would otherwise silently misalign the stack instead of failing loudly
+                    throw new IllegalStateException(
+                            "Coalesced segment image size " + segmentImage.getWidth() + "x" + segmentImage.getHeight()
+                                    + " does not match the tile size " + canvas.getWidth() + "x" + canvas.getHeight());
+                }
+                graphics.drawImage(segmentImage, 0, 0, null);
+                // drops cached/accelerated surface copies now rather than waiting for GC; does not free the raster
+                // itself, so it's no substitute for letting segmentImage go out of scope after each segment
+                segmentImage.flush();
+            }
+        } finally {
+            if (graphics != null) {
+                graphics.dispose();
+            }
+        }
+
+        if (deadline > 0 && System.currentTimeMillis() > deadline) {
+            throw new ServiceException("This request used more time than allowed and has been forcefully stopped.");
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        encoders.encode(canvas, outputFormat, out, false, null);
+        return out.toByteArray();
+    }
+
+    private BufferedImage decodeCachedSegment(CoalescedRequestSplitter.CachedSegment cached) throws Exception {
+        ConveyorTile tile = cached.member().tile();
+        if (tile.getBlob() == null) {
+            // a peek miss, or a member whose layer doesn't support the cache-only peek: render like a single-layer
+            // request, on this thread, exactly as before the peek phase existed
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer(CoalescedRequestSplitter.MULTI_LAYER_LOG_PREFIX + "Rendering cached segment " + tile
+                        + ", peek missed or was skipped");
+            }
+            cached.member().tileLayer().getTile(tile);
+        } else if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.finer(CoalescedRequestSplitter.MULTI_LAYER_LOG_PREFIX + "Cached segment " + tile
+                    + " already served by the peek");
+        }
+        String mimeType = tile.getMimeType().getMimeType();
+        return decoders.decode(mimeType, tile.getBlob(), decoders.isAggressiveInputStreamSupported(mimeType), null);
+    }
+
+    /** Cache-only peek for every cached segment's tile, in parallel; a hit leaves the tile's blob populated. */
+    private void peekCachedSegments(
+            CoalescedRequestSplitter splitter, GWC gwc, List<CoalescedRequestSplitter.Segment> segments) {
+        // live segments have nothing to peek; a member on a plain TileLayer (no GeoServerTileLayer) can't either,
+        // since peekCache isn't part of that interface
+        List<CoalescedRequestSplitter.CachedSegment> peekable = segments.stream()
+                .filter(CoalescedRequestSplitter.CachedSegment.class::isInstance)
+                .map(CoalescedRequestSplitter.CachedSegment.class::cast)
+                .filter(cached -> cached.member().tileLayer() instanceof GeoServerTileLayer)
+                .toList();
+        if (peekable.size() < 2) {
+            // 0 or 1 segment: nothing to parallelize, a sequential getTile() in the draw loop is just as fast
+            return;
+        }
+        // outside an interactive request (seeding), there's no CoalescedRequestSplitter.getMetaTilingExecutor()
+        // round trip to pay for
+        Executor executor = splitter.getMetaTilingExecutor(gwc);
+        if (executor == null || Dispatcher.REQUEST.get() == null) {
+            return;
+        }
+        // each peek runs concurrently via GeoServerTileLayer#peekCache (lock-free reads, so no contention with
+        // the serial render loop in decodeCachedSegment) and populates its own tile's blob on a hit; allOf().join()
+        // blocks this (request) thread until every peek is done, so no render below can start while one is in flight
+        List<CompletableFuture<Void>> peeks = peekable.stream()
+                .map(cached -> CompletableFuture.runAsync(() -> peekOne(cached), executor))
+                .toList();
+        CompletableFuture.allOf(peeks.toArray(new CompletableFuture[0])).join();
+    }
+
+    /**
+     * A peek is a best-effort optimization: any failure (e.g. a storage backend that isn't safe against a concurrent
+     * read racing a save) must fall back to treating the member as a miss, exactly like it would without the peek
+     * phase, never abort the whole coalesced tile over one member's read hiccup.
+     */
+    private void peekOne(CoalescedRequestSplitter.CachedSegment cached) {
+        ConveyorTile tile = cached.member().tile();
+        try {
+            GeoServerTileLayer tileLayer = (GeoServerTileLayer) cached.member().tileLayer();
+            boolean hit = tileLayer.peekCache(tile);
+            if (hit) {
+                // peekCache is a raw cache read and, unlike getTile, never fires this itself; a peek hit still
+                // needs to count towards disk quota's LFU tile usage tracking
+                tileLayer.sendTileRequestedEvent(tile);
+            }
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.finer(CoalescedRequestSplitter.MULTI_LAYER_LOG_PREFIX + "Cache peek " + (hit ? "hit" : "miss")
+                        + " for " + tile);
+            }
+        } catch (RuntimeException e) {
+            LOGGER.log(
+                    Level.FINE,
+                    e,
+                    () -> CoalescedRequestSplitter.MULTI_LAYER_LOG_PREFIX + "Cache peek failed for " + tile
+                            + ", will render it");
+        }
+    }
+}

--- a/src/gwc/src/main/java/org/geoserver/gwc/config/GWCConfig.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/config/GWCConfig.java
@@ -43,6 +43,9 @@ public class GWCConfig implements Cloneable, Serializable {
     /** Whether to cache any non default Style associated to the layer */
     private boolean cacheNonDefaultStyles;
 
+    /** Whether a tiled, transparent-PNG multi-layer GetMap is served by stacking per-layer cached tiles */
+    private boolean multiLayerCachingEnabled;
+
     /** Default meta-tiling factor for the X axis */
     private int metaTilingX;
 
@@ -173,6 +176,14 @@ public class GWCConfig implements Cloneable, Serializable {
 
     public void setCacheNonDefaultStyles(boolean cacheNonDefaultStyles) {
         this.cacheNonDefaultStyles = cacheNonDefaultStyles;
+    }
+
+    public boolean isMultiLayerCachingEnabled() {
+        return multiLayerCachingEnabled;
+    }
+
+    public void setMultiLayerCachingEnabled(boolean multiLayerCachingEnabled) {
+        this.multiLayerCachingEnabled = multiLayerCachingEnabled;
     }
 
     public Set<String> getDefaultCachingGridSetIds() {
@@ -361,6 +372,7 @@ public class GWCConfig implements Cloneable, Serializable {
                 && securityEnabled == gwcConfig.securityEnabled
                 && cacheLayersByDefault == gwcConfig.cacheLayersByDefault
                 && cacheNonDefaultStyles == gwcConfig.cacheNonDefaultStyles
+                && multiLayerCachingEnabled == gwcConfig.multiLayerCachingEnabled
                 && metaTilingX == gwcConfig.metaTilingX
                 && metaTilingY == gwcConfig.metaTilingY
                 && Objects.equals(metaTilingThreads, gwcConfig.metaTilingThreads)
@@ -387,6 +399,7 @@ public class GWCConfig implements Cloneable, Serializable {
                 securityEnabled,
                 cacheLayersByDefault,
                 cacheNonDefaultStyles,
+                multiLayerCachingEnabled,
                 metaTilingX,
                 metaTilingY,
                 metaTilingThreads,

--- a/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/layer/GeoServerTileLayer.java
@@ -582,7 +582,8 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer, TileJSO
         return true;
     }
 
-    protected final void sendTileRequestedEvent(ConveyorTile tile) {
+    /** Notifies listeners (e.g. disk quota LFU tracking) that {@code tile} was requested. */
+    public final void sendTileRequestedEvent(ConveyorTile tile) {
         if (listeners != null) {
             listeners.sendTileRequested(this, tile);
         }
@@ -1044,13 +1045,35 @@ public class GeoServerTileLayer extends TileLayer implements ProxyLayer, TileJSO
     }
 
     private boolean tryCacheFetch(ConveyorTile tile) {
+        return cacheFetch(tile, true);
+    }
+
+    /**
+     * Cache-only read for {@code tile}: same key and security derivation as {@link #getTile}, but never renders on a
+     * miss, never takes the per-tile lock, and leaves no trace on {@code tile} when the read itself fails, so it is
+     * safe to call speculatively and concurrently across members from a shared pool. On a hit, {@code tile}'s blob is
+     * populated exactly as {@link #getTile} would leave it.
+     *
+     * @return {@code true} if the tile was found in cache, {@code false} on a cache miss or a failed read
+     */
+    public boolean peekCache(ConveyorTile tile) {
+        return cacheFetch(tile, false);
+    }
+
+    /**
+     * @param recordError whether a failed read marks {@code tile} as errored; a speculative peek must not, since the
+     *     caller falls back to a normal render and {@link #finalizeTile} would otherwise refuse to set status 200
+     */
+    private boolean cacheFetch(ConveyorTile tile, boolean recordError) {
         int expireCache = this.getExpireCache((int) tile.getTileIndex()[2]);
         if (expireCache != GWCVars.CACHE_DISABLE_CACHE) {
             try {
                 return tile.retrieve(expireCache * 1000L);
             } catch (GeoWebCacheException gwce) {
                 LOGGER.info(gwce.getMessage());
-                tile.setErrorMsg(gwce.getMessage());
+                if (recordError) {
+                    tile.setErrorMsg(gwce.getMessage());
+                }
                 return false;
             }
         }

--- a/src/gwc/src/main/java/org/geoserver/gwc/wms/CachingWebMapService.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/wms/CachingWebMapService.java
@@ -25,6 +25,7 @@ import org.geoserver.gwc.layer.GeoServerTileLayer;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.HttpErrorCodeException;
 import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.WMS;
 import org.geoserver.wms.WebMap;
 import org.geoserver.wms.WebMapService;
 import org.geoserver.wms.map.RawMap;
@@ -117,9 +118,27 @@ public class CachingWebMapService implements MethodInterceptor {
         map.setContentDispositionHeader(null, "." + cachedTile.getMimeType().getFileExtension(), false);
 
         LinkedHashMap<String, String> headers = new LinkedHashMap<>();
-        GWC.setCacheControlHeaders(headers, layer, (int) cachedTile.getTileIndex()[2]);
+        boolean coalesced = GWC.isCoalescedLayers(request);
+        if (coalesced) {
+            // GWC.setCacheControlHeaders is per-single-layer (driven by the GWC layer's getExpireClients); match
+            // exactly what a live multi-layer GetMap produces instead, so a cached and uncached response agree
+            WMS.cacheMaxAge(request.isGet(), request.getLayers())
+                    .ifPresent(maxAge -> headers.putAll(WMS.cacheControlHeaders(maxAge)));
+        } else {
+            GWC.setCacheControlHeaders(headers, layer, (int) cachedTile.getTileIndex()[2]);
+        }
         GWC.setConditionalGetHeaders(headers, cachedTile, etag, request.getHttpRequestHeader("If-Modified-Since"));
         GWC.setCacheMetadataHeaders(headers, cachedTile, layer);
+        // a coalesced multi-layer tile's real per-member cache result (HIT/MISS/PARTIAL n/N) can't be expressed as
+        // a single Conveyor.CacheResult, so GWC.dispatchCoalesced smuggles it through the tile's own filtering
+        // parameters (never used for anything else on a tile that is never itself persisted or looked up). Removed
+        // right after reading: filteringParameters is otherwise a cache-key-derivation map (see
+        // GeoServerTileLayer#getModifiableParameters), so leaving the extra key behind would surprise any future
+        // code that iterates cachedTile's parameters expecting only real KVP-derived entries
+        String coalescedCacheResult = cachedTile.getFilteringParameters().remove(GWC.COALESCED_CACHE_RESULT_KEY);
+        if (coalescedCacheResult != null) {
+            headers.put("geowebcache-cache-result", coalescedCacheResult);
+        }
         headers.forEach((k, v) -> map.setResponseHeader(k, v));
 
         return map;

--- a/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
+++ b/src/gwc/src/main/resources/geowebcache-geoserver-context.xml
@@ -29,6 +29,13 @@
     <constructor-arg ref="gwcDefaultStorageFinder"/>
     <constructor-arg ref="gwcJdbcConfigurationStorage"/>
     <constructor-arg ref="gwcSynchEnv"/>
+    <constructor-arg ref="coalescedRequestSplitter"/>
+  </bean>
+
+  <bean id="coalescedRequestSplitter" class="org.geoserver.gwc.CoalescedRequestSplitter">
+    <constructor-arg ref="decoderContainer"/>
+    <constructor-arg ref="encoderContainer"/>
+    <constructor-arg ref="wmsGetMap"/>
   </bean>
 
   <bean id="gwcSynchEnv" class="org.geoserver.gwc.GWCSynchEnv" depends-on="geoWebCacheExtensions" lazy-init="false">

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCTest.java
@@ -95,7 +95,11 @@ import org.geoserver.platform.resource.Files;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.platform.resource.Resources;
 import org.geoserver.wms.DefaultWebMapService;
+import org.geoserver.wms.GetMap;
 import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.MapLayerInfo;
+import org.geoserver.wms.WMS;
+import org.geoserver.wms.WMSInfo;
 import org.geoserver.wms.WMSMapContent;
 import org.geoserver.wms.WebMap;
 import org.geoserver.wms.WebMapService;
@@ -103,11 +107,15 @@ import org.geoserver.wms.kvp.PaletteManager;
 import org.geoserver.wms.map.MetaTilingOutputFormat;
 import org.geoserver.wms.map.RawMap;
 import org.geotools.api.filter.Filter;
+import org.geotools.api.style.FeatureTypeStyle;
+import org.geotools.api.style.Style;
+import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.identity.FeatureIdImpl;
 import org.geotools.filter.text.cql2.CQL;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.geotools.styling.StyleBuilder;
 import org.geowebcache.GeoWebCacheEnvironment;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
@@ -124,12 +132,15 @@ import org.geowebcache.conveyor.ConveyorTile;
 import org.geowebcache.diskquota.DiskQuotaMonitor;
 import org.geowebcache.diskquota.QuotaStore;
 import org.geowebcache.diskquota.jdbc.JDBCConfiguration;
+import org.geowebcache.filter.parameters.RegexParameterFilter;
 import org.geowebcache.grid.BoundingBox;
 import org.geowebcache.grid.GridSet;
 import org.geowebcache.grid.GridSetBroker;
 import org.geowebcache.grid.GridSubset;
 import org.geowebcache.grid.GridSubsetFactory;
 import org.geowebcache.grid.SRS;
+import org.geowebcache.io.codec.ImageDecoderContainer;
+import org.geowebcache.io.codec.ImageEncoderContainer;
 import org.geowebcache.layer.TileLayer;
 import org.geowebcache.layer.TileLayerDispatcher;
 import org.geowebcache.mime.MimeType;
@@ -157,6 +168,8 @@ import org.springframework.context.ApplicationContext;
 public class GWCTest {
 
     private GWC mediator;
+
+    private CoalescedRequestSplitter splitter;
 
     private GWCConfig defaults;
 
@@ -202,6 +215,10 @@ public class GWCTest {
 
     private GWCSynchEnv synchEnv;
 
+    private WMSInfo wmsInfo;
+
+    private WMS wms;
+
     static Resource tmpDir() throws IOException {
         Resource root = Files.asResource(new File(System.getProperty("java.io.tmpdir", ".")));
         Resource directory = Resources.createRandom("tmp", "", root);
@@ -222,6 +239,9 @@ public class GWCTest {
 
         System.setProperty("ALLOW_ENV_PARAMETRIZATION", "true");
         System.setProperty("TEST_ENV_PROPERTY", "HSQL");
+
+        splitter = new CoalescedRequestSplitter(
+                mock(ImageDecoderContainer.class), mock(ImageEncoderContainer.class), mock(GetMap.class));
 
         catalog = mock(Catalog.class);
         layer = mockLayer("testLayer", new String[] {"style1", "style2"}, PublishedType.RASTER);
@@ -331,7 +351,8 @@ public class GWCTest {
                         storageFinder,
                         jdbcStorage,
                         blobStoreAggregator,
-                        synchEnv)
+                        synchEnv,
+                        splitter)
                 .createMock();
 
         expect(appContext.getBeanNamesForType(GWC.class))
@@ -362,6 +383,15 @@ public class GWCTest {
                 .anyTimes();
         expect(appContext.getBean("resourceLoader")).andReturn(loader).anyTimes();
         expect(appContext.isSingleton("resourceLoader")).andReturn(true).anyTimes();
+
+        wmsInfo = mock(WMSInfo.class);
+        wms = mock(WMS.class);
+        when(wms.getServiceInfo()).thenReturn(wmsInfo);
+        expect(appContext.getBeanNamesForType(WMS.class))
+                .andReturn(new String[] {"wms"})
+                .anyTimes();
+        expect(appContext.getBean("wms")).andReturn(wms).anyTimes();
+        expect(appContext.isSingleton("wms")).andReturn(true).anyTimes();
 
         replay(appContext);
 
@@ -409,7 +439,8 @@ public class GWCTest {
                 storageFinder,
                 jdbcStorage,
                 blobStoreAggregator,
-                synchEnv);
+                synchEnv,
+                splitter);
         mediator.setApplicationContext(appContext);
 
         mediator = spy(mediator);
@@ -1589,6 +1620,497 @@ public class GWCTest {
         newConfig.setMetaTilingThreads(0);
         mediator.saveConfig(newConfig);
         assertNull(mediator.getMetaTilingExecutor());
+    }
+
+    @Test
+    public void testSplitCoalescedRequestDisabled() throws Exception {
+        GetMapRequest request = coalescedRequest(new Envelope(0, 1, 0, 1), layer, layer);
+        StringBuilder mismatch = new StringBuilder();
+
+        assertNull(splitter.classifyCoalescedMembers(mediator, request, mismatch));
+        assertTrue(mismatch.toString().contains("multi-layer tile caching disabled"));
+    }
+
+    @Test
+    public void testSplitCoalescedRequestRequiresTransparentPng() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        GetMapRequest request = coalescedRequest(new Envelope(0, 1, 0, 1), layer, layer);
+        request.setFormat("image/jpeg");
+        StringBuilder mismatch = new StringBuilder();
+        assertNull(splitter.classifyCoalescedMembers(mediator, request, mismatch));
+        assertTrue(mismatch.toString().contains("requires transparent image/png"));
+
+        request.setFormat("image/png");
+        request.setTransparent(false);
+        mismatch = new StringBuilder();
+        assertNull(splitter.classifyCoalescedMembers(mediator, request, mismatch));
+        assertTrue(mismatch.toString().contains("requires transparent image/png"));
+    }
+
+    @Test
+    public void testSplitReslicesCqlFilterPerMember() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        LayerInfo layer2 = mockLayer("member2", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+        GeoServerTileLayer tl2 = mockTileLayer(new MapLayerInfo(layer2).getName(), List.of("EPSG:4326"));
+
+        // anchored to the client's EXACT text, no space around '=': ECQL.toCQL would normalize this to
+        // "NAME = 'a'" on re-encode, so this only passes if the member sees the client's own raw clause
+        RegexParameterFilter filter1 = new RegexParameterFilter();
+        filter1.setKey("CQL_FILTER");
+        filter1.setRegex("^NAME='a'$");
+        when(tl1.getParameterFilters()).thenReturn(List.of(filter1));
+
+        RegexParameterFilter filter2 = new RegexParameterFilter();
+        filter2.setKey("CQL_FILTER");
+        filter2.setRegex("^NAME='b'$");
+        when(tl2.getParameterFilters()).thenReturn(List.of(filter2));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, layer2);
+        request.setCQLFilter(List.of(CQL.toFilter("NAME='a'"), CQL.toFilter("NAME='b'")));
+        request.getRawKvp().put("CQL_FILTER", "NAME='a';NAME='b'");
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertEquals(0, mismatch.length());
+        assertNotNull(segments);
+        assertEquals(2, segments.size());
+    }
+
+    @Test
+    public void testSplitReslicesCqlFilterWithEmbeddedSemicolon() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        LayerInfo layer2 = mockLayer("member2", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+        GeoServerTileLayer tl2 = mockTileLayer(new MapLayerInfo(layer2).getName(), List.of("EPSG:4326"));
+
+        // member1's own clause has a ';' embedded in a string literal: a naive ';'-split would wrongly cut it in
+        // two ("NAME='a" and "b'"), so this only passes with a quote-aware split
+        RegexParameterFilter filter1 = new RegexParameterFilter();
+        filter1.setKey("CQL_FILTER");
+        filter1.setRegex("^NAME='a;b'$");
+        when(tl1.getParameterFilters()).thenReturn(List.of(filter1));
+
+        RegexParameterFilter filter2 = new RegexParameterFilter();
+        filter2.setKey("CQL_FILTER");
+        filter2.setRegex("^NAME='c'$");
+        when(tl2.getParameterFilters()).thenReturn(List.of(filter2));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, layer2);
+        request.setCQLFilter(List.of(CQL.toFilter("NAME='a;b'"), CQL.toFilter("NAME='c'")));
+        request.getRawKvp().put("CQL_FILTER", "NAME='a;b';NAME='c'");
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertEquals(0, mismatch.length());
+        assertNotNull(segments);
+        assertEquals(2, segments.size());
+    }
+
+    @Test
+    public void testSplitReplicatesSingleViewParamsToEveryMember() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        LayerInfo layer2 = mockLayer("member2", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+        GeoServerTileLayer tl2 = mockTileLayer(new MapLayerInfo(layer2).getName(), List.of("EPSG:4326"));
+
+        // both members must see the replicated value: if member2 instead saw "" (the pre-fix bug), it would not
+        // match this filter and the whole request would fall back to live
+        RegexParameterFilter filter1 = new RegexParameterFilter();
+        filter1.setKey("VIEWPARAMS");
+        filter1.setRegex("^a:1$");
+        when(tl1.getParameterFilters()).thenReturn(List.of(filter1));
+
+        RegexParameterFilter filter2 = new RegexParameterFilter();
+        filter2.setKey("VIEWPARAMS");
+        filter2.setRegex("^a:1$");
+        when(tl2.getParameterFilters()).thenReturn(List.of(filter2));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, layer2);
+        // GetMapKvpRequestReader.applyViewParams replicates a single parsed entry over every layer, but leaves the
+        // raw KVP as the client sent it: a single, unreplicated token
+        request.setViewParams(List.of(Map.of("a", "1"), Map.of("a", "1")));
+        request.getRawKvp().put("VIEWPARAMS", "a:1");
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertEquals(0, mismatch.length());
+        assertNotNull(segments);
+        assertEquals(2, segments.size());
+    }
+
+    @Test
+    public void testSplitCoalescedRequestAllMembersCacheable() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        LayerInfo layer2 = mockLayer("member2", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+        GeoServerTileLayer tl2 = mockTileLayer(new MapLayerInfo(layer2).getName(), List.of("EPSG:4326"));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, layer2);
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertEquals(0, mismatch.length());
+        assertNotNull(segments);
+        assertEquals(2, segments.size());
+        CoalescedRequestSplitter.CachedSegment segment1 = (CoalescedRequestSplitter.CachedSegment) segments.get(0);
+        CoalescedRequestSplitter.CachedSegment segment2 = (CoalescedRequestSplitter.CachedSegment) segments.get(1);
+        assertSame(tl1, segment1.member().tileLayer());
+        assertSame(tl2, segment2.member().tileLayer());
+        assertEquals("EPSG:4326", segment1.member().tile().getGridSetId());
+        assertEquals("EPSG:4326", segment2.member().tile().getGridSetId());
+    }
+
+    @Test
+    public void testSplitRejectsOnLabeling() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.VECTOR);
+        LayerInfo layer2 = mockLayer("member2", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+        mockTileLayer(new MapLayerInfo(layer2).getName(), List.of("EPSG:4326"));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, layer2);
+
+        StyleBuilder sb = new StyleBuilder();
+        request.getStyles().set(1, sb.createStyle(sb.createTextSymbolizer()));
+        StringBuilder mismatch = new StringBuilder();
+
+        assertNull(splitter.classifyCoalescedMembers(mediator, request, mismatch));
+        assertTrue(mismatch.toString().contains(new MapLayerInfo(layer2).getName()));
+        assertTrue(mismatch.toString().contains("draws labels or composites"));
+    }
+
+    @Test
+    public void testSplitRejectsOnCompositing() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1);
+
+        StyleBuilder sb = new StyleBuilder();
+        FeatureTypeStyle fts = sb.createFeatureTypeStyle(sb.createPolygonSymbolizer());
+        fts.getOptions().put(FeatureTypeStyle.COMPOSITE, "multiply");
+        Style compositingStyle = sb.createStyle();
+        compositingStyle.featureTypeStyles().add(fts);
+        request.getStyles().set(0, compositingStyle);
+        StringBuilder mismatch = new StringBuilder();
+
+        assertNull(splitter.classifyCoalescedMembers(mediator, request, mismatch));
+        assertTrue(mismatch.toString().contains(new MapLayerInfo(layer1).getName()));
+        assertTrue(mismatch.toString().contains("draws labels or composites"));
+    }
+
+    @Test
+    public void testSplitAllowsOutOfScaleLabels() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.VECTOR);
+        LayerInfo layer2 = mockLayer("member2", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+        mockTileLayer(new MapLayerInfo(layer2).getName(), List.of("EPSG:4326"));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, layer2);
+
+        StyleBuilder sb = new StyleBuilder();
+        // labels only active between scale denominators 1 and 2, nowhere near a zoom-0 world tile's scale
+        request.getStyles().set(1, sb.createStyle(sb.createTextSymbolizer(), 1, 2));
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertEquals(0, mismatch.length());
+        assertNotNull(segments);
+        assertEquals(2, segments.size());
+    }
+
+    @Test
+    public void testSplitAllowsOutOfScaleCompositing() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1);
+
+        StyleBuilder sb = new StyleBuilder();
+        // composite only active between scale denominators 1 and 2, nowhere near a zoom-0 world tile's scale
+        FeatureTypeStyle fts = sb.createFeatureTypeStyle(sb.createPolygonSymbolizer(), 1, 2);
+        fts.getOptions().put(FeatureTypeStyle.COMPOSITE, "multiply");
+        Style compositingStyle = sb.createStyle();
+        compositingStyle.featureTypeStyles().add(fts);
+        request.getStyles().set(0, compositingStyle);
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertEquals(0, mismatch.length());
+        assertNotNull(segments);
+        assertEquals(1, segments.size());
+    }
+
+    @Test
+    public void testClassifyBatchesNotCacheableMember() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        LayerInfo notCached = mockLayer("notCached", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, notCached);
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertNotNull(segments);
+        assertEquals(0, mismatch.length());
+        assertEquals(2, segments.size());
+        assertTrue(segments.get(0) instanceof CoalescedRequestSplitter.CachedSegment);
+        CoalescedRequestSplitter.LiveSegment live = (CoalescedRequestSplitter.LiveSegment) segments.get(1);
+        assertEquals(List.of(1), live.memberIndices());
+        assertTrue(live.reason().contains(new MapLayerInfo(notCached).getName()));
+        assertTrue(live.reason().contains("is not a tile layer"));
+    }
+
+    @Test
+    public void testClassifyGroupsConsecutiveNonCacheableMembersIntoOneLiveSegment() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        LayerInfo layer2 = mockLayer("member2", new String[] {}, PublishedType.RASTER);
+        LayerInfo layer3 = mockLayer("member3", new String[] {}, PublishedType.RASTER);
+        LayerInfo layer4 = mockLayer("member4", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+        // layer2 and layer3 are deliberately never registered as GWC tile layers
+        mockTileLayer(new MapLayerInfo(layer4).getName(), List.of("EPSG:4326"));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, layer2, layer3, layer4);
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertNotNull(segments);
+        assertEquals(0, mismatch.length());
+        // member1 cached, member2+member3 grouped into one live run, member4 cached
+        assertEquals(3, segments.size());
+        assertTrue(segments.get(0) instanceof CoalescedRequestSplitter.CachedSegment);
+        assertTrue(segments.get(1) instanceof CoalescedRequestSplitter.LiveSegment);
+        assertEquals(List.of(1, 2), ((CoalescedRequestSplitter.LiveSegment) segments.get(1)).memberIndices());
+        assertTrue(((CoalescedRequestSplitter.LiveSegment) segments.get(1))
+                .reason()
+                .contains(new MapLayerInfo(layer2).getName()));
+        assertTrue(segments.get(2) instanceof CoalescedRequestSplitter.CachedSegment);
+    }
+
+    @Test
+    public void testClassifyBatchesDifferentGridsetMember() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        LayerInfo layer2 = mockLayer("member2", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+
+        // same grid definition as EPSG:4326 (so the exact same bbox/tile matches), but registered
+        // under a different name: member2 resolves to a distinct gridSetId for that identical tile
+        GridSet renamedGridSet =
+                namedGridsetCopy("MY4326", gridSetBroker.getDefaults().worldEpsg4326());
+        GridSubset renamedSubset = GridSubsetFactory.createGridSubSet(renamedGridSet);
+        String name2 = new MapLayerInfo(layer2).getName();
+        GeoServerTileLayer tl2 = mock(GeoServerTileLayer.class);
+        when(tld.layerExists(eq(name2))).thenReturn(true);
+        when(tld.getTileLayer(eq(name2))).thenReturn(tl2);
+        when(tl2.getName()).thenReturn(name2);
+        when(tl2.isEnabled()).thenReturn(true);
+        when(tl2.getMimeTypes()).thenReturn(ImmutableList.of(MimeType.createFromFormat("image/png")));
+        when(tl2.getGridSubset(eq("MY4326"))).thenReturn(renamedSubset);
+        when(tl2.getGridSubsetsForSRS(eq(renamedGridSet.getSrs()))).thenReturn(ImmutableList.of(renamedSubset));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, layer2);
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertNotNull(segments);
+        assertEquals(0, mismatch.length());
+        assertEquals(2, segments.size());
+        assertTrue(segments.get(0) instanceof CoalescedRequestSplitter.CachedSegment);
+        CoalescedRequestSplitter.LiveSegment live = (CoalescedRequestSplitter.LiveSegment) segments.get(1);
+        assertEquals(List.of(1), live.memberIndices());
+        assertTrue(live.reason().contains(name2));
+        assertTrue(live.reason().contains("different gridset/tile"));
+    }
+
+    @Test
+    public void testSplitVerifiesAccessPerMember() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+        defaults.setSecurityEnabled(true);
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        LayerInfo layer2 = mockLayer("member2", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+        mockTileLayer(new MapLayerInfo(layer2).getName(), List.of("EPSG:4326"));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1, layer2);
+
+        String name1 = new MapLayerInfo(layer1).getName();
+        String name2 = new MapLayerInfo(layer2).getName();
+        doNothing().when(mediator).verifyAccessLayer(eq(name1), any());
+        doThrow(new SecurityException("denied")).when(mediator).verifyAccessLayer(eq(name2), any());
+        StringBuilder mismatch = new StringBuilder();
+
+        assertNull(splitter.classifyCoalescedMembers(mediator, request, mismatch));
+        assertTrue(mismatch.toString().contains(name2));
+        assertTrue(mismatch.toString().contains("access denied"));
+        verify(mediator).verifyAccessLayer(eq(name1), any());
+        verify(mediator).verifyAccessLayer(eq(name2), any());
+    }
+
+    @Test
+    public void testSplitSkipsAccessCheckWhenSecurityDisabled() throws Exception {
+        defaults.setMultiLayerCachingEnabled(true);
+        // securityEnabled left at its default: false
+
+        LayerInfo layer1 = mockLayer("member1", new String[] {}, PublishedType.RASTER);
+        GeoServerTileLayer tl1 = mockTileLayer(new MapLayerInfo(layer1).getName(), List.of("EPSG:4326"));
+
+        BoundingBox bounds = tl1.getGridSubset("EPSG:4326").boundsFromIndex(new long[] {0, 0, 0});
+        Envelope bbox = new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
+        GetMapRequest request = coalescedRequest(bbox, layer1);
+        StringBuilder mismatch = new StringBuilder();
+
+        List<CoalescedRequestSplitter.Segment> segments =
+                splitter.classifyCoalescedMembers(mediator, request, mismatch);
+
+        assertNotNull(segments);
+        verify(mediator, never()).verifyAccessLayer(any(), any());
+    }
+
+    @Test
+    public void testComputeRenderingDeadlineUnlimitedWhenNotConfigured() {
+        when(wmsInfo.getMaxRenderingTime()).thenReturn(0);
+
+        assertEquals(-1L, splitter.computeRenderingDeadline());
+    }
+
+    @Test
+    public void testComputeRenderingDeadlineAddsConfiguredSecondsToNow() {
+        when(wmsInfo.getMaxRenderingTime()).thenReturn(5);
+
+        long before = System.currentTimeMillis();
+        long deadline = splitter.computeRenderingDeadline();
+        long after = System.currentTimeMillis();
+
+        assertTrue(deadline >= before + 5000);
+        assertTrue(deadline <= after + 5000);
+    }
+
+    @Test
+    public void testMemoryLimits() {
+        when(wmsInfo.getMaxRequestMemory()).thenReturn(10_000); // 10 MB, comfortably over a 256x256 stack
+        GetMapRequest request = new GetMapRequest();
+        request.setWidth(256);
+        request.setHeight(256);
+
+        assertFalse(splitter.exceedsMaxRequestMemory(request));
+    }
+
+    @Test
+    public void testUnlimitedMemoryLimits() {
+        when(wmsInfo.getMaxRequestMemory()).thenReturn(0);
+        GetMapRequest request = new GetMapRequest();
+        request.setWidth(256);
+        request.setHeight(256);
+
+        assertFalse(splitter.exceedsMaxRequestMemory(request));
+    }
+
+    @Test
+    public void testMemoryLimitsExceeded() {
+        when(wmsInfo.getMaxRequestMemory()).thenReturn(1); // 1 KB, way under a 256x256 ARGB tile stack
+        GetMapRequest request = new GetMapRequest();
+        request.setWidth(256);
+        request.setHeight(256);
+
+        assertTrue(splitter.exceedsMaxRequestMemory(request));
+    }
+
+    /** A tiled, transparent-PNG multi-layer {@code GetMap} request over the given {@code LAYERS} members. */
+    private GetMapRequest coalescedRequest(Envelope bbox, LayerInfo... members) throws Exception {
+        GetMapRequest request = new GetMapRequest();
+        Map<String, String> rawKvp = new CaseInsensitiveMap<>(new HashMap<>());
+        request.setRawKvp(rawKvp);
+        request.setFormat("image/png");
+        request.setTransparent(true);
+        request.setTiled(true);
+        request.setSRS("EPSG:4326");
+        request.setCrs(CRS.decode("EPSG:4326"));
+        request.setWidth(256);
+        request.setHeight(256);
+        request.setBbox(bbox);
+        rawKvp.put("BBOX", bbox.getMinX() + "," + bbox.getMinY() + "," + bbox.getMaxX() + "," + bbox.getMaxY());
+
+        List<MapLayerInfo> layers = new ArrayList<>();
+        List<Style> styles = new ArrayList<>();
+        StringBuilder layersKvp = new StringBuilder();
+        for (LayerInfo member : members) {
+            MapLayerInfo mapLayerInfo = new MapLayerInfo(member);
+            layers.add(mapLayerInfo);
+            styles.add(CommonFactoryFinder.getStyleFactory().createStyle());
+            if (layersKvp.length() > 0) layersKvp.append(',');
+            layersKvp.append(mapLayerInfo.getName());
+        }
+        request.setLayers(layers);
+        request.setStyles(styles);
+        rawKvp.put("layers", layersKvp.toString());
+        return request;
     }
 
     @AfterClass

--- a/src/gwc/src/test/java/org/geoserver/gwc/MultiLayerCoalescingIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/MultiLayerCoalescingIntegrationTest.java
@@ -1,0 +1,540 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import static org.awaitility.Awaitility.await;
+import static org.geoserver.data.test.MockData.BASIC_POLYGONS;
+import static org.geoserver.data.test.MockData.FORESTS;
+import static org.geoserver.data.test.MockData.LAKES;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import javax.imageio.ImageIO;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.http.client.utils.DateUtils;
+import org.geoserver.catalog.CatalogBuilder;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.geoserver.gwc.layer.TileLayerInfoUtil;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geoserver.wms.WMSInfo;
+import org.geotools.image.test.ImageAssert;
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.GridSubset;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.storage.StorageException;
+import org.geowebcache.storage.StorageObject;
+import org.geowebcache.storage.TileObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** Multi-layer tile coalescing test. */
+public class MultiLayerCoalescingIntegrationTest extends GeoServerSystemTestSupport {
+
+    private String layer1;
+
+    private String layer2;
+
+    private GridSubset gridSubset;
+
+    @Before
+    public void enableMultiLayerCaching() throws Exception {
+        layer1 = getLayerId(BASIC_POLYGONS);
+        layer2 = getLayerId(LAKES);
+
+        GWC gwc = GWC.get();
+        GWCConfig config = gwc.getConfig();
+        config.setDirectWMSIntegrationEnabled(true);
+        config.setMultiLayerCachingEnabled(true);
+        gwc.saveConfig(config);
+
+        TileLayer tileLayer = gwc.getTileLayerByName(layer1);
+        gridSubset = tileLayer.getGridSubset("EPSG:4326");
+
+        truncate(layer1);
+        truncate(layer2);
+    }
+
+    @After
+    public void resetConfig() throws Exception {
+        GWC gwc = GWC.get();
+        GWCConfig config = gwc.getConfig();
+        config.setDirectWMSIntegrationEnabled(false);
+        config.setMultiLayerCachingEnabled(false);
+        gwc.saveConfig(config);
+    }
+
+    private void truncate(String layerName) throws Exception {
+        GWC.get().truncate(layerName);
+    }
+
+    private String coalescedGetMap(String layers) {
+        long[] coverage = gridSubset.getCoverage(0);
+        long[] tileIndex = {coverage[0], coverage[1], coverage[4]};
+        BoundingBox bounds = gridSubset.boundsFromIndex(tileIndex);
+
+        return "wms?service=WMS&request=GetMap&version=1.1.1&format=image/png&transparent=true&tiled=true"
+                + "&layers=" + layers
+                + "&srs=" + gridSubset.getSRS()
+                + "&width=" + gridSubset.getGridSet().getTileWidth()
+                + "&height=" + gridSubset.getGridSet().getTileHeight()
+                + "&bbox=" + bounds;
+    }
+
+    private TileObject sampleTile(String layerName) throws StorageException {
+        long[] coverage = gridSubset.getCoverage(0);
+        long[] tileIndex = {coverage[0], coverage[1], coverage[4]};
+        TileObject tileObject = TileObject.createQueryTileObject(
+                layerName, tileIndex, gridSubset.getName(), "image/png", Collections.emptyMap());
+        GWC.get().getCompositeBlobStore().get(tileObject);
+        return tileObject;
+    }
+
+    /**
+     * Waits for the member's own tile save to land: the conveyor tile save runs on GWC's metatiling executor, so it can
+     * still be in flight when the coalesced request returns.
+     */
+    private void awaitCached(String layerName) {
+        await().atMost(5, TimeUnit.SECONDS).until(() -> sampleTile(layerName).getStatus() != StorageObject.Status.MISS);
+    }
+
+    /**
+     * Waits for a request with these exact params to become a full cache hit, going through the real HTTP dispatch path
+     * rather than reconstructing GWC's internal parameters key by hand (e.g. its VIEWPARAMS hashing), which this test
+     * has no reliable way to reproduce.
+     */
+    private void awaitCoalescedHit(String url) {
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> "HIT".equals(getAsServletResponse(url).getHeader("geowebcache-cache-result")));
+    }
+
+    @Test
+    public void testCoalescedRequest() throws Exception {
+        // caches start empty
+        assertEquals(StorageObject.Status.MISS, sampleTile(layer1).getStatus());
+        assertEquals(StorageObject.Status.MISS, sampleTile(layer2).getStatus());
+
+        MockHttpServletResponse coalescedResponse = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        assertEquals(200, coalescedResponse.getStatus());
+        assertEquals("image/png", coalescedResponse.getContentType());
+
+        // stacking: the coalesced tile is neither member alone
+        MockHttpServletResponse layer1Response = getAsServletResponse(coalescedGetMap(layer1));
+        MockHttpServletResponse layer2Response = getAsServletResponse(coalescedGetMap(layer2));
+        byte[] coalescedBytes = coalescedResponse.getContentAsByteArray();
+        assertFalse(Arrays.equals(coalescedBytes, layer1Response.getContentAsByteArray()));
+        assertFalse(Arrays.equals(coalescedBytes, layer2Response.getContentAsByteArray()));
+
+        // cache population: each member's own tile cache now holds a real blob, keyed under its own layer name,
+        // reusable by an ordinary single-layer request
+        awaitCached(layer1);
+        awaitCached(layer2);
+        TileObject member1Tile = sampleTile(layer1);
+        TileObject member2Tile = sampleTile(layer2);
+        assertNotNull(member1Tile.getBlob());
+        assertNotNull(member2Tile.getBlob());
+
+        // a second coalesced request is now an all-cache-hit
+        MockHttpServletResponse secondResponse = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        assertEquals(200, secondResponse.getStatus());
+        assertEquals("HIT", secondResponse.getHeader("geowebcache-cache-result"));
+        assertArrayEquals(coalescedBytes, secondResponse.getContentAsByteArray());
+    }
+
+    @Test
+    public void testCoalescedRequestSupportsIfModifiedSince() throws Exception {
+        String url = coalescedGetMap(layer1 + "," + layer2);
+
+        MockHttpServletResponse response = getAsServletResponse(url);
+        assertEquals(200, response.getStatus());
+        String lastModifiedHeader = response.getHeader("Last-Modified");
+        assertNotNull(lastModifiedHeader);
+        Date lastModified = DateUtils.parseDate(lastModifiedHeader);
+        // the assembled tile's own creation time, not the TileObject default of epoch 0: catches the tile being
+        // reported as unchanged since 1970 regardless of when it was actually assembled
+        assertTrue(lastModified.after(new Date(System.currentTimeMillis() - 60000)));
+
+        assertEquals(
+                HttpServletResponse.SC_NOT_MODIFIED,
+                dispatch(getRequest(url, lastModifiedHeader), "UTF-8").getStatus());
+
+        String past = DateUtils.formatDate(new Date(lastModified.getTime() - 5000));
+        assertEquals(
+                HttpServletResponse.SC_OK,
+                dispatch(getRequest(url, past), "UTF-8").getStatus());
+
+        String future = DateUtils.formatDate(new Date(lastModified.getTime() + 5000));
+        assertEquals(
+                HttpServletResponse.SC_NOT_MODIFIED,
+                dispatch(getRequest(url, future), "UTF-8").getStatus());
+    }
+
+    private MockHttpServletRequest getRequest(String url, String ifModifiedSince) {
+        MockHttpServletRequest httpReq = createRequest(url);
+        httpReq.setMethod("GET");
+        httpReq.setContent(new byte[] {});
+        httpReq.addHeader("If-Modified-Since", ifModifiedSince);
+        return httpReq;
+    }
+
+    @Test
+    public void testCoalescedResultMatchesLiveRender() throws Exception {
+        MockHttpServletResponse coalescedResponse = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        assertEquals(200, coalescedResponse.getStatus());
+        BufferedImage coalesced = ImageIO.read(new ByteArrayInputStream(coalescedResponse.getContentAsByteArray()));
+
+        GWC gwc = GWC.get();
+        GWCConfig config = gwc.getConfig();
+        config.setMultiLayerCachingEnabled(false);
+        gwc.saveConfig(config);
+
+        MockHttpServletResponse liveResponse = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        assertEquals(200, liveResponse.getStatus());
+        BufferedImage live = ImageIO.read(new ByteArrayInputStream(liveResponse.getContentAsByteArray()));
+
+        // stacking two independently-cached tiles must reproduce the live combined render, modulo antialiasing
+        // drift at polygon edges from rendering each member separately instead of onto one shared canvas; flatten
+        // onto white first, since a transparent pixel's RGB is otherwise unconstrained and can differ between the
+        // two renders without any visible difference
+        ImageAssert.assertEquals(flattenOnWhite(live), flattenOnWhite(coalesced), 20);
+    }
+
+    /** Composites {@code image} over an opaque white background, so fully-transparent pixels compare equal. */
+    private static BufferedImage flattenOnWhite(BufferedImage image) {
+        BufferedImage flattened = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = flattened.createGraphics();
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+        graphics.drawImage(image, 0, 0, null);
+        graphics.dispose();
+        return flattened;
+    }
+
+    @Test
+    public void testPartialCacheResultWhenOnlySomeMembersAreCached() throws Exception {
+        // populate both members' caches
+        getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        awaitCached(layer1);
+        awaitCached(layer2);
+
+        // evict just one member: the next coalesced request hits layer1 but re-renders layer2
+        truncate(layer2);
+        assertEquals(StorageObject.Status.MISS, sampleTile(layer2).getStatus());
+
+        MockHttpServletResponse response = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+
+        assertEquals(200, response.getStatus());
+        assertEquals("PARTIAL 1/2", response.getHeader("geowebcache-cache-result"));
+
+        // the re-rendered member is now cached again too
+        awaitCached(layer2);
+    }
+
+    @Test
+    public void testNonCacheableMemberIsLiveRenderedAndSplicedIntoTheStack() throws Exception {
+        // populate layer1's own cache first
+        getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        awaitCached(layer1);
+
+        GWC gwc = GWC.get();
+        TileLayer forestsTileLayer = gwc.getTileLayerByName(getLayerId(FORESTS));
+        forestsTileLayer.setEnabled(false);
+        try {
+            MockHttpServletResponse response =
+                    getAsServletResponse(coalescedGetMap(layer1 + "," + getLayerId(FORESTS)));
+
+            assertEquals(200, response.getStatus());
+            assertEquals("image/png", response.getContentType());
+            // layer1 is a cache hit, the disabled member always misses
+            assertEquals("PARTIAL 1/2", response.getHeader("geowebcache-cache-result"));
+
+            // stacking happened: the coalesced result differs from layer1 rendered alone
+            byte[] coalescedBytes = response.getContentAsByteArray();
+            MockHttpServletResponse layer1Response = getAsServletResponse(coalescedGetMap(layer1));
+            assertFalse(Arrays.equals(coalescedBytes, layer1Response.getContentAsByteArray()));
+        } finally {
+            forestsTileLayer.setEnabled(true);
+        }
+    }
+
+    @Test
+    public void testPartialCacheResultCountsEveryMemberOfABatchedLiveRun() throws Exception {
+        // populate both cacheable members' caches first
+        getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        awaitCached(layer1);
+        awaitCached(layer2);
+
+        GWC gwc = GWC.get();
+        TileLayer forestsTileLayer = gwc.getTileLayerByName(getLayerId(FORESTS));
+        forestsTileLayer.setEnabled(false);
+        try {
+            String forests = getLayerId(FORESTS);
+            String layers = layer1 + "," + forests + "," + forests + "," + layer2;
+            MockHttpServletResponse response = getAsServletResponse(coalescedGetMap(layers));
+
+            assertEquals(200, response.getStatus());
+            // 4 original members: layer1 and layer2 are cache hits, both forests slots always miss
+            assertEquals("PARTIAL 2/4", response.getHeader("geowebcache-cache-result"));
+        } finally {
+            forestsTileLayer.setEnabled(true);
+        }
+    }
+
+    @Test
+    public void testCacheControl() throws Exception {
+        setCachingMetadata(layer1, true, 600);
+        setCachingMetadata(layer2, true, 300);
+
+        MockHttpServletResponse response = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        assertEquals(200, response.getStatus());
+        assertEquals("max-age=300, must-revalidate", response.getHeader("Cache-Control"));
+        assertNotNull(response.getHeader("Expires"));
+    }
+
+    @Test
+    public void testNoCacheControlWhenAnyLayerDisablesCaching() throws Exception {
+        setCachingMetadata(layer1, true, 600);
+        setCachingMetadata(layer2, false, 0);
+
+        MockHttpServletResponse response = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        assertEquals(200, response.getStatus());
+        assertNull(response.getHeader("Cache-Control"));
+    }
+
+    @Test
+    public void testLiveRender() throws Exception {
+        GWC gwc = GWC.get();
+        GWCConfig config = gwc.getConfig();
+        config.setMultiLayerCachingEnabled(false);
+        gwc.saveConfig(config);
+
+        MockHttpServletResponse response = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        assertEquals(200, response.getStatus());
+        assertEquals("image/png", response.getContentType());
+        assertEquals("MISS", response.getHeader("geowebcache-cache-result"));
+        assertTrue(response.getHeader("geowebcache-miss-reason").contains("more than one layer requested"));
+
+        // and neither member's cache was touched
+        assertEquals(StorageObject.Status.MISS, sampleTile(layer1).getStatus());
+        assertEquals(StorageObject.Status.MISS, sampleTile(layer2).getStatus());
+    }
+
+    @Test
+    public void testWithLabeledStyle() throws Exception {
+        getTestData().addStyle("labeled", "labeled.sld", MultiLayerCoalescingIntegrationTest.class, getCatalog());
+
+        // layer1 keeps its default style, layer2 uses the labeled one (positional, aligned to LAYERS)
+        String url = coalescedGetMap(layer1 + "," + layer2) + "&styles=,labeled";
+        MockHttpServletResponse response = getAsServletResponse(url);
+
+        assertEquals("MISS", response.getHeader("geowebcache-cache-result"));
+        assertTrue(response.getHeader("geowebcache-miss-reason").contains("draws labels or composites"));
+
+        // the rejected coalesced attempt never populated either member's cache
+        assertEquals(StorageObject.Status.MISS, sampleTile(layer1).getStatus());
+        assertEquals(StorageObject.Status.MISS, sampleTile(layer2).getStatus());
+    }
+
+    @Test
+    public void testWithCqlFilters() throws Exception {
+        GeoServerTileLayer tileLayer1 = (GeoServerTileLayer) GWC.get().getTileLayerByName(layer1);
+        GeoServerTileLayer tileLayer2 = (GeoServerTileLayer) GWC.get().getTileLayerByName(layer2);
+        TileLayerInfoUtil.updateAcceptAllRegExParameterFilter(tileLayer1.getInfo(), "CQL_FILTER", true);
+        TileLayerInfoUtil.updateAcceptAllRegExParameterFilter(tileLayer2.getInfo(), "CQL_FILTER", true);
+        GWC.get().save(tileLayer1);
+        GWC.get().save(tileLayer2);
+
+        // one clause per member, aligned to LAYERS order; each member must see only its own slice
+        String url = coalescedGetMap(layer1 + "," + layer2) + "&CQL_FILTER=INCLUDE;EXCLUDE";
+        MockHttpServletResponse response = getAsServletResponse(url);
+
+        assertEquals(200, response.getStatus());
+        assertEquals("image/png", response.getContentType());
+        // reaching a real cache dispatch
+        assertNull(response.getHeader("geowebcache-miss-reason"));
+        assertNotNull(response.getHeader("geowebcache-cache-result"));
+    }
+
+    @Test
+    public void testReplicatedViewParamsAppliesToEveryMembersCacheKey() throws Exception {
+        // VIEWPARAMS has to be a cacheable parameter for both members
+        for (String layerName : new String[] {layer1, layer2}) {
+            GeoServerTileLayer tileLayer = (GeoServerTileLayer) GWC.get().getTileLayerByName(layerName);
+            TileLayerInfoUtil.updateAcceptAllRegExParameterFilter(tileLayer.getInfo(), "VIEWPARAMS", true);
+            GWC.get().save(tileLayer);
+            truncate(layerName);
+        }
+
+        // GetMapKvpRequestReader.applyViewParams replicates a single entry over every layer, so both members
+        // render with a:1; the raw VIEWPARAMS mirror used for the cache key must reflect that for BOTH members,
+        // not just the first one
+        String urlA1 = coalescedGetMap(layer1 + "," + layer2) + "&VIEWPARAMS=a:1";
+        MockHttpServletResponse first = getAsServletResponse(urlA1);
+        assertEquals("image/png", first.getContentType());
+        // both members are now keyed by the replicated value, not just member1: a repeat of this exact request
+        // becomes a full HIT only once member2's tile is cached under the replicated a:1 key too - if the fix
+        // regressed back to writing "" for member2, that member would never hit and this would time out
+        awaitCoalescedHit(urlA1);
+
+        // a:2 renders differently, so neither member may be served from the a:1 run
+        MockHttpServletResponse second =
+                getAsServletResponse(coalescedGetMap(layer1 + "," + layer2) + "&VIEWPARAMS=a:2");
+        assertEquals("image/png", second.getContentType());
+        assertEquals("MISS", second.getHeader("geowebcache-cache-result"));
+
+        // and a plain request with no VIEWPARAMS at all must not be served the a:1-rendered tile either
+        MockHttpServletResponse plain = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+        assertEquals("image/png", plain.getContentType());
+        assertEquals("MISS", plain.getHeader("geowebcache-cache-result"));
+    }
+
+    /** A two-layer group, so a {@code LAYERS} slot naming it expands into two members. */
+    private LayerGroupInfo addTwoLayerGroup(String name) throws Exception {
+        LayerGroupInfo group = getCatalog().getFactory().createLayerGroup();
+        group.setName(name);
+        group.getLayers().add(getCatalog().getLayerByName(getLayerId(BASIC_POLYGONS)));
+        group.getLayers().add(getCatalog().getLayerByName(getLayerId(FORESTS)));
+        group.getStyles().add(null);
+        group.getStyles().add(null);
+        new CatalogBuilder(getCatalog()).calculateLayerGroupBounds(group);
+        getCatalog().add(group);
+        return group;
+    }
+
+    @Test
+    public void testExpandedLayerGroupIsCoalescedWhenNoPerLayerParameterIsPresent() throws Exception {
+        LayerGroupInfo group = addTwoLayerGroup("plainCoalescingGroup");
+        try {
+            // 2 raw LAYERS slots, 3 members once the group is expanded, but nothing per-layer to slice: the
+            // members line up positionally with nothing, so each is cached under its own name as usual
+            MockHttpServletResponse response = getAsServletResponse(coalescedGetMap("plainCoalescingGroup," + layer2));
+
+            assertEquals(200, response.getStatus());
+            assertEquals("image/png", response.getContentType());
+            assertNull(response.getHeader("geowebcache-miss-reason"));
+            assertNotNull(response.getHeader("geowebcache-cache-result"));
+
+            // the group's members are cached individually, so the whole request becomes a hit
+            awaitCoalescedHit(coalescedGetMap("plainCoalescingGroup," + layer2));
+        } finally {
+            getCatalog().remove(group);
+        }
+    }
+
+    @Test
+    public void testExpandedLayerGroupFallsBackAndStillMatchesTheLiveRender() throws Exception {
+        LayerGroupInfo group = addTwoLayerGroup("coalescingGroup");
+        try {
+            getTestData().addStyle("labeled", "labeled.sld", MultiLayerCoalescingIntegrationTest.class, getCatalog());
+
+            // 2 raw LAYERS slots but 3 members after the group is expanded: a positional slice of STYLES would
+            // hand "labeled" to the group's second member instead of layer2, silently drawing the wrong image
+            String url = coalescedGetMap("coalescingGroup," + layer2) + "&styles=,labeled";
+            MockHttpServletResponse response = getAsServletResponse(url);
+
+            assertEquals(200, response.getStatus());
+            assertEquals("image/png", response.getContentType());
+            assertEquals("MISS", response.getHeader("geowebcache-cache-result"));
+            assertTrue(response.getHeader("geowebcache-miss-reason").contains("a LAYERS entry was expanded"));
+            BufferedImage coalesced = ImageIO.read(new ByteArrayInputStream(response.getContentAsByteArray()));
+
+            GWC gwc = GWC.get();
+            GWCConfig config = gwc.getConfig();
+            config.setMultiLayerCachingEnabled(false);
+            gwc.saveConfig(config);
+            MockHttpServletResponse liveResponse = getAsServletResponse(url);
+            assertEquals(200, liveResponse.getStatus());
+            BufferedImage live = ImageIO.read(new ByteArrayInputStream(liveResponse.getContentAsByteArray()));
+
+            ImageAssert.assertEquals(flattenOnWhite(live), flattenOnWhite(coalesced), 20);
+        } finally {
+            getCatalog().remove(group);
+        }
+    }
+
+    @Test
+    public void testAllMembersLiveFallsBackWithoutAssembling() throws Exception {
+        GWC gwc = GWC.get();
+        TileLayer layer1TileLayer = gwc.getTileLayerByName(layer1);
+        TileLayer forestsTileLayer = gwc.getTileLayerByName(getLayerId(FORESTS));
+        layer1TileLayer.setEnabled(false);
+        forestsTileLayer.setEnabled(false);
+        try {
+            MockHttpServletResponse response =
+                    getAsServletResponse(coalescedGetMap(layer1 + "," + getLayerId(FORESTS)));
+
+            assertEquals(200, response.getStatus());
+            assertEquals("image/png", response.getContentType());
+            assertEquals("MISS", response.getHeader("geowebcache-cache-result"));
+            assertTrue(response.getHeader("geowebcache-miss-reason")
+                    .contains("no member of the coalesced request is cacheable"));
+
+            // no per-member tile was ever assembled or cached
+            assertEquals(StorageObject.Status.MISS, sampleTile(layer1).getStatus());
+        } finally {
+            layer1TileLayer.setEnabled(true);
+            forestsTileLayer.setEnabled(true);
+        }
+    }
+
+    @Test
+    public void testMemoryLimits() throws Exception {
+        // GWC's projected peak is (members + 1) * tileWidth * tileHeight * 4 bytes ARGB = 3 * 256 * 256 * 4 = 768 KB
+        // for this 2-member request. The live fallback render's own memory check (RenderedImageMapOutputFormat)
+        // uses a different, much smaller estimate: just the output buffer (256 * 256 * 4 = 256 KB) plus per-style
+        // back-buffers, which is 0 here since both layers use plain single-pass styles. 400 KB sits between the
+        // two: below GWC's conservative peak (guard fires) but above what the live render actually needs (fallback
+        // succeeds instead of also being denied by the live path's own limit).
+        setMaxRequestMemory(400);
+        try {
+            MockHttpServletResponse response = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+
+            // the guard is a fallback, not a hard error: the live combined render still succeeds
+            assertEquals(200, response.getStatus());
+            assertEquals("image/png", response.getContentType());
+            assertEquals("MISS", response.getHeader("geowebcache-cache-result"));
+            assertTrue(response.getHeader("geowebcache-miss-reason").contains("exceed max request memory"));
+
+            // fired before loading any tile: neither member's cache was touched
+            assertEquals(StorageObject.Status.MISS, sampleTile(layer1).getStatus());
+            assertEquals(StorageObject.Status.MISS, sampleTile(layer2).getStatus());
+        } finally {
+            setMaxRequestMemory(0);
+        }
+    }
+
+    private void setMaxRequestMemory(int kilobytes) throws Exception {
+        GeoServer geoServer = getGeoServer();
+        WMSInfo wms = geoServer.getService(WMSInfo.class);
+        wms.setMaxRequestMemory(kilobytes);
+        geoServer.save(wms);
+    }
+
+    private void setCachingMetadata(String layerId, boolean cachingEnabled, int cacheAgeMax) throws Exception {
+        FeatureTypeInfo ft = getCatalog().getResourceByName(layerId, FeatureTypeInfo.class);
+        ft.getMetadata().put(ResourceInfo.CACHING_ENABLED, cachingEnabled);
+        ft.getMetadata().put(ResourceInfo.CACHE_AGE_MAX, cacheAgeMax);
+        getCatalog().save(ft);
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/MultiLayerCoalescingSecurityIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/MultiLayerCoalescingSecurityIntegrationTest.java
@@ -1,0 +1,193 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import static org.geoserver.data.test.MockData.BASIC_POLYGONS;
+import static org.geoserver.data.test.MockData.LAKES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.gwc.config.GWCConfig;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.security.CatalogMode;
+import org.geoserver.security.GeoServerRoleStore;
+import org.geoserver.security.GeoServerUserGroupStore;
+import org.geoserver.security.TestResourceAccessManager;
+import org.geoserver.security.VectorAccessLimits;
+import org.geoserver.security.impl.AbstractUserGroupService;
+import org.geoserver.security.impl.GeoServerRole;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.api.filter.Filter;
+import org.geowebcache.grid.BoundingBox;
+import org.geowebcache.grid.GridSubset;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.storage.StorageObject;
+import org.geowebcache.storage.TileObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Data-security coverage for multi-layer tile coalescing: a coalesced request where one member's effective read filter
+ * excludes everything for the requesting user must fall back to a live render rather than serve or populate that
+ * member's cache.
+ */
+public class MultiLayerCoalescingSecurityIntegrationTest extends GeoServerSystemTestSupport {
+
+    private static final String RESTRICTED_USER = "restricted";
+
+    private static final String HIDDEN_USER = "hidden";
+
+    private String layer1;
+
+    private String layer2;
+
+    private GridSubset gridSubset;
+
+    /** Enable the Spring Security auth filters so requests carrying Basic auth are actually authenticated. */
+    @Override
+    protected List<javax.servlet.Filter> getFilters() {
+        return Collections.singletonList((javax.servlet.Filter) GeoServerExtensions.bean("filterChainProxy"));
+    }
+
+    @Override
+    protected void setUpSpring(List<String> springContextLocations) {
+        super.setUpSpring(springContextLocations);
+        springContextLocations.add("classpath:/org/geoserver/wms/ResourceAccessManagerContext.xml");
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+
+        GWC gwc = GWC.get();
+        GWCConfig config = gwc.getConfig();
+        config.setDirectWMSIntegrationEnabled(true);
+        config.setMultiLayerCachingEnabled(true);
+        config.setSecurityEnabled(true);
+        gwc.saveConfig(config);
+
+        GeoServerUserGroupStore userGroupStore = getSecurityManager()
+                .loadUserGroupService(AbstractUserGroupService.DEFAULT_NAME)
+                .createStore();
+        userGroupStore.addUser(userGroupStore.createUserObject(RESTRICTED_USER, RESTRICTED_USER, true));
+        userGroupStore.addUser(userGroupStore.createUserObject(HIDDEN_USER, HIDDEN_USER, true));
+        userGroupStore.store();
+
+        GeoServerRoleStore roleStore =
+                getSecurityManager().getActiveRoleService().createStore();
+        GeoServerRole role = roleStore.createRoleObject("ROLE_DUMMY");
+        roleStore.addRole(role);
+        roleStore.associateRoleToUser(role, RESTRICTED_USER);
+        roleStore.associateRoleToUser(role, HIDDEN_USER);
+        roleStore.store();
+
+        Catalog catalog = getCatalog();
+        FeatureTypeInfo restrictedLayer = catalog.getResourceByName(getLayerId(LAKES), FeatureTypeInfo.class);
+
+        // modeled on GWCDataSecurityTest's TestResourceAccessManager setup, the mechanism that exercises this
+        // specific case: the user is authenticated and the layer is nameable, only its filtered content differs,
+        // so the request reaches WebMapService.getMap instead of being rejected earlier by the security filter chain
+        TestResourceAccessManager accessManager =
+                (TestResourceAccessManager) applicationContext.getBean("testResourceAccessManager");
+        // CatalogMode.HIDE + Filter.EXCLUDE makes the secured catalog return null from getLayerByName outright
+        // (see GWC.verifyAccessLayer's own comment: "HIDE+EXCLUDE layers are already gone") - that fails even
+        // earlier, at WMS KVP parsing, never reaching GWC at all. CHALLENGE keeps the layer nameable/resolvable
+        // as a SecuredLayerInfo wrapping a Filter.EXCLUDE read filter, which is the case verifyAccessLayer checks.
+        // Must be VectorAccessLimits (not the bare DataAccessLimits superclass): SecureFeatureSources, invoked while
+        // GetMapKvpRequestReader validates the requested style against the feature type, rejects a plain
+        // DataAccessLimits on a vector layer with "unexpected AccessLimits class".
+        VectorAccessLimits excludeEverything =
+                new VectorAccessLimits(CatalogMode.CHALLENGE, null, Filter.EXCLUDE, null, null);
+        accessManager.putLimits(RESTRICTED_USER, restrictedLayer, excludeEverything);
+
+        // HIDE makes the secured catalog return null from getLayerByName outright, so this user's coalesced
+        // request must fail at WMS KVP parsing, before ever reaching GWC.dispatch
+        VectorAccessLimits hideEverything = new VectorAccessLimits(CatalogMode.HIDE, null, Filter.EXCLUDE, null, null);
+        accessManager.putLimits(HIDDEN_USER, restrictedLayer, hideEverything);
+    }
+
+    @Before
+    public void lookUpTestFixtures() throws Exception {
+        layer1 = getLayerId(BASIC_POLYGONS);
+        layer2 = getLayerId(LAKES);
+
+        TileLayer tileLayer = GWC.get().getTileLayerByName(layer1);
+        gridSubset = tileLayer.getGridSubset("EPSG:4326");
+    }
+
+    private String coalescedGetMap(String layers) {
+        long[] coverage = gridSubset.getCoverage(0);
+        long[] tileIndex = {coverage[0], coverage[1], coverage[4]};
+        BoundingBox bounds = gridSubset.boundsFromIndex(tileIndex);
+
+        return "wms?service=WMS&request=GetMap&version=1.1.1&format=image/png&transparent=true&tiled=true"
+                + "&layers=" + layers
+                + "&srs=" + gridSubset.getSRS()
+                + "&width=" + gridSubset.getGridSet().getTileWidth()
+                + "&height=" + gridSubset.getGridSet().getTileHeight()
+                + "&bbox=" + bounds;
+    }
+
+    private TileObject sampleTile(String layerName) throws Exception {
+        long[] coverage = gridSubset.getCoverage(0);
+        long[] tileIndex = {coverage[0], coverage[1], coverage[4]};
+        TileObject tileObject = TileObject.createQueryTileObject(
+                layerName, tileIndex, gridSubset.getName(), "image/png", Collections.emptyMap());
+        GWC.get().getCompositeBlobStore().get(tileObject);
+        return tileObject;
+    }
+
+    @Test
+    public void testCoalescedRequestFallsBackWhenAMembersReadFilterExcludesEverything() throws Exception {
+        setRequestAuth(RESTRICTED_USER, RESTRICTED_USER);
+
+        // verifyAccessLayer denies the coalesced shortcut for LAKES, falling back to a live combined render;
+        // CatalogMode.CHALLENGE then denies THAT render too when it actually touches the restricted data. Both
+        // paths agree: deny.
+        MockHttpServletResponse response = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+
+        // an authenticated-but-unauthorized CHALLENGE denial (see GWCDataSecurityChallengeIntegrationTest), not
+        // just "any non-image response" - a 500 would pass a weaker check just as well
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+
+        // the filtered member's cache was never populated by the coalesced attempt
+        assertEquals(StorageObject.Status.MISS, sampleTile(layer2).getStatus());
+    }
+
+    @Test
+    public void testCoalescedRequestFailsAtKvpParsingWhenHideModeExcludesLayer() throws Exception {
+        setRequestAuth(HIDDEN_USER, HIDDEN_USER);
+
+        MockHttpServletResponse response = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+
+        // a layer-resolution failure at KVP parsing (GetMapKvpRequestReader), not GWC's own access-check fallback:
+        // confirms the "HIDE+EXCLUDE layers are already gone" assumption GWC.verifyAccessLayer's comment relies on
+        assertEquals("application/vnd.ogc.se_xml", getBaseMimeType(response.getContentType()));
+        assertThat(response.getContentAsString(), containsString("Could not find layer"));
+
+        // never even reached GWC's coalescing logic, so nothing to populate the cache with
+        assertEquals(StorageObject.Status.MISS, sampleTile(layer2).getStatus());
+    }
+
+    @Test
+    public void testCoalescedRequestSucceedsForAnUnrestrictedUser() throws Exception {
+        setRequestAuth("admin", "geoserver");
+
+        MockHttpServletResponse response = getAsServletResponse(coalescedGetMap(layer1 + "," + layer2));
+
+        assertEquals(200, response.getStatus());
+        assertEquals("image/png", response.getContentType());
+        assertNull(response.getHeader("geowebcache-miss-reason"));
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/TileStackAssemblerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/TileStackAssemblerTest.java
@@ -1,0 +1,231 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.gwc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+import javax.imageio.ImageIO;
+import org.geoserver.gwc.layer.GeoServerTileLayer;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.Request;
+import org.geoserver.platform.ServiceException;
+import org.geowebcache.conveyor.ConveyorTile;
+import org.geowebcache.io.ByteArrayResource;
+import org.geowebcache.io.codec.ImageDecoder;
+import org.geowebcache.io.codec.ImageDecoderContainer;
+import org.geowebcache.io.codec.ImageDecoderImpl;
+import org.geowebcache.io.codec.ImageEncoder;
+import org.geowebcache.io.codec.ImageEncoderContainer;
+import org.geowebcache.io.codec.ImageEncoderImpl;
+import org.geowebcache.layer.TileLayer;
+import org.geowebcache.mime.MimeType;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+
+/** Unit test suite for {@link TileStackAssembler}. */
+public class TileStackAssemblerTest {
+
+    private MimeType png;
+
+    private TileStackAssembler assembler;
+
+    @Before
+    public void setUp() throws Exception {
+        png = MimeType.createFromFormat("image/png");
+
+        ImageDecoderContainer decoders = new ImageDecoderContainer();
+        ApplicationContext decoderContext = mock(ApplicationContext.class);
+        when(decoderContext.getBeansOfType(ImageDecoder.class))
+                .thenReturn(Map.of("d", new ImageDecoderImpl(false, List.of("image/png"))));
+        decoders.setApplicationContext(decoderContext);
+
+        ImageEncoderContainer encoders = new ImageEncoderContainer();
+        ApplicationContext encoderContext = mock(ApplicationContext.class);
+        when(encoderContext.getBeansOfType(ImageEncoder.class))
+                .thenReturn(Map.of("e", new ImageEncoderImpl(false, List.of("image/png"), Map.of())));
+        encoders.setApplicationContext(encoderContext);
+
+        assembler = new TileStackAssembler(decoders, encoders);
+    }
+
+    @Test
+    public void testAssembleStacksMembersInLayersOrder() throws Exception {
+        CoalescedRequestSplitter.Segment bottom = segment(solidTile(Color.RED));
+        CoalescedRequestSplitter.Segment top = segment(solidTile(Color.BLUE));
+
+        BufferedImage result = decode(assembler.assemble(null, null, null, List.of(bottom, top), png, -1));
+
+        assertEquals(Color.BLUE.getRGB(), result.getRGB(0, 0));
+    }
+
+    @Test
+    public void testAssembleAppliesAlphaOverCompositing() throws Exception {
+        CoalescedRequestSplitter.Segment bottom = segment(solidTile(Color.RED));
+        CoalescedRequestSplitter.Segment transparentTop = segment(solidTile(new Color(0, 0, 255, 0)));
+
+        BufferedImage result = decode(assembler.assemble(null, null, null, List.of(bottom, transparentTop), png, -1));
+
+        assertEquals(Color.RED.getRGB(), result.getRGB(0, 0));
+    }
+
+    @Test
+    public void testAssembleFailsWhenDeadlineHasPassed() throws Exception {
+        CoalescedRequestSplitter.Segment segment = segment(solidTile(Color.RED));
+        long deadlineAlreadyPassed = System.currentTimeMillis() - 1000;
+
+        assertThrows(
+                ServiceException.class,
+                () -> assembler.assemble(null, null, null, List.of(segment), png, deadlineAlreadyPassed));
+    }
+
+    @Test
+    public void testAssemblePropagatesPlainRuntimeExceptionFromRender() throws Exception {
+        // a getTile() failure (e.g. a storage backend hiccup) must surface as a plain RuntimeException, distinct
+        // from the ServiceException the deadline check throws: CoalescedRequestSplitter.dispatchCoalesced relies on
+        // that distinction to
+        // fall back to a live render instead of failing the whole request outright
+        TileLayer tileLayer = mock(TileLayer.class);
+        RuntimeException renderFailure = new RuntimeException("cannot access file, used by another process");
+        when(tileLayer.getTile(any())).thenThrow(renderFailure);
+        ConveyorTile tile = new ConveyorTile(null, "member", "TEST", new long[] {0, 0, 0}, png, Map.of(), null, null);
+        CoalescedRequestSplitter.Segment segment = new CoalescedRequestSplitter.CachedSegment(
+                new CoalescedRequestSplitter.TileLayerMember(tileLayer, tile));
+
+        RuntimeException thrown = assertThrows(
+                RuntimeException.class, () -> assembler.assemble(null, null, null, List.of(segment), png, -1));
+
+        assertSame(renderFailure, thrown);
+    }
+
+    @Test
+    public void testAssembleFailsWhenASegmentSizeDoesNotMatchTheCanvas() throws Exception {
+        CoalescedRequestSplitter.Segment bottom = segment(solidTile(Color.RED, 2, 2));
+        CoalescedRequestSplitter.Segment mismatched = segment(solidTile(Color.BLUE, 3, 3));
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> assembler.assemble(null, null, null, List.of(bottom, mismatched), png, -1));
+    }
+
+    @Test
+    public void testAssemblePeekHitSkipsRender() throws Exception {
+        CoalescedRequestSplitter splitter = mock(CoalescedRequestSplitter.class);
+        when(splitter.getMetaTilingExecutor(any())).thenReturn(Runnable::run);
+        Dispatcher.REQUEST.set(new Request());
+        try {
+            CoalescedRequestSplitter.CachedSegment bottom = peekHitSegment(solidTile(Color.RED));
+            CoalescedRequestSplitter.CachedSegment top = peekHitSegment(solidTile(Color.BLUE));
+
+            BufferedImage result = decode(assembler.assemble(splitter, null, null, List.of(bottom, top), png, -1));
+
+            assertEquals(Color.BLUE.getRGB(), result.getRGB(0, 0));
+            // the peek already populated both blobs, so the render loop must never fall back to getTile()
+            verify(bottom.member().tileLayer(), never()).getTile(any());
+            verify(top.member().tileLayer(), never()).getTile(any());
+        } finally {
+            Dispatcher.REQUEST.remove();
+        }
+    }
+
+    @Test
+    public void testAssembleRendersOnPeekMiss() throws Exception {
+        CoalescedRequestSplitter splitter = mock(CoalescedRequestSplitter.class);
+        when(splitter.getMetaTilingExecutor(any())).thenReturn(Runnable::run);
+        Dispatcher.REQUEST.set(new Request());
+        try {
+            CoalescedRequestSplitter.CachedSegment bottom = peekMissSegment(solidTile(Color.RED));
+            CoalescedRequestSplitter.CachedSegment top = peekMissSegment(solidTile(Color.BLUE));
+
+            BufferedImage result = decode(assembler.assemble(splitter, null, null, List.of(bottom, top), png, -1));
+
+            assertEquals(Color.BLUE.getRGB(), result.getRGB(0, 0));
+            // both peeks missed, so each member must still get rendered exactly once, like before the peek phase
+            verify(bottom.member().tileLayer(), times(1)).getTile(any());
+            verify(top.member().tileLayer(), times(1)).getTile(any());
+        } finally {
+            Dispatcher.REQUEST.remove();
+        }
+    }
+
+    /** A cached segment whose peek is a hit: {@code peekCache} stamps the blob and returns {@code true}. */
+    private CoalescedRequestSplitter.CachedSegment peekHitSegment(byte[] pngBytes) throws Exception {
+        ConveyorTile tile = new ConveyorTile(null, "member", "TEST", new long[] {0, 0, 0}, png, Map.of(), null, null);
+        GeoServerTileLayer tileLayer = mock(GeoServerTileLayer.class);
+        when(tileLayer.peekCache(any())).thenAnswer(invocation -> {
+            ConveyorTile t = invocation.getArgument(0);
+            t.setBlob(new ByteArrayResource(pngBytes));
+            return true;
+        });
+        return new CoalescedRequestSplitter.CachedSegment(
+                new CoalescedRequestSplitter.TileLayerMember(tileLayer, tile));
+    }
+
+    /** A cached segment whose peek always misses; {@code getTile} is the only thing that stamps the blob. */
+    private CoalescedRequestSplitter.CachedSegment peekMissSegment(byte[] pngBytes) throws Exception {
+        ConveyorTile tile = new ConveyorTile(null, "member", "TEST", new long[] {0, 0, 0}, png, Map.of(), null, null);
+        GeoServerTileLayer tileLayer = mock(GeoServerTileLayer.class);
+        when(tileLayer.peekCache(any())).thenReturn(false);
+        doAnswer(invocation -> {
+                    ConveyorTile t = invocation.getArgument(0);
+                    t.setBlob(new ByteArrayResource(pngBytes));
+                    return t;
+                })
+                .when(tileLayer)
+                .getTile(any(ConveyorTile.class));
+        return new CoalescedRequestSplitter.CachedSegment(
+                new CoalescedRequestSplitter.TileLayerMember(tileLayer, tile));
+    }
+
+    private byte[] solidTile(Color color) throws Exception {
+        return solidTile(color, 2, 2);
+    }
+
+    private byte[] solidTile(Color color, int width, int height) throws Exception {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = image.createGraphics();
+        g.setColor(color);
+        g.fillRect(0, 0, width, height);
+        g.dispose();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", out);
+        return out.toByteArray();
+    }
+
+    private BufferedImage decode(byte[] encoded) throws Exception {
+        return ImageIO.read(new ByteArrayInputStream(encoded));
+    }
+
+    /** A cached segment whose {@code TileLayer.getTile} just stamps the given PNG bytes as the tile's blob. */
+    private CoalescedRequestSplitter.CachedSegment segment(byte[] pngBytes) throws Exception {
+        ConveyorTile tile = new ConveyorTile(null, "member", "TEST", new long[] {0, 0, 0}, png, Map.of(), null, null);
+        TileLayer tileLayer = mock(TileLayer.class);
+        doAnswer(invocation -> {
+                    ConveyorTile t = invocation.getArgument(0);
+                    t.setBlob(new ByteArrayResource(pngBytes));
+                    return t;
+                })
+                .when(tileLayer)
+                .getTile(any(ConveyorTile.class));
+        return new CoalescedRequestSplitter.CachedSegment(
+                new CoalescedRequestSplitter.TileLayerMember(tileLayer, tile));
+    }
+}

--- a/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/layer/GeoServerTileLayerTest.java
@@ -856,6 +856,52 @@ public class GeoServerTileLayerTest {
         }
     }
 
+    @Test
+    public void testPeekCacheHitNeverRenders() throws Exception {
+        StorageBroker storageBroker = mock(StorageBroker.class);
+        when(storageBroker.get(any())).thenReturn(true);
+
+        layerInfoTileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
+        ConveyorTile tile = new ConveyorTile(
+                storageBroker,
+                layerInfoTileLayer.getName(),
+                "EPSG:4326",
+                new long[] {0, 0, 0},
+                MimeType.createFromFormat("image/png"),
+                null,
+                null,
+                null);
+
+        assertTrue(layerInfoTileLayer.peekCache(tile));
+        assertEquals(CacheResult.HIT, tile.getCacheResult());
+        // proves the peek is read-only: no render-and-save side effect, unlike getTile() on a miss
+        verify(storageBroker, never()).put(any());
+        verify(storageBroker, never()).putTransient(any());
+    }
+
+    @Test
+    public void testPeekCacheMissNeverRenders() throws Exception {
+        StorageBroker storageBroker = mock(StorageBroker.class);
+        when(storageBroker.get(any())).thenReturn(false);
+
+        layerInfoTileLayer = new GeoServerTileLayer(layerInfo, defaults, gridSetBroker);
+        ConveyorTile tile = new ConveyorTile(
+                storageBroker,
+                layerInfoTileLayer.getName(),
+                "EPSG:4326",
+                new long[] {0, 0, 0},
+                MimeType.createFromFormat("image/png"),
+                null,
+                null,
+                null);
+
+        assertFalse(layerInfoTileLayer.peekCache(tile));
+        assertEquals(CacheResult.MISS, tile.getCacheResult());
+        // a miss must stay a miss here: no fallback render, that's the render loop's job, not the peek's
+        verify(storageBroker, never()).put(any());
+        verify(storageBroker, never()).putTransient(any());
+    }
+
     @SuppressWarnings("unchecked")
     protected class GetTileMockTester {
 

--- a/src/gwc/src/test/resources/org/geoserver/gwc/labeled.sld
+++ b/src/gwc/src/test/resources/org/geoserver/gwc/labeled.sld
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<sld:StyledLayerDescriptor xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+                           xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0">
+
+    <sld:NamedLayer>
+        <sld:Name>labeled</sld:Name>
+        <sld:UserStyle>
+            <sld:FeatureTypeStyle>
+                <sld:Rule>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#808080</sld:CssParameter>
+                        </sld:Fill>
+                    </sld:PolygonSymbolizer>
+                    <sld:TextSymbolizer>
+                        <sld:Label>test</sld:Label>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#000000</sld:CssParameter>
+                        </sld:Fill>
+                    </sld:TextSymbolizer>
+                </sld:Rule>
+            </sld:FeatureTypeStyle>
+        </sld:UserStyle>
+    </sld:NamedLayer>
+
+</sld:StyledLayerDescriptor>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/CachingOptionsPanel.html
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/CachingOptionsPanel.html
@@ -10,6 +10,12 @@
         <wicket:message key="GWCSettingsPage.cacheLayersByDefault">Automatically cache newly added layers</wicket:message>
       </label>
     </li>
+    <li class="choiceItem">
+      <input id="multiLayerCachingEnabled" type="checkbox" wicket:id="multiLayerCachingEnabled"/>
+      <label for="multiLayerCachingEnabled">
+        <wicket:message key="GWCSettingsPage.multiLayerCachingEnabled">Enable multi-layer tile caching</wicket:message>
+      </label>
+    </li>
     <li wicket:id="container">
       <div wicket:id="configs">
         <ul>

--- a/src/web/gwc/src/main/java/org/geoserver/gwc/web/CachingOptionsPanel.java
+++ b/src/web/gwc/src/main/java/org/geoserver/gwc/web/CachingOptionsPanel.java
@@ -57,6 +57,9 @@ public class CachingOptionsPanel extends Panel {
         final CheckBox autoCacheLayers = new CheckBox("cacheLayersByDefault", autoCacheLayersModel);
         add(autoCacheLayers);
 
+        final IModel<Boolean> multiLayerCachingModel = new PropertyModel<>(gwcConfigModel, "multiLayerCachingEnabled");
+        add(new CheckBox("multiLayerCachingEnabled", multiLayerCachingModel));
+
         final WebMarkupContainer container = new WebMarkupContainer("container");
         container.setOutputMarkupId(true);
         add(container);

--- a/src/web/gwc/src/main/resources/GeoServerApplication.properties
+++ b/src/web/gwc/src/main/resources/GeoServerApplication.properties
@@ -33,6 +33,7 @@ GWCSettingsPage.lockProvider.memoryLock=In memory locking (suitable for stand al
 GWCSettingsPage.lockProvider.nioLock=Shared file system locking (suitable for clustered usage)
 GWCSettingsPage.lockProvider.globalLock=Global locking (configure in global settings)
 GWCSettingsPage.cacheLayersByDefault=Automatically configure a GeoWebCache layer for each new layer or layer group
+GWCSettingsPage.multiLayerCachingEnabled=Enable multi-layer tile caching
 GWCSettingsPage.cacheNonDefaultStyles=Automatically cache non-default styles
 GWCSettingsPage.metaTiling=Default metatile size:
 GWCSettingsPage.metaTilingX=tiles wide by

--- a/src/wms/src/main/java/org/geoserver/wms/GetMap.java
+++ b/src/wms/src/main/java/org/geoserver/wms/GetMap.java
@@ -6,15 +6,10 @@
 package org.geoserver.wms;
 
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -260,19 +255,9 @@ public class GetMap {
 
         fireMapContentInit(mapContent);
 
-        // track the external caching strategy for any map layers
-        boolean cachingPossible = request.isGet();
         final String featureVersion = request.getFeatureVersion();
-        int maxAge = Integer.MAX_VALUE;
         for (int i = 0; i < layers.size(); i++) {
             final MapLayerInfo mapLayerInfo = layers.get(i);
-
-            cachingPossible &= mapLayerInfo.isCachingEnabled();
-            if (cachingPossible) {
-                maxAge = Math.min(maxAge, mapLayerInfo.getCacheMaxAge());
-            } else {
-                cachingPossible = false;
-            }
 
             final Style layerStyle = styles[i];
             final Filter layerFilter = SimplifyingFilterVisitor.simplify(filters[i]);
@@ -326,15 +311,8 @@ public class GetMap {
         mapContent = fireBeforeRender(mapContent);
         WebMap map = delegate.produceMap(mapContent);
 
-        if (cachingPossible) {
-            map.setResponseHeader("Cache-Control", "max-age=" + maxAge + ", must-revalidate");
-
-            final GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
-            calendar.add(Calendar.SECOND, maxAge);
-            DateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
-            format.setTimeZone(TimeZone.getTimeZone("GMT"));
-            map.setResponseHeader("Expires", format.format(calendar.getTime()));
-        }
+        WMS.cacheMaxAge(request.isGet(), layers)
+                .ifPresent(maxAge -> WMS.cacheControlHeaders(maxAge).forEach(map::setResponseHeader));
 
         return map;
     }

--- a/src/wms/src/main/java/org/geoserver/wms/WMS.java
+++ b/src/wms/src/main/java/org/geoserver/wms/WMS.java
@@ -14,17 +14,25 @@ import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -2009,5 +2017,47 @@ public class WMS implements ApplicationContextAware {
 
     public boolean isAutoEscapeTemplateValues() {
         return getServiceInfo().isAutoEscapeTemplateValues();
+    }
+
+    /**
+     * The combined {@code Cache-Control} max-age for a GetMap response covering {@code layers}: present iff
+     * {@code isGet} and every layer has caching enabled, in which case it is the smallest of each layer's own max age.
+     * Shared by the live multi-layer GetMap path and GWC's coalesced tile-caching path so both apply the exact same
+     * rule.
+     */
+    public static OptionalInt cacheMaxAge(boolean isGet, List<MapLayerInfo> layers) {
+        if (!isGet || layers.isEmpty()) {
+            return OptionalInt.empty();
+        }
+        int maxAge = Integer.MAX_VALUE;
+        for (MapLayerInfo layer : layers) {
+            if (!layer.isCachingEnabled()) {
+                return OptionalInt.empty();
+            }
+            maxAge = Math.min(maxAge, layer.getCacheMaxAge());
+        }
+        return OptionalInt.of(maxAge);
+    }
+
+    /** HTTP dates are always GMT, see RFC 9110 section 5.6.7. */
+    private static final TimeZone GMT_TIME_ZONE = TimeZone.getTimeZone("GMT");
+
+    /**
+     * Formats the {@code Cache-Control}/{@code Expires} header pair for {@code maxAgeSeconds}, as computed by
+     * {@link #cacheMaxAge}.
+     */
+    public static Map<String, String> cacheControlHeaders(int maxAgeSeconds) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Cache-Control", "max-age=" + maxAgeSeconds + ", must-revalidate");
+
+        GregorianCalendar calendar = new GregorianCalendar(GMT_TIME_ZONE);
+        calendar.add(Calendar.SECOND, maxAgeSeconds);
+        // not thread-safe, must stay a fresh instance per call; Locale.US because an HTTP-date's day and month
+        // names are always English, see RFC 9110 section 5.6.7
+        DateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+        format.setTimeZone(GMT_TIME_ZONE);
+        headers.put("Expires", format.format(calendar.getTime()));
+
+        return headers;
     }
 }

--- a/src/wms/src/test/java/org/geoserver/wms/WMSCacheHeadersTest.java
+++ b/src/wms/src/test/java/org/geoserver/wms/WMSCacheHeadersTest.java
@@ -1,0 +1,75 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import org.geoserver.catalog.PublishedType;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.impl.FeatureTypeInfoImpl;
+import org.geoserver.catalog.impl.LayerInfoImpl;
+import org.geoserver.catalog.impl.NamespaceInfoImpl;
+import org.junit.Test;
+
+/** Unit test suite for {@link WMS#cacheMaxAge} and {@link WMS#cacheControlHeaders}. */
+public class WMSCacheHeadersTest {
+
+    private static int nextName = 0;
+
+    /** A {@code MapLayerInfo} backed by real catalog objects, since {@code MapLayerInfo} is {@code final}. */
+    private MapLayerInfo layer(boolean cachingEnabled, int maxAge) {
+        NamespaceInfoImpl ns = new NamespaceInfoImpl();
+        ns.setPrefix("test");
+        ns.setURI("http://example.com");
+
+        FeatureTypeInfoImpl resource = new FeatureTypeInfoImpl((org.geoserver.catalog.Catalog) null);
+        resource.setName("layer" + nextName++);
+        resource.setNamespace(ns);
+        resource.getMetadata().put(ResourceInfo.CACHING_ENABLED, cachingEnabled);
+        resource.getMetadata().put(ResourceInfo.CACHE_AGE_MAX, maxAge);
+
+        LayerInfoImpl layer = new LayerInfoImpl();
+        layer.setResource(resource);
+        layer.setType(PublishedType.VECTOR);
+        return new MapLayerInfo(layer);
+    }
+
+    @Test
+    public void testCacheMaxAgeAbsentOnPost() {
+        OptionalInt maxAge = WMS.cacheMaxAge(false, List.of(layer(true, 60)));
+        assertFalse(maxAge.isPresent());
+    }
+
+    @Test
+    public void testCacheMaxAgeAbsentWhenAnyLayerDisablesCaching() {
+        OptionalInt maxAge = WMS.cacheMaxAge(true, List.of(layer(true, 60), layer(false, 120)));
+        assertFalse(maxAge.isPresent());
+    }
+
+    @Test
+    public void testCacheMaxAgeAbsentWhenNoLayers() {
+        OptionalInt maxAge = WMS.cacheMaxAge(true, List.of());
+        assertFalse(maxAge.isPresent());
+    }
+
+    @Test
+    public void testCacheMaxAgeIsSmallestAmongLayers() {
+        OptionalInt maxAge = WMS.cacheMaxAge(true, List.of(layer(true, 120), layer(true, 60), layer(true, 300)));
+        assertTrue(maxAge.isPresent());
+        assertEquals(60, maxAge.getAsInt());
+    }
+
+    @Test
+    public void testCacheControlHeadersFormat() {
+        Map<String, String> headers = WMS.cacheControlHeaders(60);
+        assertEquals("max-age=60, must-revalidate", headers.get("Cache-Control"));
+        assertTrue(headers.containsKey("Expires"));
+    }
+}


### PR DESCRIPTION
[![GEOS-12180](https://badgen.net/badge/JIRA/GEOS-12180/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12180) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Backport GEOS-12180 to 2.28.x 