### PR TITLE
[Backport 2.28.x] [GEOS-12099] Fix: GWC backup deadlock caused by DefaultTileLayerCatalog FileSystemWatcher

### DIFF
--- a/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/CatalogBackupRestoreTasklet.java
+++ b/src/community/backup-restore/core/src/main/java/org/geoserver/backuprestore/tasklet/CatalogBackupRestoreTasklet.java
@@ -8,6 +8,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Maps;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
@@ -234,22 +235,11 @@ public class CatalogBackupRestoreTasklet extends AbstractCatalogBackupRestoreTas
 
             Assert.notNull(gwcConfig, "gwcConfig is NULL");
 
-            // Store GWC Layers Configurations
-            final TileLayerCatalog gwcCatalog = (TileLayerCatalog) GeoServerExtensions.bean("GeoSeverTileLayerCatalog");
-
-            if (gwcCatalog != null) {
-                final XMLConfiguration gwcXmlPersisterFactory =
-                        (XMLConfiguration) GeoServerExtensions.bean("gwcXmlConfig");
-                final GeoServerResourceLoader resourceLoader = new GeoServerResourceLoader(targetBackupFolder.dir());
-
-                final DefaultTileLayerCatalog gwcBackupCatalog =
-                        new DefaultTileLayerCatalog(resourceLoader, gwcXmlPersisterFactory);
-                gwcBackupCatalog.initialize();
-
-                for (String layerName : gwcCatalog.getLayerNames()) {
-                    backupGwcLayer(gwcCatalog, gwcBackupCatalog, layerName);
-                }
-            }
+            // Store GWC Layers Configurations by copying files directly.
+            // This avoids creating a DefaultTileLayerCatalog which registers a
+            // FileSystemWatcher that causes lock contention and deadlocks on
+            // subsequent backup operations.
+            backupGwcLayersDirect(targetBackupFolder, true);
 
         } catch (Exception e) {
             logValidationExceptions(null, e);
@@ -1009,67 +999,68 @@ public class CatalogBackupRestoreTasklet extends AbstractCatalogBackupRestoreTas
                 }
             }
 
-            // Store GWC Layers Configurations
-            // TODO: This should be done using the spring-batch item reader/writer, since it is not
-            // safe to save tons of single XML files.
-            //       Nonetheless, given the default implementation of GWC Catalog does not have much
-            // sense to refactor this code now.
-            final TileLayerCatalog gwcCatalog = (TileLayerCatalog) GeoServerExtensions.bean("GeoSeverTileLayerCatalog");
-
-            if (gwcCatalog != null) {
-                final XMLConfiguration gwcXmlPersisterFactory =
-                        (XMLConfiguration) GeoServerExtensions.bean("gwcXmlConfig");
-                final GeoServerResourceLoader resourceLoader = new GeoServerResourceLoader(targetBackupFolder.dir());
-
-                final DefaultTileLayerCatalog gwcBackupCatalog =
-                        new DefaultTileLayerCatalog(resourceLoader, gwcXmlPersisterFactory);
-                gwcBackupCatalog.initialize();
-
-                for (String layerName : gwcCatalog.getLayerNames()) {
-                    backupGwcLayer(gwcCatalog, gwcBackupCatalog, layerName);
-                }
-            }
+            // Store GWC Layers Configurations by copying files directly
+            backupGwcLayersDirect(targetBackupFolder, true);
 
         } catch (Exception e) {
             logValidationExceptions(null, e);
         }
     }
 
