### PR TITLE
[Backport-2.28.x][GEOS-12193]: "Encode coordinates measures" gives different geometries per GML version (faulty WFS)

### DIFF
--- a/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
+++ b/src/wfs/src/main/java/org/geoserver/wfs/xml/GML2OutputFormat.java
@@ -182,6 +182,7 @@ public class GML2OutputFormat extends WFSGetFeatureOutputFormat implements Compl
         transformer.setNumDecimals(numDecimals);
         transformer.setPadWithZeros(padWithZeros);
         transformer.setForceDecimalEncoding(forcedDecimal);
+        transformer.setEncodeMeasures(encodeMeasures(results.getFeature(), catalog));
         transformer.setFeatureBounding(wfs.isFeatureBounding());
         transformer.setCollectionBounding(wfs.isFeatureBounding());
         transformer.setEncoding(Charset.forName(settings.getCharset()));

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/GML2MeasuresTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/GML2MeasuresTest.java
@@ -1,0 +1,76 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.response;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.Collections;
+import javax.xml.namespace.QName;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.wfs.WFSTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** Checks that the per layer measures setting reaches the GML2 output, as it already does for GML3. */
+public final class GML2MeasuresTest extends WFSTestSupport {
+
+    private static final QName LINESTRING_ZM = new QName(MockData.DEFAULT_URI, "lineStringZm", MockData.DEFAULT_PREFIX);
+
+    private static final QName LINESTRING_M = new QName(MockData.DEFAULT_URI, "lineStringM", MockData.DEFAULT_PREFIX);
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        // in memory layer holding a single XYZM line
+        testData.addVectorLayer(
+                LINESTRING_ZM, Collections.emptyMap(), "lineStringZm.properties", GML2MeasuresTest.class, getCatalog());
+        // and one holding a single XYM line, where the measure is not a height
+        testData.addVectorLayer(
+                LINESTRING_M, Collections.emptyMap(), "lineStringM.properties", GML2MeasuresTest.class, getCatalog());
+    }
+
+    @Before
+    public void deactivateMeasuresEncoding() {
+        setMeasuresEncoding(getCatalog(), LINESTRING_ZM.getLocalPart(), false);
+        setMeasuresEncoding(getCatalog(), LINESTRING_M.getLocalPart(), false);
+    }
+
+    @Test
+    public void testMeasuresNotEncoded() throws Exception {
+        assertThat(getGml2(), containsString("120,50,20 90,80,35"));
+    }
+
+    @Test
+    public void testMeasuresEncoded() throws Exception {
+        setMeasuresEncoding(getCatalog(), LINESTRING_ZM.getLocalPart(), true);
+        assertThat(getGml2(), containsString("120,50,20,15 90,80,35,5"));
+    }
+
+    /** XYM, measures off: the measure is not a height, so nothing of it may reach the third slot. */
+    @Test
+    public void testXYMMeasuresNotEncoded() throws Exception {
+        assertThat(getGml2(LINESTRING_M), containsString("120,50 90,80"));
+    }
+
+    @Test
+    public void testXYMMeasuresEncoded() throws Exception {
+        setMeasuresEncoding(getCatalog(), LINESTRING_M.getLocalPart(), true);
+        assertThat(getGml2(LINESTRING_M), containsString("120,50,15 90,80,5"));
+    }
+
+    private String getGml2() throws Exception {
+        return getGml2(LINESTRING_ZM);
+    }
+
+    private String getGml2(QName layer) throws Exception {
+        MockHttpServletResponse response =
+                getAsServletResponse("wfs?request=GetFeature&typename=gs:%s".formatted(layer.getLocalPart())
+                        + "&version=1.0.0&service=wfs&outputFormat=GML2");
+        return response.getContentAsString();
+    }
+}

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/GML32MeasuresTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/GML32MeasuresTest.java
@@ -1,0 +1,80 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.response;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import javax.xml.namespace.QName;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.wfs.v2_0.WFS20TestSupport;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Checks that a GML 3.2 response declares the same number of ordinates it writes, on measured geometries: the 3.2
+ * configuration carries the measures setting on its own path, separate from the 3.1 one.
+ */
+public final class GML32MeasuresTest extends WFS20TestSupport {
+
+    private static final QName LINESTRING_ZM = new QName(MockData.DEFAULT_URI, "lineStringZm", MockData.DEFAULT_PREFIX);
+
+    private static final QName LINESTRING_M = new QName(MockData.DEFAULT_URI, "lineStringM", MockData.DEFAULT_PREFIX);
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        addLayer(testData, LINESTRING_ZM, "lineStringZm.properties");
+        addLayer(testData, LINESTRING_M, "lineStringM.properties");
+    }
+
+    private void addLayer(SystemTestData testData, QName layer, String properties) throws Exception {
+        testData.addVectorLayer(layer, Collections.emptyMap(), properties, GML32MeasuresTest.class, getCatalog());
+    }
+
+    @Before
+    public void deactivateMeasuresEncoding() {
+        setMeasuresEncoding(getCatalog(), LINESTRING_ZM.getLocalPart(), false);
+        setMeasuresEncoding(getCatalog(), LINESTRING_M.getLocalPart(), false);
+    }
+
+    @Test
+    public void testLineXYZMMeasuresNotEncoded() throws Exception {
+        assertPosList(LINESTRING_ZM, "50 120 20 80 90 35", 3);
+    }
+
+    @Test
+    public void testLineXYZMMeasuresEncoded() throws Exception {
+        setMeasuresEncoding(getCatalog(), LINESTRING_ZM.getLocalPart(), true);
+        assertPosList(LINESTRING_ZM, "50 120 20 15 80 90 35 5", 4);
+    }
+
+    /** XYM, measures off: the measure is not a height, so a plain 2D line is written and declared. */
+    @Test
+    public void testLineXYMMeasuresNotEncoded() throws Exception {
+        assertPosList(LINESTRING_M, "50 120 80 90", 2);
+    }
+
+    @Test
+    public void testLineXYMMeasuresEncoded() throws Exception {
+        setMeasuresEncoding(getCatalog(), LINESTRING_M.getLocalPart(), true);
+        assertPosList(LINESTRING_M, "50 120 15 80 90 5", 3);
+    }
+
+    /** The bug being guarded: srsDimension has to be the ordinates written per coordinate. */
+    private void assertPosList(QName layer, String expected, int expectedDimension) throws Exception {
+        Document dom = getAsDOM(
+                "wfs?request=GetFeature&typenames=gs:%s&version=2.0.0&service=wfs".formatted(layer.getLocalPart()));
+        assertXpathEvaluatesTo(expected, "//gml:LineString/gml:posList", dom);
+        assertXpathEvaluatesTo(String.valueOf(expectedDimension), "//gml:LineString/@srsDimension", dom);
+        assertEquals(
+                "declared dimension differs from the ordinates written",
+                0,
+                expected.split("\\s+").length % expectedDimension);
+    }
+}

--- a/src/wfs/src/test/java/org/geoserver/wfs/response/GML3MeasuresTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/response/GML3MeasuresTest.java
@@ -1,0 +1,81 @@
+/* (c) 2026 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.wfs.response;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import javax.xml.namespace.QName;
+import org.geoserver.data.test.MockData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.wfs.WFSTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Checks that a GML 3.1 response declares the same number of ordinates it writes, on measured geometries, with the per
+ * layer measures setting both on and off.
+ */
+public final class GML3MeasuresTest extends WFSTestSupport {
+
+    private static final QName LINESTRING_ZM = new QName(MockData.DEFAULT_URI, "lineStringZm", MockData.DEFAULT_PREFIX);
+
+    private static final QName LINESTRING_M = new QName(MockData.DEFAULT_URI, "lineStringM", MockData.DEFAULT_PREFIX);
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        addLayer(testData, LINESTRING_ZM, "lineStringZm.properties");
+        addLayer(testData, LINESTRING_M, "lineStringM.properties");
+    }
+
+    private void addLayer(SystemTestData testData, QName layer, String properties) throws Exception {
+        testData.addVectorLayer(layer, Collections.emptyMap(), properties, GML3MeasuresTest.class, getCatalog());
+    }
+
+    @Before
+    public void deactivateMeasuresEncoding() {
+        setMeasuresEncoding(getCatalog(), LINESTRING_ZM.getLocalPart(), false);
+        setMeasuresEncoding(getCatalog(), LINESTRING_M.getLocalPart(), false);
+    }
+
+    /** XYZM, measures off: the height stays, the measure goes, and the declaration follows. */
+    @Test
+    public void testLineXYZMMeasuresNotEncoded() throws Exception {
+        assertPosList(LINESTRING_ZM, "50 120 20 80 90 35", 3);
+    }
+
+    @Test
+    public void testLineXYZMMeasuresEncoded() throws Exception {
+        setMeasuresEncoding(getCatalog(), LINESTRING_ZM.getLocalPart(), true);
+        assertPosList(LINESTRING_ZM, "50 120 20 15 80 90 35 5", 4);
+    }
+
+    /** XYM, measures off: the measure is not a height, so a plain 2D line is written and declared. */
+    @Test
+    public void testLineXYMMeasuresNotEncoded() throws Exception {
+        assertPosList(LINESTRING_M, "50 120 80 90", 2);
+    }
+
+    @Test
+    public void testLineXYMMeasuresEncoded() throws Exception {
+        setMeasuresEncoding(getCatalog(), LINESTRING_M.getLocalPart(), true);
+        assertPosList(LINESTRING_M, "50 120 15 80 90 5", 3);
+    }
+
+    /** The bug being guarded: srsDimension has to be the ordinates written per coordinate. */
+    private void assertPosList(QName layer, String expected, int expectedDimension) throws Exception {
+        Document dom = getAsDOM(
+                "wfs?request=GetFeature&typename=gs:%s&version=1.1.0&service=wfs".formatted(layer.getLocalPart()));
+        assertXpathEvaluatesTo(expected, "//gml:LineString/gml:posList", dom);
+        assertXpathEvaluatesTo(String.valueOf(expectedDimension), "//gml:LineString/@srsDimension", dom);
+        assertEquals(
+                "declared dimension differs from the ordinates written",
+                0,
+                expected.split("\\s+").length % expectedDimension);
+    }
+}

--- a/src/wfs/src/test/resources/org/geoserver/wfs/response/lineStringM.properties
+++ b/src/wfs/src/test/resources/org/geoserver/wfs/response/lineStringM.properties
@@ -1,0 +1,2 @@
+_=name:String,geometry:Geometry
+lineStringM.1=lineString_m_1|LINESTRINGM(120 50 15, 90 80 5)


### PR DESCRIPTION
[![GEOS-12193](https://badgen.net/badge/JIRA/GEOS-12193/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12193) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Backport to 2.28.x 