### PR TITLE
[GEOS-12191] ImagesServiceXStreamLoader use images.xml (tiles.xml conflict)

### DIFF
--- a/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/v1/images/ImagesServiceXStreamLoader.java
+++ b/src/community/ogcapi/ogcapi-images/src/main/java/org/geoserver/ogcapi/v1/images/ImagesServiceXStreamLoader.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 public class ImagesServiceXStreamLoader extends XStreamServiceLoader<ImagesServiceInfo> {
 
     public ImagesServiceXStreamLoader(GeoServerResourceLoader resourceLoader) {
-        super(resourceLoader, "tiles");
+        super(resourceLoader, "images");
     }
 
     @Override


### PR DESCRIPTION
[![GEOS-12191](https://badgen.net/badge/JIRA/GEOS-12191/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12191) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This avoids TilesServiceInfoImpl and ImagesServiceInfoImpl conflicting over use of tiles.xml

This is a change to community module, only noticed as I had a configuration trying out all ogcapi modules.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] I have read and applied the [AI policy](https://geoserver.org/ai)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [x] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

The PR will be merged when all the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)), there is a code committer review, and the checklist has been fulfilled. 