-    private void backupGwcLayer(
-            final TileLayerCatalog gwcCatalog, final DefaultTileLayerCatalog gwcBackupCatalog, String layerName) {
-        GeoServerTileLayerInfo gwcLayerInfo = gwcCatalog.getLayerByName(layerName);
+    /**
+     * Copy GWC layer XML files directly to the target backup folder. This avoids creating a DefaultTileLayerCatalog
+     * which registers a FileSystemWatcher that causes lock contention and deadlocks on subsequent backup operations.
+     *
+     * @param targetBackupFolder the target folder for the backup
+     * @param applyFilter whether to apply workspace/layer filters
+     */
+    private void backupGwcLayersDirect(Resource targetBackupFolder, boolean applyFilter) throws Exception {
+        final TileLayerCatalog gwcCatalog = (TileLayerCatalog) GeoServerExtensions.bean("GeoSeverTileLayerCatalog");
+        if (gwcCatalog == null) return;
 
-        // Persist the GWC Layer Info into the backup folder
-        boolean persistResource = false;
+        GeoServerDataDirectory dd = (GeoServerDataDirectory) GeoServerExtensions.bean("dataDirectory");
+        Resource gwcLayersDir = dd.get("gwc-layers");
+        Resource targetGwcLayersDir = BackupUtils.dir(targetBackupFolder, "gwc-layers");
 
+        for (String layerName : gwcCatalog.getLayerNames()) {
+            GeoServerTileLayerInfo layerInfo = gwcCatalog.getLayerByName(layerName);
+            if (layerInfo == null) continue;
+
+            if (applyFilter && !shouldBackupGwcLayer(layerName)) {
+                continue;
+            }
+
+            String layerId = layerInfo.getId();
+            if (layerId == null) continue;
+            Resource sourceFile = gwcLayersDir.get(layerId + ".xml");
+            if (Resources.exists(sourceFile)) {
+                try (FileInputStream fis = new FileInputStream(sourceFile.file())) {
+                    Resources.copy(fis, targetGwcLayersDir, layerId + ".xml");
+                }
+            }
+        }
+    }
+
+    /** Determines if a GWC layer should be backed up based on filter settings. */
+    private boolean shouldBackupGwcLayer(String layerName) {
         LayerInfo layerInfo = getCatalog().getLayerByName(layerName);
-
         if (layerInfo != null) {
             WorkspaceInfo ws = getLayerWorkspace(layerInfo);
-
-            if (!filteredResource(layerInfo, ws, true, LayerInfo.class)) {
-                persistResource = true;
-            }
-        } else {
-            try {
-                LayerGroupInfo layerGroupInfo = getCatalog().getLayerGroupByName(layerName);
-                if (layerGroupInfo != null) {
-                    WorkspaceInfo ws = getLayerGroupWorkspace(layerGroupInfo);
-
-                    if (!filteredResource(ws, false)) {
-                        persistResource = true;
-                    }
-                }
-            } catch (NullPointerException e) {
-                if (getCurrentJobExecution() != null) {
-                    getCurrentJobExecution().addWarningExceptions(Arrays.asList(e));
-                }
-            }
+            return !filteredResource(layerInfo, ws, true, LayerInfo.class);
         }
 
-        if (persistResource) {
-            gwcBackupCatalog.save(gwcLayerInfo);
+        try {
+            LayerGroupInfo layerGroupInfo = getCatalog().getLayerGroupByName(layerName);
+            if (layerGroupInfo != null) {
+                WorkspaceInfo ws = getLayerGroupWorkspace(layerGroupInfo);
+                return !filteredResource(ws, false);
+            }
+        } catch (NullPointerException e) {
+            if (getCurrentJobExecution() != null) {
+                getCurrentJobExecution().addWarningExceptions(List.of(e));
+            }
         }
+        return false;
     }
 
     private WorkspaceInfo getLayerGroupWorkspace(LayerGroupInfo layerGroupInfo) {

--- a/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/GwcRepeatedBackupTest.java
+++ b/src/community/backup-restore/core/src/test/java/org/geoserver/backuprestore/GwcRepeatedBackupTest.java
@@ -1,0 +1,126 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.backuprestore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.logging.Level;
+import org.geoserver.backuprestore.utils.BackupUtils;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.platform.resource.Files;
+import org.geoserver.platform.resource.Resource;
+import org.geoserver.platform.resource.Resources;
+import org.geotools.util.factory.Hints;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.batch.core.BatchStatus;
+
+/**
+ * Tests that repeated backup operations with GWC enabled complete without deadlock.
+ *
+ * <p>Prior to the fix, the backup code created DefaultTileLayerCatalog instances which register FileSystemWatcher
+ * listeners that are never cleaned up. On subsequent backup operations, this caused lock contention in
+ * MemoryLockProvider leading to deadlocks. The fix replaces DefaultTileLayerCatalog usage with direct file copy.
+ */
+public class GwcRepeatedBackupTest extends BackupRestoreTestSupport {
+
+    @Override
+    @Before
+    public void beforeTest() throws InterruptedException {
+        ensureCleanedQueues();
+        login("admin", "geoserver", "ROLE_ADMINISTRATOR");
+    }
+
+    @Test
+    public void testRepeatedBackupsWithGwcDoNotDeadlock() throws Exception {
+        // Run 3 consecutive backups with GWC enabled.
+        // Previously, each backup leaked FileSystemWatcher listeners from
+        // DefaultTileLayerCatalog, causing deadlocks on subsequent operations.
+        for (int i = 0; i < 3; i++) {
+            Hints hints = new Hints(new HashMap<>(2));
+            hints.add(new Hints(new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE), Backup.PARAM_BEST_EFFORT_MODE));
+
+            File backupFile = File.createTempFile("testGwcBackup_" + i, ".zip");
+            backupFile.deleteOnExit();
+            BackupExecutionAdapter backupExecution =
+                    backupFacade.runBackupAsync(Files.asResource(backupFile), true, null, null, null, hints);
+
+            Thread.sleep(100);
+
+            assertNotNull(backupFacade.getBackupExecutions());
+            assertFalse(backupFacade.getBackupExecutions().isEmpty());
+            assertNotNull(backupExecution);
+
+            int cnt = 0;
+            while (cnt < 100 && (backupExecution.getStatus() != BatchStatus.COMPLETED || backupExecution.isRunning())) {
+                Thread.sleep(100);
+                cnt++;
+
+                if (backupExecution.getStatus() == BatchStatus.ABANDONED
+                        || backupExecution.getStatus() == BatchStatus.FAILED
+                        || backupExecution.getStatus() == BatchStatus.UNKNOWN) {
+                    for (Throwable exception : backupExecution.getAllFailureExceptions()) {
+                        LOGGER.log(Level.WARNING, "ERROR: " + exception.getLocalizedMessage(), exception);
+                    }
+                    break;
+                }
+            }
+
+            assertEquals(
+                    "Backup " + i + " should complete successfully",
+                    BatchStatus.COMPLETED,
+                    backupExecution.getStatus());
+        }
+    }
+
+    @Test
+    public void testGwcLayerFilesCopiedDirectly() throws Exception {
+        // Verify that GWC layer XML files are present in the backup output,
+        // confirming the direct file copy approach works correctly.
+        GeoServerDataDirectory dd = backupFacade.getGeoServerDataDirectory();
+
+        Hints hints = new Hints(new HashMap<>(2));
+        hints.add(new Hints(new Hints.OptionKey(Backup.PARAM_BEST_EFFORT_MODE), Backup.PARAM_BEST_EFFORT_MODE));
+
+        File backupFile = File.createTempFile("testGwcLayerFiles", ".zip");
+        backupFile.deleteOnExit();
+        BackupExecutionAdapter backupExecution =
+                backupFacade.runBackupAsync(Files.asResource(backupFile), true, null, null, null, hints);
+
+        Thread.sleep(100);
+
+        int cnt = 0;
+        while (cnt < 100 && (backupExecution.getStatus() != BatchStatus.COMPLETED || backupExecution.isRunning())) {
+            Thread.sleep(100);
+            cnt++;
+
+            if (backupExecution.getStatus() == BatchStatus.ABANDONED
+                    || backupExecution.getStatus() == BatchStatus.FAILED
+                    || backupExecution.getStatus() == BatchStatus.UNKNOWN) {
+                for (Throwable exception : backupExecution.getAllFailureExceptions()) {
+                    LOGGER.log(Level.WARNING, "ERROR: " + exception.getLocalizedMessage(), exception);
+                }
+                break;
+            }
+        }
+
+        assertEquals(BatchStatus.COMPLETED, backupExecution.getStatus());
+        assertTrue(Resources.exists(Files.asResource(backupFile)));
+
+        // Extract backup and verify gwc-layers directory exists with content
+        Resource targetFolder = BackupUtils.geoServerTmpDir(dd);
+        BackupUtils.extractTo(Files.asResource(backupFile), targetFolder);
+
+        if (Resources.exists(targetFolder)) {
+            Resource gwcLayers = targetFolder.get("gwc-layers");
+            assertTrue("gwc-layers directory should exist in backup", Resources.exists(gwcLayers));
+        }
+    }
+}


### PR DESCRIPTION
[![GEOS-12099](https://badgen.net/badge/JIRA/GEOS-12099/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12099) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Backport of #9026.
**Authored by:** @caocuongngo

JIRA: https://osgeo-org.atlassian.net/browse/GEOS-12099

The automatic backport failed with a conflict in `CatalogBackupRestoreTasklet.java` (see the `geoserver-bot` comments on #9026), so this was cherry-picked and resolved by hand.

### Why it conflicted

`97d66838da` ("Backup-restore: fix build and QA (partially)") landed on `main` shortly after the 2.28.x branch point and was never backported. It renamed identifiers (`sourceRestoreFodler` → `sourceRestoreFolder`, `backupFullAdditionals` → `backupFullAdditional`), tightened the `filteredResource(...)` class arguments (`StoreInfo.class` → `DataStoreInfo.class`, etc.) and swapped `Arrays.asList(e)` → `List.of(e)`. That shifted the context around the code #9026 deletes, so git could not line up the removed hunks.

### How it was resolved

Both conflict hunks were leftover fragments of the old `backupGwcLayer(...)` method that #9026 removes, so both were resolved in favour of the incoming change. Checks performed on the result:

- every remaining difference between this file and `main`'s post-#9026 version is attributable to `97d66838da` — zero unexplained lines;
- the import block is identical to `main`'s, with no unused imports introduced;
- no remnants of the old GWC backup path survive (`backupGwcLayer`, `gwcBackupCatalog`, `persistResource` all gone);
- the newly added `GwcRepeatedBackupTest.java` is byte-identical to `main`'s copy.

The resulting `CatalogBackupRestoreTasklet.java` is identical on the 2.28.x and 2.27.x backports, since that file is identical on both branches.

**Verified locally:** `gs-backup-restore-core` compiles (main and test sources) and `GwcRepeatedBackupTest` passes.

### Note on test flakiness

`GwcRepeatedBackupTest#testRepeatedBackupsWithGwcDoNotDeadlock` is timing-sensitive and fails intermittently (roughly 1 run in 3 on 2.27.x locally). This is a pre-existing flake in the test as merged on `main`, not something introduced here: `jobOperator.getRunningExecutions()` can still report the previous execution as running after `BackupExecutionAdapter.getStatus()` returns `COMPLETED` and `isRunning()` returns `false`, so the next `runBackupAsync(...)` in the loop can throw `Could not start a new Backup Job Execution since there are currently Running jobs`. The same class of failure affects four pre-existing `BackupTest` tests on unmodified 2.27.x and 2.28.x. Happy to follow up with a separate PR that makes the wait loop also drain `getBackupRunningExecutions()` if you'd like it fixed on all branches. 