### PR TITLE
[Backport 2.28.x] [GEOS-12100] Fix: Limit tasklet executor concurrency to prevent deadlock in backup/restore

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/AbstractCatalogBackupRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/AbstractCatalogBackupRestoreTasklet.java
@@ -165,7 +165,7 @@ public abstract class AbstractCatalogBackupRestoreTasklet<T> extends BackupResto
 
     private StepExecution execution = null;
 
-    private TaskExecutor taskExecutor = new SimpleAsyncTaskExecutor();
+    private TaskExecutor taskExecutor = createDefaultTaskExecutor();
 
     private boolean interruptOnCancel = false;
 
@@ -597,6 +597,17 @@ public abstract class AbstractCatalogBackupRestoreTasklet<T> extends BackupResto
      */
     public void setTerminationCheckInterval(long checkInterval) {
         this.checkInterval = checkInterval;
+    }
+
+    /**
+     * Creates the default task executor with a concurrency limit of 1. This ensures tasklets run on a separate thread
+     * (preserving timeout and cancellation support) while preventing multiple concurrent tasklets from competing for
+     * GeoServer resource locks, which causes deadlocks.
+     */
+    private static TaskExecutor createDefaultTaskExecutor() {
+        SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
+        executor.setConcurrencyLimit(1);
+        return executor;
     }
 
     /**

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/SequentialBackupTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/SequentialBackupTest.java
@@ -1,0 +1,101 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.logging.Level;
+import org.geoserver.backuprestore.tasklet.AbstractCatalogBackupRestoreTasklet;
+import org.geoserver.platform.resource.Files;
+import org.geotools.util.factory.Hints;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+
+/**
+ * Tests that backup/restore tasklets use a concurrency-limited executor to prevent deadlock.
+ *
+ * <p>Prior to the fix, the default SimpleAsyncTaskExecutor had no concurrency limit, spawning new threads for each
+ * tasklet. This caused deadlock when multiple tasklets competed for the same GeoServer resource locks
+ * (MemoryLockProvider/GlobalLockProvider). The fix limits concurrency to 1, ensuring tasklets run sequentially while
+ * preserving async execution for timeout and cancellation support.
+ */
+public class SequentialBackupTest extends BackupRestoreTestSupport {
+
+    @Override
+    @Before
+    public void beforeTest() throws InterruptedException {
+        ensureCleanedQueues();
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+    }
+
+    @Test
+    public void testTaskExecutorHasConcurrencyLimit() throws Exception {
+        // Verify that the tasklet's executor is a SimpleAsyncTaskExecutor with concurrency
+        // limit of 1, which prevents deadlock from concurrent lock acquisition while still
+        // preserving timeout and cancellation support (unlike SyncTaskExecutor).
+        AbstractCatalogBackupRestoreTasklet<?> tasklet =
+                applicationContext.getBean("catalogBackupTasklet", AbstractCatalogBackupRestoreTasklet.class);
+        assertNotNull("catalogBackupTasklet bean should exist", tasklet);
+
+        Field executorField = AbstractCatalogBackupRestoreTasklet.class.getDeclaredField("taskExecutor");
+        executorField.setAccessible(true);
+        TaskExecutor executor = (TaskExecutor) executorField.get(tasklet);
+
+        assertTrue(
+                "TaskExecutor should be SimpleAsyncTaskExecutor (not SyncTaskExecutor)",
+                executor instanceof SimpleAsyncTaskExecutor);
+        SimpleAsyncTaskExecutor asyncExecutor = (SimpleAsyncTaskExecutor) executor;
+        assertEquals("Concurrency limit should be 1 to prevent deadlock", 1, asyncExecutor.getConcurrencyLimit());
+    }
+
+    @Test
+    public void testSequentialBackupsComplete() throws Exception {
+        // Run two sequential backups to verify no deadlock occurs.
+        for (int i = 0; i < 2; i++) {
+            Hints hints = new Hints(new HashMap<>(2));
+            hints.add(new Hints(new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE), Backup.PARAM_BEST_EFFORT_MODE));
+
+            File backupFile = File.createTempFile("testSequentialBackup_" + i, ".zip");
+            backupFile.deleteOnExit();
+            BackupExecutionAdapter backupExecution =
+                    backupFacade.runBackupAsync(Files.asResource(backupFile), true, null, null, null, hints);
+
+            Thread.sleep(100);
+
+            assertNotNull(backupFacade.getBackupExecutions());
+            assertFalse(backupFacade.getBackupExecutions().isEmpty());
+            assertNotNull(backupExecution);
+
+            int cnt = 0;
+            while (cnt < 100 && (backupExecution.getStatus() != BatchStatus.COMPLETED || backupExecution.isRunning())) {
+                Thread.sleep(100);
+                cnt++;
+
+                if (backupExecution.getStatus() == BatchStatus.ABANDONED
+                        || backupExecution.getStatus() == BatchStatus.FAILED
+                        || backupExecution.getStatus() == BatchStatus.UNKNOWN) {
+                    for (Throwable exception : backupExecution.getAllFailureExceptions()) {
+                        LOGGER.log(Level.WARNING, "ERROR: " + exception.getLocalizedMessage(), exception);
+                    }
+                    break;
+                }
+            }
+
+            assertEquals(
+                    "Backup " + i + " should complete successfully",
+                    BatchStatus.COMPLETED,
+                    backupExecution.getStatus());
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-12100](https://badgen.net/badge/JIRA/GEOS-12100/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12100) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Backport of #9023.
**Authored by:** @caocuongngo

JIRA: https://osgeo-org.atlassian.net/browse/GEOS-12100

Clean cherry-pick — the applied patch is byte-identical to the one merged on `main` (`0668b8ce0c`). No adaptation was needed.

This backport was never requested at merge time (#9023 carried no `backport` labels), which is why the bot never ran for it.

**Verified locally:** `gs-backup-restore-core` compiles and `SequentialBackupTest` passes. 