### PR TITLE
Make CoalescedRequestSplitter public

### DIFF
--- a/src/gwc/src/main/java/org/geoserver/gwc/CoalescedRequestSplitter.java
+++ b/src/gwc/src/main/java/org/geoserver/gwc/CoalescedRequestSplitter.java
@@ -51,7 +51,7 @@ import org.geowebcache.layer.TileLayer;
  * contiguous live-render runs, and assembles the result. A Spring singleton with no per-request state: the {@link GWC}
  * mediator it delegates security/tile-layer lookups to is passed in by each call instead.
  */
-class CoalescedRequestSplitter {
+public class CoalescedRequestSplitter {
 
     /** Log message prefix for multi-layer tile coalescing, so these lines are easy to grep out on their own. */
     static final String MULTI_LAYER_LOG_PREFIX = "GWC MultiLayer >> ";
@@ -62,7 +62,7 @@ class CoalescedRequestSplitter {
 
     private final GetMap getMap;
 
-    CoalescedRequestSplitter(ImageDecoderContainer decoders, ImageEncoderContainer encoders, GetMap getMap) {
+    public CoalescedRequestSplitter(ImageDecoderContainer decoders, ImageEncoderContainer encoders, GetMap getMap) {
         this.decoders = decoders;
         this.encoders = encoders;
         this.getMap = getMap;


### PR DESCRIPTION
Same reason as in 3c668612a2: avoid Spring using reflection

Spring beans that are declared in applicationContext.xml and have non-public constructors can't be instantiated with Java Configuraion classes and in both cases (java and xml) force the constructors to be made accessible through reflection.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled.