### PR TITLE
Fixing snapshot variable used in zip plugins

### DIFF
--- a/doc/version.py
+++ b/doc/version.py
@@ -118,7 +118,8 @@ def define_env(env):
     else:
         release = _guess_release(branch, version, default='3.1.0')
 
-    snapshot = f"{version}-SNAPSHOT"
+    # nightly artifacts carry the full Maven version (3.1.0-SNAPSHOT), not the 3.1 series
+    snapshot = f"{_guess_release(branch, version)}-SNAPSHOT"
 
     env.variables['branch'] = branch
     env.variables['is_snapshot'] = is_snapshot


### PR DESCRIPTION
There are sections of the community documentations that refer to SNAPSHOT plugins providing wrong download links.

For example:
https://docs.geoserver.org/latest/en/user/community/features-templating/installing/ refers to:
https://build.geoserver.org/geoserver/main/community-latest/geoserver-3.1-SNAPSHOT-features-templating-plugin.zip

https://docs.geoserver.org/latest/en/user/community/keycloak/installing/ refers to:
https://build.geoserver.org/geoserver/main/community-latest/geoserver-3.1-SNAPSHOT-sec-keycloak-roles-plugin.zip

in both cases you will get a 404 Not Found (since the actual zips start with geoserver-3.1.0-SNAPSHOT)

With GeoServer 3, even snapshot versions are now made of 3 numbers. i.e. 3.0.0-SNAPSHOT and 3.1.0-SNAPSHOT.
This fix will produce the same numbering.