### PR TITLE
[GEOS-12200] Fix color picker palette layout in Style Editor

### DIFF
--- a/src/web/wms/src/main/java/org/geoserver/wms/web/data/js/spectrum/spectrum.js
+++ b/src/web/wms/src/main/java/org/geoserver/wms/web/data/js/spectrum/spectrum.js
@@ -143,8 +143,7 @@
                 // Start GEOS-11585 Changes
                 // Original Code:
                 // html.push('<span title="' + formattedString + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-thumb-inner" style="' + swatchStyle + ';" /></span>');
-                html.push('<span title="' + formattedString + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-palette-el sp-thumb-inner" data-css="' + swatchStyle + ';" /></span>');
-                // End GEOS-11585 Changes
+                html.push('<span title="' + formattedString + '" data-color="' + tiny.toRgbString() + '" class="' + c + '"><span class="sp-palette-el sp-thumb-inner" data-css="' + swatchStyle + ';"></span></span>');
             } else {
                 var cls = 'sp-clear-display';
                 html.push($('<div />')


### PR DESCRIPTION
[![GEOS-12200](https://badgen.net/badge/JIRA/GEOS-12200/0052CC)](https://osgeo-org.atlassian.net/browse/GEOS-12200) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geoserver&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Description

Fixes the color picker palette layout issue in the GeoServer Style Editor.

The color palette was not being rendered with the expected layout because the HTML generated by the Spectrum color picker in `spectrum.js` contained incorrectly nested palette elements.

The issue was caused by the generated markup for the palette rows. The opening and closing HTML tags did not produce the expected structure, resulting in the color palette rows being nested incorrectly in the DOM.

This change corrects the generated HTML structure in `spectrum.js` so that each palette row is created and closed correctly. This restores the expected color picker layout while keeping the existing color selection behavior unchanged.

## Related Issue

GEOS-12200

## Testing

- Verified the generated palette HTML in the browser using DevTools.
- Confirmed that the palette rows are structured correctly in the DOM.
- Rebuilt the affected GeoServer module successfully. 